### PR TITLE
Add in-kind contributions to "Contributions By Type"

### DIFF
--- a/build/candidate/10/supporting/index.json
+++ b/build/candidate/10/supporting/index.json
@@ -12,7 +12,7 @@
   "total_contributions": 41597.08,
   "total_expenditures": 9736.75,
   "contributions_by_type": {
-    "Committee": 2600.0,
+    "Committee": 3250.0,
     "Individual": 29188.16,
     "Unitemized": 808.92,
     "Other (includes Businesses)": 8350.0

--- a/build/candidate/19/supporting/index.json
+++ b/build/candidate/19/supporting/index.json
@@ -14,6 +14,6 @@
   "contributions_by_type": {
     "Individual": 4000.0,
     "Unitemized": 575.0,
-    "Other (includes Businesses)": 900.0
+    "Other (includes Businesses)": 1400.0
   }
 }


### PR DESCRIPTION
These contributions are reported in the same format as monetary
contributions; we can treat them the same way when reporting candidate
contributions by type.

[Finishes #5]