### PR TITLE
Add measure supporters opponents

### DIFF
--- a/build/referendum/1/opposing/index.json
+++ b/build/referendum/1/opposing/index.json
@@ -5,6 +5,13 @@
   "title": "Sugar-Sweetened BeverageTax",
   "summary": "This measure would impose a tax on the distribution of Sugar-Sweetened Beverage Products in Oakland. Sugar-Sweetened beverages are defined as any beverage to which one or more Caloric Sweeteners have been added and that contain 25 or more calories per 12 fluid ounces of beverage. The tax would not be imposed on infant or baby formula, beverages for medical use, supplemental, meal replacement, or nutritional beverages, milk products, fruit or vegetable juices with no added sweeteners, or alcoholic beverages. The measure would require that any distributor of sugar-sweetened beverages register with the City and establish a Community Advisory Board. The Board would be responsible for making recommendations to the City Council on setting up or funding programs that prevent or reduce the health consequences of consuming sugar-sweetened beverages.",
   "number": "HH",
+  "opposing_organizations": [
+    {
+      "id": "no-id-yet-but-there-will-be-one-here-eventually",
+      "name": "NO OAKLAND GROCERY TAX, WITH MAJOR FUNDING BY AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC",
+      "amount": 593709.77
+    }
+  ],
   "money_opposing": 3333,
   "money_opposing_by_region": {
     "within_oakland": 123,

--- a/build/referendum/1/supporting/index.json
+++ b/build/referendum/1/supporting/index.json
@@ -5,6 +5,13 @@
   "title": "Sugar-Sweetened BeverageTax",
   "summary": "This measure would impose a tax on the distribution of Sugar-Sweetened Beverage Products in Oakland. Sugar-Sweetened beverages are defined as any beverage to which one or more Caloric Sweeteners have been added and that contain 25 or more calories per 12 fluid ounces of beverage. The tax would not be imposed on infant or baby formula, beverages for medical use, supplemental, meal replacement, or nutritional beverages, milk products, fruit or vegetable juices with no added sweeteners, or alcoholic beverages. The measure would require that any distributor of sugar-sweetened beverages register with the City and establish a Community Advisory Board. The Board would be responsible for making recommendations to the City Council on setting up or funding programs that prevent or reduce the health consequences of consuming sugar-sweetened beverages.",
   "number": "HH",
+  "supporting_organizations": [
+    {
+      "id": "no-id-yet-but-there-will-be-one-here-eventually",
+      "name": "COALITION FOR HEALTHY OAKLAND CHILDREN",
+      "amount": 4760.22
+    }
+  ],
   "money_supporting": 1234,
   "money_supporting_by_region": {
     "within_oakland": 123,

--- a/build/referendum/2/opposing/index.json
+++ b/build/referendum/2/opposing/index.json
@@ -5,6 +5,9 @@
   "title": "Lease Term for City-Owned or City-Controlled Property",
   "summary": "This measure would amend the Charter to increase the term the City Council can lease City-owned or City-controlled real property to a maximum of ninety-nine (99) years. The Oakland City Charter currently authorizes the City Council to lease real property owned or controlled by the City of Oakland for a maximum term of sixty-six (66) years. (City Charter Section 1001).",
   "number": "II",
+  "opposing_organizations": [
+
+  ],
   "money_opposing": 3333,
   "money_opposing_by_region": {
     "within_oakland": 123,

--- a/build/referendum/2/supporting/index.json
+++ b/build/referendum/2/supporting/index.json
@@ -5,6 +5,9 @@
   "title": "Lease Term for City-Owned or City-Controlled Property",
   "summary": "This measure would amend the Charter to increase the term the City Council can lease City-owned or City-controlled real property to a maximum of ninety-nine (99) years. The Oakland City Charter currently authorizes the City Council to lease real property owned or controlled by the City of Oakland for a maximum term of sixty-six (66) years. (City Charter Section 1001).",
   "number": "II",
+  "supporting_organizations": [
+
+  ],
   "money_supporting": 1234,
   "money_supporting_by_region": {
     "within_oakland": 123,

--- a/build/referendum/3/opposing/index.json
+++ b/build/referendum/3/opposing/index.json
@@ -5,6 +5,9 @@
   "title": "Just Cause for Eviction and Rent Adjustment",
   "summary": "This measure would: (1) extend the just cause eviction requirements to rental units constructed and approved for occupancy before December 31, 1995, if the units were newly constructed from the group and not created by rehabilitating, improving, or converting pre-existing commercial space or other residential rental space; (2) amend the Rent Ordinance to require that landlords obtain approval from the Rent Program before imposing any rent increases exceeding the Consumer Price Index. Without advance approval, landlords could not make tenants pay any rent increases noticed on or after February 1, 2017 exceeding the allowable adjustment. In addition the measure would require the City to provide an annual notice to residents that would include the amount of the allowable cost-of-living rent adjustment for the year while explaining how to get information for a rent increase.",
   "number": "JJ",
+  "opposing_organizations": [
+
+  ],
   "money_opposing": 3333,
   "money_opposing_by_region": {
     "within_oakland": 123,

--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -5,6 +5,13 @@
   "title": "Just Cause for Eviction and Rent Adjustment",
   "summary": "This measure would: (1) extend the just cause eviction requirements to rental units constructed and approved for occupancy before December 31, 1995, if the units were newly constructed from the group and not created by rehabilitating, improving, or converting pre-existing commercial space or other residential rental space; (2) amend the Rent Ordinance to require that landlords obtain approval from the Rent Program before imposing any rent increases exceeding the Consumer Price Index. Without advance approval, landlords could not make tenants pay any rent increases noticed on or after February 1, 2017 exceeding the allowable adjustment. In addition the measure would require the City to provide an annual notice to residents that would include the amount of the allowable cost-of-living rent adjustment for the year while explaining how to get information for a rent increase.",
   "number": "JJ",
+  "supporting_organizations": [
+    {
+      "id": "no-id-yet-but-there-will-be-one-here-eventually",
+      "name": "Committee to Protect Oakland Renters sponsored by labor and community organizations",
+      "amount": 190026.16
+    }
+  ],
   "money_supporting": 1234,
   "money_supporting_by_region": {
     "within_oakland": 123,

--- a/build/referendum/4/opposing/index.json
+++ b/build/referendum/4/opposing/index.json
@@ -5,6 +5,9 @@
   "title": "Infrastructure and Housing bonds",
   "summary": "This measure would allow the City to borrow up to $600 million by issuing general obligation bonds. The bonds would be repaid with revenue from an “ad valorem” property tax. “Ad valorem” means according to the value of the property. The City would impose a tax based on the value of real property and improvements within the City to pay the principal and interest of the bonds. The City would use this money to build, buy, improve, and rehabilitate facilities and infrastructure and for affordable housing in Oakland. The projects financed by the bonds would be completed as needed according to City Council established priorities as set forth in the City’s Capital Improvement Plan.",
   "number": "KK",
+  "opposing_organizations": [
+
+  ],
   "money_opposing": 3333,
   "money_opposing_by_region": {
     "within_oakland": 123,

--- a/build/referendum/4/supporting/index.json
+++ b/build/referendum/4/supporting/index.json
@@ -5,6 +5,13 @@
   "title": "Infrastructure and Housing bonds",
   "summary": "This measure would allow the City to borrow up to $600 million by issuing general obligation bonds. The bonds would be repaid with revenue from an “ad valorem” property tax. “Ad valorem” means according to the value of the property. The City would impose a tax based on the value of real property and improvements within the City to pay the principal and interest of the bonds. The City would use this money to build, buy, improve, and rehabilitate facilities and infrastructure and for affordable housing in Oakland. The projects financed by the bonds would be completed as needed according to City Council established priorities as set forth in the City’s Capital Improvement Plan.",
   "number": "KK",
+  "supporting_organizations": [
+    {
+      "id": "no-id-yet-but-there-will-be-one-here-eventually",
+      "name": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
+      "amount": 53630.57
+    }
+  ],
   "money_supporting": 1234,
   "money_supporting_by_region": {
     "within_oakland": 123,

--- a/build/referendum/5/opposing/index.json
+++ b/build/referendum/5/opposing/index.json
@@ -5,6 +5,9 @@
   "title": "Police Commission",
   "summary": "This measure would establish a Police Commission consisting of seven regular and two alternate members. Commission members would be Oakland residents with no member permitted to be a police officer, current City employee, former Oakland police officer, or current or former official, employee or representative of a union that represents police officers. The first group of Commissioners would serve two, three, or four year terms. Later members would serve three-year terms with a two-term limit. The Commission would establish a Community Police Review Agency (“Agency”) which would receive and review complaints of police misconduct. The Agency would be required to investigate complaints involving use of force, in-custody deaths, profiling and public assemblies. After completing its investigation of a complaint, the Agency would submit its findings and proposed discipline to the Commission and Chief. In addition The Commission would review the OPD’s policies, procedures and General Orders while being able to propose changes and approve or reject the OPD’s changes to those policies. The majority of the Commission’s members would be independently appointed by a panel of Oakland residents with subpoena power and five commissioners could vote to fire the chief.",
   "number": "LL",
+  "opposing_organizations": [
+
+  ],
   "money_opposing": 3333,
   "money_opposing_by_region": {
     "within_oakland": 123,

--- a/build/referendum/5/supporting/index.json
+++ b/build/referendum/5/supporting/index.json
@@ -5,6 +5,9 @@
   "title": "Police Commission",
   "summary": "This measure would establish a Police Commission consisting of seven regular and two alternate members. Commission members would be Oakland residents with no member permitted to be a police officer, current City employee, former Oakland police officer, or current or former official, employee or representative of a union that represents police officers. The first group of Commissioners would serve two, three, or four year terms. Later members would serve three-year terms with a two-term limit. The Commission would establish a Community Police Review Agency (“Agency”) which would receive and review complaints of police misconduct. The Agency would be required to investigate complaints involving use of force, in-custody deaths, profiling and public assemblies. After completing its investigation of a complaint, the Agency would submit its findings and proposed discipline to the Commission and Chief. In addition The Commission would review the OPD’s policies, procedures and General Orders while being able to propose changes and approve or reject the OPD’s changes to those policies. The majority of the Commission’s members would be independently appointed by a panel of Oakland residents with subpoena power and five commissioners could vote to fire the chief.",
   "number": "LL",
+  "supporting_organizations": [
+
+  ],
   "money_supporting": 1234,
   "money_supporting_by_region": {
     "within_oakland": 123,

--- a/calculators/referendum_supporters_calculator.rb
+++ b/calculators/referendum_supporters_calculator.rb
@@ -1,0 +1,56 @@
+class ReferendumSupportersCalculator
+  def initialize(candidates: [], ballot_measures: [])
+    @ballot_measures = ballot_measures
+  end
+
+  def fetch
+    expenditures = ActiveRecord::Base.connection.execute(<<-SQL)
+      SELECT "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd",
+             SUM("Amount") AS "Total_Amount"
+        FROM "efile_COAK_2016_E-Expenditure"
+       WHERE "Bal_Name" IS NOT NULL
+       GROUP BY "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd";
+    SQL
+
+    supporting_by_measure_name = {}
+    opposing_by_measure_name = {}
+
+    expenditures.each do |row|
+      if row['Sup_Opp_Cd'] == 'S'
+        supporting_by_measure_name[row['Bal_Name']] ||= []
+        supporting_by_measure_name[row['Bal_Name']] << row
+      elsif row['Sup_Opp_Cd'] == 'O'
+        opposing_by_measure_name[row['Bal_Name']] ||= []
+        opposing_by_measure_name[row['Bal_Name']] << row
+      end
+    end
+
+    [
+      # { bal_name => rows }     , calculation name
+      [supporting_by_measure_name, :supporting_organizations],
+      [opposing_by_measure_name, :opposing_organizations],
+    ].each do |rows_by_bal_name, calculation_name|
+      # the processing is the same for both supporting and opposing expenses
+      rows_by_bal_name.each do |bal_name, rows|
+        ballot_measure = ballot_measure_from_name(bal_name)
+        ballot_measure.save_calculation(calculation_name, rows.map do |row|
+          # committees in support/opposition:
+          {
+            id: 'no-id-yet-but-there-will-be-one-here-eventually',
+            name: row['Filer_NamL'],
+            amount: row['Total_Amount'],
+          }
+        end)
+      end
+    end
+  end
+
+  private
+
+  def ballot_measure_from_name(bal_name)
+    @ballot_measures.detect do |measure|
+      measure['Measure_number'] ==
+        OaklandReferendum.name_to_measure_number(bal_name)
+    end
+  end
+end

--- a/models/oakland_referendum.rb
+++ b/models/oakland_referendum.rb
@@ -1,4 +1,28 @@
 class OaklandReferendum < ActiveRecord::Base
+  NETFILE_NAMES_TO_MEASURE_NUMBER = {
+    'CITY OF OAKLAND SODA TAX' => 'HH',
+    'SUGAR-SWEETENED DRINKS DISTRIBUTOR TAX' => 'HH',
+    'Proposed amendments to residental rent adjustments and evictions ordinance' => 'JJ',
+    'City of Oakland Renters Upgrade Act' => 'KK',
+  }
+
+  def self.name_to_measure_number(name)
+    NETFILE_NAMES_TO_MEASURE_NUMBER[name]
+  end
+
+  has_many :calculations, as: :subject
+
+  def calculation(name)
+    @_calculations_cache ||= calculations.index_by(&:name)
+    @_calculations_cache[name.to_s].try(:value)
+  end
+
+  def save_calculation(name, value)
+    calculations
+      .where(name: name)
+      .first_or_create
+      .update_attributes(value: value)
+  end
 
   def as_json(options = nil)
     {

--- a/process.rb
+++ b/process.rb
@@ -106,17 +106,21 @@ OaklandReferendum.find_each do |referendum|
 
   build_file("/referendum/#{referendum.id}/supporting") do |f|
     f.puts JSON.pretty_generate(referendum.as_json.merge(
+      supporting_organizations:
+        referendum.calculation(:supporting_organizations) || [],
       money_supporting: 1234,
       money_supporting_by_region: {
         within_oakland: 123,
         within_california: 111,
         out_of_state: 222,
-      }
+      },
     ))
   end
 
   build_file("/referendum/#{referendum.id}/opposing") do |f|
     f.puts JSON.pretty_generate(referendum.as_json.merge(
+      opposing_organizations:
+        referendum.calculation(:opposing_organizations) || [],
       money_opposing: 3333,
       money_opposing_by_region: {
         within_oakland: 123,


### PR DESCRIPTION
This adds a simple calculation based on Schedule E to determine a ballot
measure's supporters and opponents. The matching is a bit fuzzy - as of
writing the "Bal_Num" column contains only "TBD", so we can't easily
match up the expenditures to the ballot measure except by hardcoding a
mapping of the four "Bal_Name" values.

This branch doesn't support using Filer IDs or a custom ID for these
committees because there would be nowhere for those links to go, and I
want to punt on figuring out how to model the committees until later.

This is probably incomplete, because I did this work on a plane and
don't have the 460 downloaded. We probably need to include schedule D as
well.

Fixes #2
Fixes #3 
cc @adborden @monkeyhippies @mikeubell 