### PR TITLE
Standardize ballot measure API key names

### DIFF
--- a/build/referendum/1/opposing/index.json
+++ b/build/referendum/1/opposing/index.json
@@ -12,8 +12,8 @@
       "amount": 593709.77
     }
   ],
-  "money_opposing": 3333,
-  "money_opposing_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/build/referendum/1/supporting/index.json
+++ b/build/referendum/1/supporting/index.json
@@ -12,8 +12,8 @@
       "amount": 4760.22
     }
   ],
-  "money_supporting": 1234,
-  "money_supporting_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/build/referendum/2/opposing/index.json
+++ b/build/referendum/2/opposing/index.json
@@ -8,8 +8,8 @@
   "opposing_organizations": [
 
   ],
-  "money_opposing": 3333,
-  "money_opposing_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/build/referendum/2/supporting/index.json
+++ b/build/referendum/2/supporting/index.json
@@ -8,8 +8,8 @@
   "supporting_organizations": [
 
   ],
-  "money_supporting": 1234,
-  "money_supporting_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/build/referendum/3/opposing/index.json
+++ b/build/referendum/3/opposing/index.json
@@ -8,8 +8,8 @@
   "opposing_organizations": [
 
   ],
-  "money_opposing": 3333,
-  "money_opposing_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -12,8 +12,8 @@
       "amount": 190026.16
     }
   ],
-  "money_supporting": 1234,
-  "money_supporting_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/build/referendum/4/opposing/index.json
+++ b/build/referendum/4/opposing/index.json
@@ -8,8 +8,8 @@
   "opposing_organizations": [
 
   ],
-  "money_opposing": 3333,
-  "money_opposing_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/build/referendum/4/supporting/index.json
+++ b/build/referendum/4/supporting/index.json
@@ -12,8 +12,8 @@
       "amount": 53630.57
     }
   ],
-  "money_supporting": 1234,
-  "money_supporting_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/build/referendum/5/opposing/index.json
+++ b/build/referendum/5/opposing/index.json
@@ -8,8 +8,8 @@
   "opposing_organizations": [
 
   ],
-  "money_opposing": 3333,
-  "money_opposing_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/build/referendum/5/supporting/index.json
+++ b/build/referendum/5/supporting/index.json
@@ -8,8 +8,8 @@
   "supporting_organizations": [
 
   ],
-  "money_supporting": 1234,
-  "money_supporting_by_region": {
+  "total_contributions": 456,
+  "contributions_by_region": {
     "within_oakland": 123,
     "within_california": 111,
     "out_of_state": 222

--- a/process.rb
+++ b/process.rb
@@ -111,8 +111,8 @@ OaklandReferendum.find_each do |referendum|
     f.puts JSON.pretty_generate(referendum.as_json.merge(
       supporting_organizations:
         referendum.calculation(:supporting_organizations) || [],
-      money_supporting: 1234,
-      money_supporting_by_region: {
+      total_contributions: 456,
+      contributions_by_region: {
         within_oakland: 123,
         within_california: 111,
         out_of_state: 222,
@@ -124,8 +124,8 @@ OaklandReferendum.find_each do |referendum|
     f.puts JSON.pretty_generate(referendum.as_json.merge(
       opposing_organizations:
         referendum.calculation(:opposing_organizations) || [],
-      money_opposing: 3333,
-      money_opposing_by_region: {
+      total_contributions: 456,
+      contributions_by_region: {
         within_oakland: 123,
         within_california: 111,
         out_of_state: 222,


### PR DESCRIPTION
This changes two API keys to be the same between endpoints:

```
  /referendums/:id/supporting
    money_supporting -> total_contributions
    money_supporting_by_region -> contributions_by_region
  /referendums/:id/opposing
    money_opposing -> total_contributions
    money_opposing_by_region -> contributions_by_region
```

I didn't worry about backwards compatibility because the key names do
not appear in the disclosure-frontend repo.