### PR TITLE
    Always serialize OaklandCandidate with contribution calculations

### DIFF
--- a/build/ballot/1/index.json
+++ b/build/ballot/1/index.json
@@ -16,7 +16,7 @@
           "last_name": "Macleay",
           "ballot_item": 1,
           "office_election": 1,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -26,7 +26,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -48,7 +48,7 @@
           "last_name": "London",
           "ballot_item": 1,
           "office_election": 1,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 5975.0,
             "total_contributions": 5975.0,
             "total_expenditures": 4826.78,
@@ -67,7 +67,7 @@
               "campaign literature and mailings": 850.0
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 5975.0,
@@ -105,7 +105,7 @@
           "last_name": "Parker",
           "ballot_item": 2,
           "office_election": 2,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 60871.0,
             "total_contributions": 60871.0,
             "total_expenditures": 7510.5,
@@ -119,7 +119,7 @@
               "campaign consultants": 7500.0
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 60871.0,
@@ -152,7 +152,7 @@
           "last_name": "Corbett",
           "ballot_item": 3,
           "office_election": 3,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 19375.0,
             "total_contributions": 19375.0,
             "total_expenditures": 8479.42,
@@ -165,7 +165,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 19375.0,
@@ -190,7 +190,7 @@
           "last_name": "Kalb",
           "ballot_item": 3,
           "office_election": 3,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 39058.66,
             "total_contributions": 39058.66,
             "total_expenditures": 6118.11,
@@ -207,7 +207,7 @@
               "information technology costs (internet, e-mail)": 404.03
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 39058.66,
@@ -243,7 +243,7 @@
           "last_name": "Brown",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -253,7 +253,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -275,7 +275,7 @@
           "last_name": "Gibson McElhaney",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 41597.08,
             "total_contributions": 41597.08,
             "total_expenditures": 9736.75,
@@ -295,7 +295,7 @@
               "information technology costs (internet, e-mail)": 942.85
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 41597.08,
@@ -327,7 +327,7 @@
           "last_name": "Session",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -337,7 +337,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -359,7 +359,7 @@
           "last_name": "Karamooz",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -369,7 +369,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -391,7 +391,7 @@
           "last_name": "McNeal",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -401,7 +401,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -423,7 +423,7 @@
           "last_name": "Jordan",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -433,7 +433,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -462,7 +462,7 @@
           "last_name": "Kaplan",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 52199.0,
             "total_contributions": 52199.0,
             "total_expenditures": 16219.89,
@@ -483,7 +483,7 @@
               "information technology costs (internet, e-mail)": 220.0
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 52199.0,
@@ -516,7 +516,7 @@
           "last_name": "Quan",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -526,7 +526,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -548,7 +548,7 @@
           "last_name": "Sidebotham",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -558,7 +558,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -580,7 +580,7 @@
           "last_name": "Matt Hummell",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -590,7 +590,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -612,7 +612,7 @@
           "last_name": "Moore",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -622,7 +622,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -644,7 +644,7 @@
           "last_name": "Ellis",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -654,7 +654,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -676,7 +676,7 @@
           "last_name": "Young Jr.",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -686,7 +686,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -708,7 +708,7 @@
           "last_name": "Cabello",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -718,7 +718,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -747,7 +747,7 @@
           "last_name": "Harris",
           "ballot_item": 6,
           "office_election": 6,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -757,7 +757,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -779,7 +779,7 @@
           "last_name": "Jackson",
           "ballot_item": 6,
           "office_election": 6,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 5822.0,
             "total_contributions": 5822.0,
             "total_expenditures": 12413.89,
@@ -792,7 +792,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 5822.0,
@@ -824,7 +824,7 @@
           "last_name": "Hinton Hodge",
           "ballot_item": 7,
           "office_election": 7,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -834,7 +834,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -856,7 +856,7 @@
           "last_name": "Lang",
           "ballot_item": 7,
           "office_election": 7,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -866,7 +866,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -888,7 +888,7 @@
           "last_name": "Wiginton",
           "ballot_item": 7,
           "office_election": 7,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -898,7 +898,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -920,7 +920,7 @@
           "last_name": "Narain",
           "ballot_item": 7,
           "office_election": 7,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -930,7 +930,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -959,7 +959,7 @@
           "last_name": "Hodge",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -969,7 +969,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -991,7 +991,7 @@
           "last_name": "Imara",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1001,7 +1001,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1023,7 +1023,7 @@
           "last_name": "Reid",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1033,7 +1033,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1055,7 +1055,7 @@
           "last_name": "Reid",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1065,7 +1065,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1087,7 +1087,7 @@
           "last_name": "Oliver-Benson",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1097,7 +1097,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1119,7 +1119,7 @@
           "last_name": "De Jimenez",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1129,7 +1129,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1158,7 +1158,7 @@
           "last_name": "Hassid",
           "ballot_item": 9,
           "office_election": 9,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1168,7 +1168,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1190,7 +1190,7 @@
           "last_name": "Hutchinson",
           "ballot_item": 9,
           "office_election": 9,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1200,7 +1200,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1222,7 +1222,7 @@
           "last_name": "Torres",
           "ballot_item": 9,
           "office_election": 9,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 6895.0,
             "total_contributions": 6895.0,
             "total_expenditures": 6673.3,
@@ -1241,7 +1241,7 @@
               "information technology costs (internet, e-mail)": 400.0
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 6895.0,
@@ -1272,7 +1272,7 @@
           "last_name": "Trenado",
           "ballot_item": 9,
           "office_election": 9,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1282,7 +1282,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1311,7 +1311,7 @@
           "last_name": "Gallo",
           "ballot_item": 10,
           "office_election": 10,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1321,7 +1321,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1343,7 +1343,7 @@
           "last_name": "Gonzales",
           "ballot_item": 10,
           "office_election": 10,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1353,7 +1353,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,

--- a/build/ballot/1/index.json
+++ b/build/ballot/1/index.json
@@ -15,7 +15,28 @@
           "first_name": "Donald",
           "last_name": "Macleay",
           "ballot_item": 1,
-          "office_election": 1
+          "office_election": 1,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 27,
@@ -26,7 +47,46 @@
           "first_name": "Jody",
           "last_name": "London",
           "ballot_item": 1,
-          "office_election": 1
+          "office_election": 1,
+          "supporting_contribution_data": {
+            "contributions_received": 5975.0,
+            "total_contributions": 5975.0,
+            "total_expenditures": 4826.78,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Individual": 4000.0,
+              "Unitemized": 575.0,
+              "Other (includes Businesses)": 1400.0
+            },
+            "expenditures_by_type": {
+              "office expenses": 166.47,
+              "fundraising events": 475.05,
+              "campaign consultants": 1000.0,
+              "meetings and appearances": 437.32,
+              "campaign paraphernalia/misc.": 1397.94,
+              "campaign literature and mailings": 850.0
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 5975.0,
+          "total_contributions": 5975.0,
+          "total_expenditures": 4826.78,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Individual": 4000.0,
+            "Unitemized": 575.0,
+            "Other (includes Businesses)": 1400.0
+          },
+          "expenditures_by_type": {
+            "office expenses": 166.47,
+            "fundraising events": 475.05,
+            "campaign consultants": 1000.0,
+            "meetings and appearances": 437.32,
+            "campaign paraphernalia/misc.": 1397.94,
+            "campaign literature and mailings": 850.0
+          }
         }
       ]
     },
@@ -44,7 +104,36 @@
           "first_name": "Barbara",
           "last_name": "Parker",
           "ballot_item": 2,
-          "office_election": 2
+          "office_election": 2,
+          "supporting_contribution_data": {
+            "contributions_received": 60871.0,
+            "total_contributions": 60871.0,
+            "total_expenditures": 7510.5,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Individual": 55100.0,
+              "Unitemized": 355.0,
+              "Other (includes Businesses)": 5416.0
+            },
+            "expenditures_by_type": {
+              "campaign consultants": 7500.0
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 60871.0,
+          "total_contributions": 60871.0,
+          "total_expenditures": 7510.5,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Individual": 55100.0,
+            "Unitemized": 355.0,
+            "Other (includes Businesses)": 5416.0
+          },
+          "expenditures_by_type": {
+            "campaign consultants": 7500.0
+          }
         }
       ]
     },
@@ -62,7 +151,34 @@
           "first_name": "Kevin",
           "last_name": "Corbett",
           "ballot_item": 3,
-          "office_election": 3
+          "office_election": 3,
+          "supporting_contribution_data": {
+            "contributions_received": 19375.0,
+            "total_contributions": 19375.0,
+            "total_expenditures": 8479.42,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Individual": 16250.0,
+              "Unitemized": 675.0,
+              "Other (includes Businesses)": 2450.0
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 19375.0,
+          "total_contributions": 19375.0,
+          "total_expenditures": 8479.42,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Individual": 16250.0,
+            "Unitemized": 675.0,
+            "Other (includes Businesses)": 2450.0
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 11,
@@ -73,7 +189,42 @@
           "first_name": "Dan",
           "last_name": "Kalb",
           "ballot_item": 3,
-          "office_election": 3
+          "office_election": 3,
+          "supporting_contribution_data": {
+            "contributions_received": 39058.66,
+            "total_contributions": 39058.66,
+            "total_expenditures": 6118.11,
+            "total_loans_received": 9000.0,
+            "contributions_by_type": {
+              "Committee": 2400.0,
+              "Individual": 22487.0,
+              "Unitemized": 3521.66,
+              "Other (includes Businesses)": 1650.0
+            },
+            "expenditures_by_type": {
+              "fundraising events": 4749.38,
+              "campaign literature and mailings": 894.7,
+              "information technology costs (internet, e-mail)": 404.03
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 39058.66,
+          "total_contributions": 39058.66,
+          "total_expenditures": 6118.11,
+          "total_loans_received": 9000.0,
+          "contributions_by_type": {
+            "Committee": 2400.0,
+            "Individual": 22487.0,
+            "Unitemized": 3521.66,
+            "Other (includes Businesses)": 1650.0
+          },
+          "expenditures_by_type": {
+            "fundraising events": 4749.38,
+            "campaign literature and mailings": 894.7,
+            "information technology costs (internet, e-mail)": 404.03
+          }
         }
       ]
     },
@@ -91,7 +242,28 @@
           "first_name": "Alan",
           "last_name": "Brown",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 13,
@@ -102,7 +274,48 @@
           "first_name": "Lynette",
           "last_name": "Gibson McElhaney",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": 41597.08,
+            "total_contributions": 41597.08,
+            "total_expenditures": 9736.75,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Committee": 3250.0,
+              "Individual": 29188.16,
+              "Unitemized": 808.92,
+              "Other (includes Businesses)": 8350.0
+            },
+            "expenditures_by_type": {
+              "civic donations": 450.0,
+              "office expenses": 2340.51,
+              "fundraising events": 718.87,
+              "meetings and appearances": 184.17,
+              "professional services (legal, accounting)": 4318.35,
+              "information technology costs (internet, e-mail)": 942.85
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 41597.08,
+          "total_contributions": 41597.08,
+          "total_expenditures": 9736.75,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Committee": 3250.0,
+            "Individual": 29188.16,
+            "Unitemized": 808.92,
+            "Other (includes Businesses)": 8350.0
+          },
+          "expenditures_by_type": {
+            "civic donations": 450.0,
+            "office expenses": 2340.51,
+            "fundraising events": 718.87,
+            "meetings and appearances": 184.17,
+            "professional services (legal, accounting)": 4318.35,
+            "information technology costs (internet, e-mail)": 942.85
+          }
         },
         {
           "id": 14,
@@ -113,7 +326,28 @@
           "first_name": "Noni",
           "last_name": "Session",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 15,
@@ -124,7 +358,28 @@
           "first_name": "Saied",
           "last_name": "Karamooz",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 16,
@@ -135,7 +390,28 @@
           "first_name": "Anthony",
           "last_name": "McNeal",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 17,
@@ -146,7 +422,28 @@
           "first_name": "Tyron",
           "last_name": "Jordan",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -164,7 +461,50 @@
           "first_name": "Rebecca",
           "last_name": "Kaplan",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": 52199.0,
+            "total_contributions": 52199.0,
+            "total_expenditures": 16219.89,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Committee": 4400.0,
+              "Individual": 39954.0,
+              "Unitemized": 1495.0,
+              "Other (includes Businesses)": 6350.0
+            },
+            "expenditures_by_type": {
+              "office expenses": 4936.55,
+              "fundraising events": 200.0,
+              "campaign paraphernalia/misc.": 1916.25,
+              "campaign literature and mailings": 4765.23,
+              "postage, delivery and messenger services": 1255.12,
+              "professional services (legal, accounting)": 1236.26,
+              "information technology costs (internet, e-mail)": 220.0
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 52199.0,
+          "total_contributions": 52199.0,
+          "total_expenditures": 16219.89,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Committee": 4400.0,
+            "Individual": 39954.0,
+            "Unitemized": 1495.0,
+            "Other (includes Businesses)": 6350.0
+          },
+          "expenditures_by_type": {
+            "office expenses": 4936.55,
+            "fundraising events": 200.0,
+            "campaign paraphernalia/misc.": 1916.25,
+            "campaign literature and mailings": 4765.23,
+            "postage, delivery and messenger services": 1255.12,
+            "professional services (legal, accounting)": 1236.26,
+            "information technology costs (internet, e-mail)": 220.0
+          }
         },
         {
           "id": 3,
@@ -175,7 +515,28 @@
           "first_name": "Bruce",
           "last_name": "Quan",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 4,
@@ -186,7 +547,28 @@
           "first_name": "Nancy",
           "last_name": "Sidebotham",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 5,
@@ -197,7 +579,28 @@
           "first_name": "Francis",
           "last_name": "Matt Hummell",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 6,
@@ -208,7 +611,28 @@
           "first_name": "Peggy",
           "last_name": "Moore",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 7,
@@ -219,7 +643,28 @@
           "first_name": "Patricia",
           "last_name": "Ellis",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 8,
@@ -230,7 +675,28 @@
           "first_name": "Larry",
           "last_name": "Young Jr.",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 9,
@@ -241,7 +707,28 @@
           "first_name": "Manuel",
           "last_name": "Cabello",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -259,7 +746,28 @@
           "first_name": "James",
           "last_name": "Harris",
           "ballot_item": 6,
-          "office_election": 6
+          "office_election": 6,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 37,
@@ -270,7 +778,34 @@
           "first_name": "Chris",
           "last_name": "Jackson",
           "ballot_item": 6,
-          "office_election": 6
+          "office_election": 6,
+          "supporting_contribution_data": {
+            "contributions_received": 5822.0,
+            "total_contributions": 5822.0,
+            "total_expenditures": 12413.89,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Committee": 1200.0,
+              "Individual": 2950.0,
+              "Unitemized": 1672.0
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 5822.0,
+          "total_contributions": 5822.0,
+          "total_expenditures": 12413.89,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Committee": 1200.0,
+            "Individual": 2950.0,
+            "Unitemized": 1672.0
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -288,7 +823,28 @@
           "first_name": "Jumoke",
           "last_name": "Hinton Hodge",
           "ballot_item": 7,
-          "office_election": 7
+          "office_election": 7,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 29,
@@ -299,7 +855,28 @@
           "first_name": "Benjamin",
           "last_name": "Lang",
           "ballot_item": 7,
-          "office_election": 7
+          "office_election": 7,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 30,
@@ -310,7 +887,28 @@
           "first_name": "Kharyshi",
           "last_name": "Wiginton",
           "ballot_item": 7,
-          "office_election": 7
+          "office_election": 7,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 31,
@@ -321,7 +919,28 @@
           "first_name": "Lucky",
           "last_name": "Narain",
           "ballot_item": 7,
-          "office_election": 7
+          "office_election": 7,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -339,7 +958,28 @@
           "first_name": "Marcie",
           "last_name": "Hodge",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 21,
@@ -350,7 +990,28 @@
           "first_name": "Nehanda",
           "last_name": "Imara",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 22,
@@ -361,7 +1022,28 @@
           "first_name": "Larry",
           "last_name": "Reid",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 23,
@@ -372,7 +1054,28 @@
           "first_name": "Treva",
           "last_name": "Reid",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 24,
@@ -383,7 +1086,28 @@
           "first_name": "Maxine",
           "last_name": "Oliver-Benson",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 25,
@@ -394,7 +1118,28 @@
           "first_name": "Olivia",
           "last_name": "De Jimenez",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -412,7 +1157,28 @@
           "first_name": "Michael",
           "last_name": "Hassid",
           "ballot_item": 9,
-          "office_election": 9
+          "office_election": 9,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 33,
@@ -423,7 +1189,28 @@
           "first_name": "Michael",
           "last_name": "Hutchinson",
           "ballot_item": 9,
-          "office_election": 9
+          "office_election": 9,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 34,
@@ -434,7 +1221,46 @@
           "first_name": "Roseann",
           "last_name": "Torres",
           "ballot_item": 9,
-          "office_election": 9
+          "office_election": 9,
+          "supporting_contribution_data": {
+            "contributions_received": 6895.0,
+            "total_contributions": 6895.0,
+            "total_expenditures": 6673.3,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Committee": 1700.0,
+              "Individual": 4150.0,
+              "Unitemized": 345.0,
+              "Other (includes Businesses)": 700.0
+            },
+            "expenditures_by_type": {
+              "office expenses": 107.05,
+              "fundraising events": 600.0,
+              "campaign consultants": 1130.0,
+              "professional services (legal, accounting)": 3626.34,
+              "information technology costs (internet, e-mail)": 400.0
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 6895.0,
+          "total_contributions": 6895.0,
+          "total_expenditures": 6673.3,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Committee": 1700.0,
+            "Individual": 4150.0,
+            "Unitemized": 345.0,
+            "Other (includes Businesses)": 700.0
+          },
+          "expenditures_by_type": {
+            "office expenses": 107.05,
+            "fundraising events": 600.0,
+            "campaign consultants": 1130.0,
+            "professional services (legal, accounting)": 3626.34,
+            "information technology costs (internet, e-mail)": 400.0
+          }
         },
         {
           "id": 35,
@@ -445,7 +1271,28 @@
           "first_name": "Huber",
           "last_name": "Trenado",
           "ballot_item": 9,
-          "office_election": 9
+          "office_election": 9,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -463,7 +1310,28 @@
           "first_name": "Noel",
           "last_name": "Gallo",
           "ballot_item": 10,
-          "office_election": 10
+          "office_election": 10,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 19,
@@ -474,7 +1342,28 @@
           "first_name": "Viola",
           "last_name": "Gonzales",
           "ballot_item": 10,
-          "office_election": 10
+          "office_election": 10,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },

--- a/build/candidate/1/index.json
+++ b/build/candidate/1/index.json
@@ -7,5 +7,34 @@
   "first_name": "Barbara",
   "last_name": "Parker",
   "ballot_item": 2,
-  "office_election": 2
+  "office_election": 2,
+  "supporting_contribution_data": {
+    "contributions_received": 60871.0,
+    "total_contributions": 60871.0,
+    "total_expenditures": 7510.5,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Individual": 55100.0,
+      "Unitemized": 355.0,
+      "Other (includes Businesses)": 5416.0
+    },
+    "expenditures_by_type": {
+      "campaign consultants": 7500.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 60871.0,
+  "total_contributions": 60871.0,
+  "total_expenditures": 7510.5,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Individual": 55100.0,
+    "Unitemized": 355.0,
+    "Other (includes Businesses)": 5416.0
+  },
+  "expenditures_by_type": {
+    "campaign consultants": 7500.0
+  }
 }

--- a/build/candidate/1/index.json
+++ b/build/candidate/1/index.json
@@ -8,7 +8,7 @@
   "last_name": "Parker",
   "ballot_item": 2,
   "office_election": 2,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 60871.0,
     "total_contributions": 60871.0,
     "total_expenditures": 7510.5,
@@ -22,7 +22,7 @@
       "campaign consultants": 7500.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 60871.0,

--- a/build/candidate/1/opposing/index.json
+++ b/build/candidate/1/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Parker",
   "ballot_item": 2,
   "office_election": 2,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 60871.0,
     "total_contributions": 60871.0,
     "total_expenditures": 7510.5,
@@ -22,7 +22,7 @@
       "campaign consultants": 7500.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 60871.0,

--- a/build/candidate/1/opposing/index.json
+++ b/build/candidate/1/opposing/index.json
@@ -8,5 +8,33 @@
   "last_name": "Parker",
   "ballot_item": 2,
   "office_election": 2,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": 60871.0,
+    "total_contributions": 60871.0,
+    "total_expenditures": 7510.5,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Individual": 55100.0,
+      "Unitemized": 355.0,
+      "Other (includes Businesses)": 5416.0
+    },
+    "expenditures_by_type": {
+      "campaign consultants": 7500.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 60871.0,
+  "total_contributions": 60871.0,
+  "total_expenditures": 7510.5,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Individual": 55100.0,
+    "Unitemized": 355.0,
+    "Other (includes Businesses)": 5416.0
+  },
+  "expenditures_by_type": {
+    "campaign consultants": 7500.0
+  }
 }

--- a/build/candidate/1/supporting/index.json
+++ b/build/candidate/1/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Parker",
   "ballot_item": 2,
   "office_election": 2,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 60871.0,
     "total_contributions": 60871.0,
     "total_expenditures": 7510.5,
@@ -22,7 +22,7 @@
       "campaign consultants": 7500.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 60871.0,

--- a/build/candidate/1/supporting/index.json
+++ b/build/candidate/1/supporting/index.json
@@ -8,6 +8,23 @@
   "last_name": "Parker",
   "ballot_item": 2,
   "office_election": 2,
+  "supporting_contribution_data": {
+    "contributions_received": 60871.0,
+    "total_contributions": 60871.0,
+    "total_expenditures": 7510.5,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Individual": 55100.0,
+      "Unitemized": 355.0,
+      "Other (includes Businesses)": 5416.0
+    },
+    "expenditures_by_type": {
+      "campaign consultants": 7500.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": 60871.0,
   "total_contributions": 60871.0,
   "total_expenditures": 7510.5,

--- a/build/candidate/10/index.json
+++ b/build/candidate/10/index.json
@@ -8,7 +8,7 @@
   "last_name": "Corbett",
   "ballot_item": 3,
   "office_election": 3,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 19375.0,
     "total_contributions": 19375.0,
     "total_expenditures": 8479.42,
@@ -21,7 +21,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 19375.0,

--- a/build/candidate/10/index.json
+++ b/build/candidate/10/index.json
@@ -7,5 +7,32 @@
   "first_name": "Kevin",
   "last_name": "Corbett",
   "ballot_item": 3,
-  "office_election": 3
+  "office_election": 3,
+  "supporting_contribution_data": {
+    "contributions_received": 19375.0,
+    "total_contributions": 19375.0,
+    "total_expenditures": 8479.42,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Individual": 16250.0,
+      "Unitemized": 675.0,
+      "Other (includes Businesses)": 2450.0
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 19375.0,
+  "total_contributions": 19375.0,
+  "total_expenditures": 8479.42,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Individual": 16250.0,
+    "Unitemized": 675.0,
+    "Other (includes Businesses)": 2450.0
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/10/opposing/index.json
+++ b/build/candidate/10/opposing/index.json
@@ -8,5 +8,31 @@
   "last_name": "Corbett",
   "ballot_item": 3,
   "office_election": 3,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": 19375.0,
+    "total_contributions": 19375.0,
+    "total_expenditures": 8479.42,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Individual": 16250.0,
+      "Unitemized": 675.0,
+      "Other (includes Businesses)": 2450.0
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 19375.0,
+  "total_contributions": 19375.0,
+  "total_expenditures": 8479.42,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Individual": 16250.0,
+    "Unitemized": 675.0,
+    "Other (includes Businesses)": 2450.0
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/10/opposing/index.json
+++ b/build/candidate/10/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Corbett",
   "ballot_item": 3,
   "office_election": 3,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 19375.0,
     "total_contributions": 19375.0,
     "total_expenditures": 8479.42,
@@ -21,7 +21,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 19375.0,

--- a/build/candidate/10/supporting/index.json
+++ b/build/candidate/10/supporting/index.json
@@ -8,6 +8,22 @@
   "last_name": "Corbett",
   "ballot_item": 3,
   "office_election": 3,
+  "supporting_contribution_data": {
+    "contributions_received": 19375.0,
+    "total_contributions": 19375.0,
+    "total_expenditures": 8479.42,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Individual": 16250.0,
+      "Unitemized": 675.0,
+      "Other (includes Businesses)": 2450.0
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": 19375.0,
   "total_contributions": 19375.0,
   "total_expenditures": 8479.42,

--- a/build/candidate/10/supporting/index.json
+++ b/build/candidate/10/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Corbett",
   "ballot_item": 3,
   "office_election": 3,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 19375.0,
     "total_contributions": 19375.0,
     "total_expenditures": 8479.42,
@@ -21,7 +21,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 19375.0,

--- a/build/candidate/11/index.json
+++ b/build/candidate/11/index.json
@@ -7,5 +7,40 @@
   "first_name": "Dan",
   "last_name": "Kalb",
   "ballot_item": 3,
-  "office_election": 3
+  "office_election": 3,
+  "supporting_contribution_data": {
+    "contributions_received": 39058.66,
+    "total_contributions": 39058.66,
+    "total_expenditures": 6118.11,
+    "total_loans_received": 9000.0,
+    "contributions_by_type": {
+      "Committee": 2400.0,
+      "Individual": 22487.0,
+      "Unitemized": 3521.66,
+      "Other (includes Businesses)": 1650.0
+    },
+    "expenditures_by_type": {
+      "fundraising events": 4749.38,
+      "campaign literature and mailings": 894.7,
+      "information technology costs (internet, e-mail)": 404.03
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 39058.66,
+  "total_contributions": 39058.66,
+  "total_expenditures": 6118.11,
+  "total_loans_received": 9000.0,
+  "contributions_by_type": {
+    "Committee": 2400.0,
+    "Individual": 22487.0,
+    "Unitemized": 3521.66,
+    "Other (includes Businesses)": 1650.0
+  },
+  "expenditures_by_type": {
+    "fundraising events": 4749.38,
+    "campaign literature and mailings": 894.7,
+    "information technology costs (internet, e-mail)": 404.03
+  }
 }

--- a/build/candidate/11/index.json
+++ b/build/candidate/11/index.json
@@ -8,7 +8,7 @@
   "last_name": "Kalb",
   "ballot_item": 3,
   "office_election": 3,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 39058.66,
     "total_contributions": 39058.66,
     "total_expenditures": 6118.11,
@@ -25,7 +25,7 @@
       "information technology costs (internet, e-mail)": 404.03
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 39058.66,

--- a/build/candidate/11/opposing/index.json
+++ b/build/candidate/11/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Kalb",
   "ballot_item": 3,
   "office_election": 3,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 39058.66,
     "total_contributions": 39058.66,
     "total_expenditures": 6118.11,
@@ -25,7 +25,7 @@
       "information technology costs (internet, e-mail)": 404.03
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 39058.66,

--- a/build/candidate/11/opposing/index.json
+++ b/build/candidate/11/opposing/index.json
@@ -8,5 +8,39 @@
   "last_name": "Kalb",
   "ballot_item": 3,
   "office_election": 3,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": 39058.66,
+    "total_contributions": 39058.66,
+    "total_expenditures": 6118.11,
+    "total_loans_received": 9000.0,
+    "contributions_by_type": {
+      "Committee": 2400.0,
+      "Individual": 22487.0,
+      "Unitemized": 3521.66,
+      "Other (includes Businesses)": 1650.0
+    },
+    "expenditures_by_type": {
+      "fundraising events": 4749.38,
+      "campaign literature and mailings": 894.7,
+      "information technology costs (internet, e-mail)": 404.03
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 39058.66,
+  "total_contributions": 39058.66,
+  "total_expenditures": 6118.11,
+  "total_loans_received": 9000.0,
+  "contributions_by_type": {
+    "Committee": 2400.0,
+    "Individual": 22487.0,
+    "Unitemized": 3521.66,
+    "Other (includes Businesses)": 1650.0
+  },
+  "expenditures_by_type": {
+    "fundraising events": 4749.38,
+    "campaign literature and mailings": 894.7,
+    "information technology costs (internet, e-mail)": 404.03
+  }
 }

--- a/build/candidate/11/supporting/index.json
+++ b/build/candidate/11/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Kalb",
   "ballot_item": 3,
   "office_election": 3,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 39058.66,
     "total_contributions": 39058.66,
     "total_expenditures": 6118.11,
@@ -25,7 +25,7 @@
       "information technology costs (internet, e-mail)": 404.03
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 39058.66,

--- a/build/candidate/11/supporting/index.json
+++ b/build/candidate/11/supporting/index.json
@@ -8,6 +8,26 @@
   "last_name": "Kalb",
   "ballot_item": 3,
   "office_election": 3,
+  "supporting_contribution_data": {
+    "contributions_received": 39058.66,
+    "total_contributions": 39058.66,
+    "total_expenditures": 6118.11,
+    "total_loans_received": 9000.0,
+    "contributions_by_type": {
+      "Committee": 2400.0,
+      "Individual": 22487.0,
+      "Unitemized": 3521.66,
+      "Other (includes Businesses)": 1650.0
+    },
+    "expenditures_by_type": {
+      "fundraising events": 4749.38,
+      "campaign literature and mailings": 894.7,
+      "information technology costs (internet, e-mail)": 404.03
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": 39058.66,
   "total_contributions": 39058.66,
   "total_expenditures": 6118.11,

--- a/build/candidate/12/index.json
+++ b/build/candidate/12/index.json
@@ -7,5 +7,26 @@
   "first_name": "Alan",
   "last_name": "Brown",
   "ballot_item": 4,
-  "office_election": 4
+  "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/12/index.json
+++ b/build/candidate/12/index.json
@@ -8,7 +8,7 @@
   "last_name": "Brown",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/12/opposing/index.json
+++ b/build/candidate/12/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Brown",
   "ballot_item": 4,
   "office_election": 4,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/12/opposing/index.json
+++ b/build/candidate/12/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Brown",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/12/supporting/index.json
+++ b/build/candidate/12/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Brown",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/12/supporting/index.json
+++ b/build/candidate/12/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Brown",
   "ballot_item": 4,
   "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/13/index.json
+++ b/build/candidate/13/index.json
@@ -8,7 +8,7 @@
   "last_name": "Gibson McElhaney",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 41597.08,
     "total_contributions": 41597.08,
     "total_expenditures": 9736.75,
@@ -28,7 +28,7 @@
       "information technology costs (internet, e-mail)": 942.85
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 41597.08,

--- a/build/candidate/13/index.json
+++ b/build/candidate/13/index.json
@@ -7,5 +7,46 @@
   "first_name": "Lynette",
   "last_name": "Gibson McElhaney",
   "ballot_item": 4,
-  "office_election": 4
+  "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": 41597.08,
+    "total_contributions": 41597.08,
+    "total_expenditures": 9736.75,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 3250.0,
+      "Individual": 29188.16,
+      "Unitemized": 808.92,
+      "Other (includes Businesses)": 8350.0
+    },
+    "expenditures_by_type": {
+      "civic donations": 450.0,
+      "office expenses": 2340.51,
+      "fundraising events": 718.87,
+      "meetings and appearances": 184.17,
+      "professional services (legal, accounting)": 4318.35,
+      "information technology costs (internet, e-mail)": 942.85
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 41597.08,
+  "total_contributions": 41597.08,
+  "total_expenditures": 9736.75,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Committee": 3250.0,
+    "Individual": 29188.16,
+    "Unitemized": 808.92,
+    "Other (includes Businesses)": 8350.0
+  },
+  "expenditures_by_type": {
+    "civic donations": 450.0,
+    "office expenses": 2340.51,
+    "fundraising events": 718.87,
+    "meetings and appearances": 184.17,
+    "professional services (legal, accounting)": 4318.35,
+    "information technology costs (internet, e-mail)": 942.85
+  }
 }

--- a/build/candidate/13/opposing/index.json
+++ b/build/candidate/13/opposing/index.json
@@ -8,5 +8,45 @@
   "last_name": "Gibson McElhaney",
   "ballot_item": 4,
   "office_election": 4,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": 41597.08,
+    "total_contributions": 41597.08,
+    "total_expenditures": 9736.75,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 3250.0,
+      "Individual": 29188.16,
+      "Unitemized": 808.92,
+      "Other (includes Businesses)": 8350.0
+    },
+    "expenditures_by_type": {
+      "civic donations": 450.0,
+      "office expenses": 2340.51,
+      "fundraising events": 718.87,
+      "meetings and appearances": 184.17,
+      "professional services (legal, accounting)": 4318.35,
+      "information technology costs (internet, e-mail)": 942.85
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 41597.08,
+  "total_contributions": 41597.08,
+  "total_expenditures": 9736.75,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Committee": 3250.0,
+    "Individual": 29188.16,
+    "Unitemized": 808.92,
+    "Other (includes Businesses)": 8350.0
+  },
+  "expenditures_by_type": {
+    "civic donations": 450.0,
+    "office expenses": 2340.51,
+    "fundraising events": 718.87,
+    "meetings and appearances": 184.17,
+    "professional services (legal, accounting)": 4318.35,
+    "information technology costs (internet, e-mail)": 942.85
+  }
 }

--- a/build/candidate/13/opposing/index.json
+++ b/build/candidate/13/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Gibson McElhaney",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 41597.08,
     "total_contributions": 41597.08,
     "total_expenditures": 9736.75,
@@ -28,7 +28,7 @@
       "information technology costs (internet, e-mail)": 942.85
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 41597.08,

--- a/build/candidate/13/supporting/index.json
+++ b/build/candidate/13/supporting/index.json
@@ -8,6 +8,29 @@
   "last_name": "Gibson McElhaney",
   "ballot_item": 4,
   "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": 41597.08,
+    "total_contributions": 41597.08,
+    "total_expenditures": 9736.75,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 3250.0,
+      "Individual": 29188.16,
+      "Unitemized": 808.92,
+      "Other (includes Businesses)": 8350.0
+    },
+    "expenditures_by_type": {
+      "civic donations": 450.0,
+      "office expenses": 2340.51,
+      "fundraising events": 718.87,
+      "meetings and appearances": 184.17,
+      "professional services (legal, accounting)": 4318.35,
+      "information technology costs (internet, e-mail)": 942.85
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": 41597.08,
   "total_contributions": 41597.08,
   "total_expenditures": 9736.75,

--- a/build/candidate/13/supporting/index.json
+++ b/build/candidate/13/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Gibson McElhaney",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 41597.08,
     "total_contributions": 41597.08,
     "total_expenditures": 9736.75,
@@ -28,7 +28,7 @@
       "information technology costs (internet, e-mail)": 942.85
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 41597.08,

--- a/build/candidate/14/index.json
+++ b/build/candidate/14/index.json
@@ -8,7 +8,7 @@
   "last_name": "Session",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/14/index.json
+++ b/build/candidate/14/index.json
@@ -7,5 +7,26 @@
   "first_name": "Noni",
   "last_name": "Session",
   "ballot_item": 4,
-  "office_election": 4
+  "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/14/opposing/index.json
+++ b/build/candidate/14/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Session",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/14/opposing/index.json
+++ b/build/candidate/14/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Session",
   "ballot_item": 4,
   "office_election": 4,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/14/supporting/index.json
+++ b/build/candidate/14/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Session",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/14/supporting/index.json
+++ b/build/candidate/14/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Session",
   "ballot_item": 4,
   "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/15/index.json
+++ b/build/candidate/15/index.json
@@ -7,5 +7,26 @@
   "first_name": "Saied",
   "last_name": "Karamooz",
   "ballot_item": 4,
-  "office_election": 4
+  "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/15/index.json
+++ b/build/candidate/15/index.json
@@ -8,7 +8,7 @@
   "last_name": "Karamooz",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/15/opposing/index.json
+++ b/build/candidate/15/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Karamooz",
   "ballot_item": 4,
   "office_election": 4,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/15/opposing/index.json
+++ b/build/candidate/15/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Karamooz",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/15/supporting/index.json
+++ b/build/candidate/15/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Karamooz",
   "ballot_item": 4,
   "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/15/supporting/index.json
+++ b/build/candidate/15/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Karamooz",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/16/index.json
+++ b/build/candidate/16/index.json
@@ -7,5 +7,26 @@
   "first_name": "Anthony",
   "last_name": "McNeal",
   "ballot_item": 4,
-  "office_election": 4
+  "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/16/index.json
+++ b/build/candidate/16/index.json
@@ -8,7 +8,7 @@
   "last_name": "McNeal",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/16/opposing/index.json
+++ b/build/candidate/16/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "McNeal",
   "ballot_item": 4,
   "office_election": 4,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/16/opposing/index.json
+++ b/build/candidate/16/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "McNeal",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/16/supporting/index.json
+++ b/build/candidate/16/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "McNeal",
   "ballot_item": 4,
   "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/16/supporting/index.json
+++ b/build/candidate/16/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "McNeal",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/17/index.json
+++ b/build/candidate/17/index.json
@@ -8,7 +8,7 @@
   "last_name": "Jordan",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/17/index.json
+++ b/build/candidate/17/index.json
@@ -7,5 +7,26 @@
   "first_name": "Tyron",
   "last_name": "Jordan",
   "ballot_item": 4,
-  "office_election": 4
+  "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/17/opposing/index.json
+++ b/build/candidate/17/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Jordan",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/17/opposing/index.json
+++ b/build/candidate/17/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Jordan",
   "ballot_item": 4,
   "office_election": 4,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/17/supporting/index.json
+++ b/build/candidate/17/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Jordan",
   "ballot_item": 4,
   "office_election": 4,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/17/supporting/index.json
+++ b/build/candidate/17/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Jordan",
   "ballot_item": 4,
   "office_election": 4,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/18/index.json
+++ b/build/candidate/18/index.json
@@ -8,7 +8,7 @@
   "last_name": "Gallo",
   "ballot_item": 10,
   "office_election": 10,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/18/index.json
+++ b/build/candidate/18/index.json
@@ -7,5 +7,26 @@
   "first_name": "Noel",
   "last_name": "Gallo",
   "ballot_item": 10,
-  "office_election": 10
+  "office_election": 10,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/18/opposing/index.json
+++ b/build/candidate/18/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Gallo",
   "ballot_item": 10,
   "office_election": 10,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/18/opposing/index.json
+++ b/build/candidate/18/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Gallo",
   "ballot_item": 10,
   "office_election": 10,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/18/supporting/index.json
+++ b/build/candidate/18/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Gallo",
   "ballot_item": 10,
   "office_election": 10,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/18/supporting/index.json
+++ b/build/candidate/18/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Gallo",
   "ballot_item": 10,
   "office_election": 10,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/19/index.json
+++ b/build/candidate/19/index.json
@@ -8,7 +8,7 @@
   "last_name": "Gonzales",
   "ballot_item": 10,
   "office_election": 10,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/19/index.json
+++ b/build/candidate/19/index.json
@@ -7,5 +7,26 @@
   "first_name": "Viola",
   "last_name": "Gonzales",
   "ballot_item": 10,
-  "office_election": 10
+  "office_election": 10,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/19/opposing/index.json
+++ b/build/candidate/19/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Gonzales",
   "ballot_item": 10,
   "office_election": 10,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/19/opposing/index.json
+++ b/build/candidate/19/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Gonzales",
   "ballot_item": 10,
   "office_election": 10,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/19/supporting/index.json
+++ b/build/candidate/19/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Gonzales",
   "ballot_item": 10,
   "office_election": 10,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/19/supporting/index.json
+++ b/build/candidate/19/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Gonzales",
   "ballot_item": 10,
   "office_election": 10,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/2/index.json
+++ b/build/candidate/2/index.json
@@ -7,5 +7,48 @@
   "first_name": "Rebecca",
   "last_name": "Kaplan",
   "ballot_item": 5,
-  "office_election": 5
+  "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": 52199.0,
+    "total_contributions": 52199.0,
+    "total_expenditures": 16219.89,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 4400.0,
+      "Individual": 39954.0,
+      "Unitemized": 1495.0,
+      "Other (includes Businesses)": 6350.0
+    },
+    "expenditures_by_type": {
+      "office expenses": 4936.55,
+      "fundraising events": 200.0,
+      "campaign paraphernalia/misc.": 1916.25,
+      "campaign literature and mailings": 4765.23,
+      "postage, delivery and messenger services": 1255.12,
+      "professional services (legal, accounting)": 1236.26,
+      "information technology costs (internet, e-mail)": 220.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 52199.0,
+  "total_contributions": 52199.0,
+  "total_expenditures": 16219.89,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Committee": 4400.0,
+    "Individual": 39954.0,
+    "Unitemized": 1495.0,
+    "Other (includes Businesses)": 6350.0
+  },
+  "expenditures_by_type": {
+    "office expenses": 4936.55,
+    "fundraising events": 200.0,
+    "campaign paraphernalia/misc.": 1916.25,
+    "campaign literature and mailings": 4765.23,
+    "postage, delivery and messenger services": 1255.12,
+    "professional services (legal, accounting)": 1236.26,
+    "information technology costs (internet, e-mail)": 220.0
+  }
 }

--- a/build/candidate/2/index.json
+++ b/build/candidate/2/index.json
@@ -8,7 +8,7 @@
   "last_name": "Kaplan",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 52199.0,
     "total_contributions": 52199.0,
     "total_expenditures": 16219.89,
@@ -29,7 +29,7 @@
       "information technology costs (internet, e-mail)": 220.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 52199.0,

--- a/build/candidate/2/opposing/index.json
+++ b/build/candidate/2/opposing/index.json
@@ -8,5 +8,47 @@
   "last_name": "Kaplan",
   "ballot_item": 5,
   "office_election": 5,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": 52199.0,
+    "total_contributions": 52199.0,
+    "total_expenditures": 16219.89,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 4400.0,
+      "Individual": 39954.0,
+      "Unitemized": 1495.0,
+      "Other (includes Businesses)": 6350.0
+    },
+    "expenditures_by_type": {
+      "office expenses": 4936.55,
+      "fundraising events": 200.0,
+      "campaign paraphernalia/misc.": 1916.25,
+      "campaign literature and mailings": 4765.23,
+      "postage, delivery and messenger services": 1255.12,
+      "professional services (legal, accounting)": 1236.26,
+      "information technology costs (internet, e-mail)": 220.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 52199.0,
+  "total_contributions": 52199.0,
+  "total_expenditures": 16219.89,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Committee": 4400.0,
+    "Individual": 39954.0,
+    "Unitemized": 1495.0,
+    "Other (includes Businesses)": 6350.0
+  },
+  "expenditures_by_type": {
+    "office expenses": 4936.55,
+    "fundraising events": 200.0,
+    "campaign paraphernalia/misc.": 1916.25,
+    "campaign literature and mailings": 4765.23,
+    "postage, delivery and messenger services": 1255.12,
+    "professional services (legal, accounting)": 1236.26,
+    "information technology costs (internet, e-mail)": 220.0
+  }
 }

--- a/build/candidate/2/opposing/index.json
+++ b/build/candidate/2/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Kaplan",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 52199.0,
     "total_contributions": 52199.0,
     "total_expenditures": 16219.89,
@@ -29,7 +29,7 @@
       "information technology costs (internet, e-mail)": 220.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 52199.0,

--- a/build/candidate/2/supporting/index.json
+++ b/build/candidate/2/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Kaplan",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 52199.0,
     "total_contributions": 52199.0,
     "total_expenditures": 16219.89,
@@ -29,7 +29,7 @@
       "information technology costs (internet, e-mail)": 220.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 52199.0,

--- a/build/candidate/2/supporting/index.json
+++ b/build/candidate/2/supporting/index.json
@@ -8,6 +8,30 @@
   "last_name": "Kaplan",
   "ballot_item": 5,
   "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": 52199.0,
+    "total_contributions": 52199.0,
+    "total_expenditures": 16219.89,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 4400.0,
+      "Individual": 39954.0,
+      "Unitemized": 1495.0,
+      "Other (includes Businesses)": 6350.0
+    },
+    "expenditures_by_type": {
+      "office expenses": 4936.55,
+      "fundraising events": 200.0,
+      "campaign paraphernalia/misc.": 1916.25,
+      "campaign literature and mailings": 4765.23,
+      "postage, delivery and messenger services": 1255.12,
+      "professional services (legal, accounting)": 1236.26,
+      "information technology costs (internet, e-mail)": 220.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": 52199.0,
   "total_contributions": 52199.0,
   "total_expenditures": 16219.89,

--- a/build/candidate/20/index.json
+++ b/build/candidate/20/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hodge",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/20/index.json
+++ b/build/candidate/20/index.json
@@ -7,5 +7,26 @@
   "first_name": "Marcie",
   "last_name": "Hodge",
   "ballot_item": 8,
-  "office_election": 8
+  "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/20/opposing/index.json
+++ b/build/candidate/20/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Hodge",
   "ballot_item": 8,
   "office_election": 8,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/20/opposing/index.json
+++ b/build/candidate/20/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hodge",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/20/supporting/index.json
+++ b/build/candidate/20/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hodge",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/20/supporting/index.json
+++ b/build/candidate/20/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Hodge",
   "ballot_item": 8,
   "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/21/index.json
+++ b/build/candidate/21/index.json
@@ -7,5 +7,26 @@
   "first_name": "Nehanda",
   "last_name": "Imara",
   "ballot_item": 8,
-  "office_election": 8
+  "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/21/index.json
+++ b/build/candidate/21/index.json
@@ -8,7 +8,7 @@
   "last_name": "Imara",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/21/opposing/index.json
+++ b/build/candidate/21/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Imara",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/21/opposing/index.json
+++ b/build/candidate/21/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Imara",
   "ballot_item": 8,
   "office_election": 8,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/21/supporting/index.json
+++ b/build/candidate/21/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Imara",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/21/supporting/index.json
+++ b/build/candidate/21/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Imara",
   "ballot_item": 8,
   "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/22/index.json
+++ b/build/candidate/22/index.json
@@ -7,5 +7,26 @@
   "first_name": "Larry",
   "last_name": "Reid",
   "ballot_item": 8,
-  "office_election": 8
+  "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/22/index.json
+++ b/build/candidate/22/index.json
@@ -8,7 +8,7 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/22/opposing/index.json
+++ b/build/candidate/22/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/22/opposing/index.json
+++ b/build/candidate/22/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/22/supporting/index.json
+++ b/build/candidate/22/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/22/supporting/index.json
+++ b/build/candidate/22/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/23/index.json
+++ b/build/candidate/23/index.json
@@ -7,5 +7,26 @@
   "first_name": "Treva",
   "last_name": "Reid",
   "ballot_item": 8,
-  "office_election": 8
+  "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/23/index.json
+++ b/build/candidate/23/index.json
@@ -8,7 +8,7 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/23/opposing/index.json
+++ b/build/candidate/23/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/23/opposing/index.json
+++ b/build/candidate/23/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/23/supporting/index.json
+++ b/build/candidate/23/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/23/supporting/index.json
+++ b/build/candidate/23/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Reid",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/24/index.json
+++ b/build/candidate/24/index.json
@@ -7,5 +7,26 @@
   "first_name": "Maxine",
   "last_name": "Oliver-Benson",
   "ballot_item": 8,
-  "office_election": 8
+  "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/24/index.json
+++ b/build/candidate/24/index.json
@@ -8,7 +8,7 @@
   "last_name": "Oliver-Benson",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/24/opposing/index.json
+++ b/build/candidate/24/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Oliver-Benson",
   "ballot_item": 8,
   "office_election": 8,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/24/opposing/index.json
+++ b/build/candidate/24/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Oliver-Benson",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/24/supporting/index.json
+++ b/build/candidate/24/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Oliver-Benson",
   "ballot_item": 8,
   "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/24/supporting/index.json
+++ b/build/candidate/24/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Oliver-Benson",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/25/index.json
+++ b/build/candidate/25/index.json
@@ -8,7 +8,7 @@
   "last_name": "De Jimenez",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/25/index.json
+++ b/build/candidate/25/index.json
@@ -7,5 +7,26 @@
   "first_name": "Olivia",
   "last_name": "De Jimenez",
   "ballot_item": 8,
-  "office_election": 8
+  "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/25/opposing/index.json
+++ b/build/candidate/25/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "De Jimenez",
   "ballot_item": 8,
   "office_election": 8,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/25/opposing/index.json
+++ b/build/candidate/25/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "De Jimenez",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/25/supporting/index.json
+++ b/build/candidate/25/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "De Jimenez",
   "ballot_item": 8,
   "office_election": 8,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/25/supporting/index.json
+++ b/build/candidate/25/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "De Jimenez",
   "ballot_item": 8,
   "office_election": 8,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/26/index.json
+++ b/build/candidate/26/index.json
@@ -7,5 +7,26 @@
   "first_name": "Donald",
   "last_name": "Macleay",
   "ballot_item": 1,
-  "office_election": 1
+  "office_election": 1,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/26/index.json
+++ b/build/candidate/26/index.json
@@ -8,7 +8,7 @@
   "last_name": "Macleay",
   "ballot_item": 1,
   "office_election": 1,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/26/opposing/index.json
+++ b/build/candidate/26/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Macleay",
   "ballot_item": 1,
   "office_election": 1,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/26/opposing/index.json
+++ b/build/candidate/26/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Macleay",
   "ballot_item": 1,
   "office_election": 1,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/26/supporting/index.json
+++ b/build/candidate/26/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Macleay",
   "ballot_item": 1,
   "office_election": 1,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/26/supporting/index.json
+++ b/build/candidate/26/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Macleay",
   "ballot_item": 1,
   "office_election": 1,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/27/index.json
+++ b/build/candidate/27/index.json
@@ -8,7 +8,7 @@
   "last_name": "London",
   "ballot_item": 1,
   "office_election": 1,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 5975.0,
     "total_contributions": 5975.0,
     "total_expenditures": 4826.78,
@@ -27,7 +27,7 @@
       "campaign literature and mailings": 850.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 5975.0,

--- a/build/candidate/27/index.json
+++ b/build/candidate/27/index.json
@@ -7,5 +7,44 @@
   "first_name": "Jody",
   "last_name": "London",
   "ballot_item": 1,
-  "office_election": 1
+  "office_election": 1,
+  "supporting_contribution_data": {
+    "contributions_received": 5975.0,
+    "total_contributions": 5975.0,
+    "total_expenditures": 4826.78,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Individual": 4000.0,
+      "Unitemized": 575.0,
+      "Other (includes Businesses)": 1400.0
+    },
+    "expenditures_by_type": {
+      "office expenses": 166.47,
+      "fundraising events": 475.05,
+      "campaign consultants": 1000.0,
+      "meetings and appearances": 437.32,
+      "campaign paraphernalia/misc.": 1397.94,
+      "campaign literature and mailings": 850.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 5975.0,
+  "total_contributions": 5975.0,
+  "total_expenditures": 4826.78,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Individual": 4000.0,
+    "Unitemized": 575.0,
+    "Other (includes Businesses)": 1400.0
+  },
+  "expenditures_by_type": {
+    "office expenses": 166.47,
+    "fundraising events": 475.05,
+    "campaign consultants": 1000.0,
+    "meetings and appearances": 437.32,
+    "campaign paraphernalia/misc.": 1397.94,
+    "campaign literature and mailings": 850.0
+  }
 }

--- a/build/candidate/27/opposing/index.json
+++ b/build/candidate/27/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "London",
   "ballot_item": 1,
   "office_election": 1,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 5975.0,
     "total_contributions": 5975.0,
     "total_expenditures": 4826.78,
@@ -27,7 +27,7 @@
       "campaign literature and mailings": 850.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 5975.0,

--- a/build/candidate/27/opposing/index.json
+++ b/build/candidate/27/opposing/index.json
@@ -8,5 +8,43 @@
   "last_name": "London",
   "ballot_item": 1,
   "office_election": 1,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": 5975.0,
+    "total_contributions": 5975.0,
+    "total_expenditures": 4826.78,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Individual": 4000.0,
+      "Unitemized": 575.0,
+      "Other (includes Businesses)": 1400.0
+    },
+    "expenditures_by_type": {
+      "office expenses": 166.47,
+      "fundraising events": 475.05,
+      "campaign consultants": 1000.0,
+      "meetings and appearances": 437.32,
+      "campaign paraphernalia/misc.": 1397.94,
+      "campaign literature and mailings": 850.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 5975.0,
+  "total_contributions": 5975.0,
+  "total_expenditures": 4826.78,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Individual": 4000.0,
+    "Unitemized": 575.0,
+    "Other (includes Businesses)": 1400.0
+  },
+  "expenditures_by_type": {
+    "office expenses": 166.47,
+    "fundraising events": 475.05,
+    "campaign consultants": 1000.0,
+    "meetings and appearances": 437.32,
+    "campaign paraphernalia/misc.": 1397.94,
+    "campaign literature and mailings": 850.0
+  }
 }

--- a/build/candidate/27/supporting/index.json
+++ b/build/candidate/27/supporting/index.json
@@ -8,6 +8,28 @@
   "last_name": "London",
   "ballot_item": 1,
   "office_election": 1,
+  "supporting_contribution_data": {
+    "contributions_received": 5975.0,
+    "total_contributions": 5975.0,
+    "total_expenditures": 4826.78,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Individual": 4000.0,
+      "Unitemized": 575.0,
+      "Other (includes Businesses)": 1400.0
+    },
+    "expenditures_by_type": {
+      "office expenses": 166.47,
+      "fundraising events": 475.05,
+      "campaign consultants": 1000.0,
+      "meetings and appearances": 437.32,
+      "campaign paraphernalia/misc.": 1397.94,
+      "campaign literature and mailings": 850.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": 5975.0,
   "total_contributions": 5975.0,
   "total_expenditures": 4826.78,

--- a/build/candidate/27/supporting/index.json
+++ b/build/candidate/27/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "London",
   "ballot_item": 1,
   "office_election": 1,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 5975.0,
     "total_contributions": 5975.0,
     "total_expenditures": 4826.78,
@@ -27,7 +27,7 @@
       "campaign literature and mailings": 850.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 5975.0,

--- a/build/candidate/28/index.json
+++ b/build/candidate/28/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hinton Hodge",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/28/index.json
+++ b/build/candidate/28/index.json
@@ -7,5 +7,26 @@
   "first_name": "Jumoke",
   "last_name": "Hinton Hodge",
   "ballot_item": 7,
-  "office_election": 7
+  "office_election": 7,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/28/opposing/index.json
+++ b/build/candidate/28/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hinton Hodge",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/28/opposing/index.json
+++ b/build/candidate/28/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Hinton Hodge",
   "ballot_item": 7,
   "office_election": 7,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/28/supporting/index.json
+++ b/build/candidate/28/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Hinton Hodge",
   "ballot_item": 7,
   "office_election": 7,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/28/supporting/index.json
+++ b/build/candidate/28/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hinton Hodge",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/29/index.json
+++ b/build/candidate/29/index.json
@@ -7,5 +7,26 @@
   "first_name": "Benjamin",
   "last_name": "Lang",
   "ballot_item": 7,
-  "office_election": 7
+  "office_election": 7,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/29/index.json
+++ b/build/candidate/29/index.json
@@ -8,7 +8,7 @@
   "last_name": "Lang",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/29/opposing/index.json
+++ b/build/candidate/29/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Lang",
   "ballot_item": 7,
   "office_election": 7,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/29/opposing/index.json
+++ b/build/candidate/29/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Lang",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/29/supporting/index.json
+++ b/build/candidate/29/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Lang",
   "ballot_item": 7,
   "office_election": 7,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/29/supporting/index.json
+++ b/build/candidate/29/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Lang",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/3/index.json
+++ b/build/candidate/3/index.json
@@ -8,7 +8,7 @@
   "last_name": "Quan",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/3/index.json
+++ b/build/candidate/3/index.json
@@ -7,5 +7,26 @@
   "first_name": "Bruce",
   "last_name": "Quan",
   "ballot_item": 5,
-  "office_election": 5
+  "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/3/opposing/index.json
+++ b/build/candidate/3/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Quan",
   "ballot_item": 5,
   "office_election": 5,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/3/opposing/index.json
+++ b/build/candidate/3/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Quan",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/3/supporting/index.json
+++ b/build/candidate/3/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Quan",
   "ballot_item": 5,
   "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/3/supporting/index.json
+++ b/build/candidate/3/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Quan",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/30/index.json
+++ b/build/candidate/30/index.json
@@ -8,7 +8,7 @@
   "last_name": "Wiginton",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/30/index.json
+++ b/build/candidate/30/index.json
@@ -7,5 +7,26 @@
   "first_name": "Kharyshi",
   "last_name": "Wiginton",
   "ballot_item": 7,
-  "office_election": 7
+  "office_election": 7,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/30/opposing/index.json
+++ b/build/candidate/30/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Wiginton",
   "ballot_item": 7,
   "office_election": 7,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/30/opposing/index.json
+++ b/build/candidate/30/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Wiginton",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/30/supporting/index.json
+++ b/build/candidate/30/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Wiginton",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/30/supporting/index.json
+++ b/build/candidate/30/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Wiginton",
   "ballot_item": 7,
   "office_election": 7,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/31/index.json
+++ b/build/candidate/31/index.json
@@ -8,7 +8,7 @@
   "last_name": "Narain",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/31/index.json
+++ b/build/candidate/31/index.json
@@ -7,5 +7,26 @@
   "first_name": "Lucky",
   "last_name": "Narain",
   "ballot_item": 7,
-  "office_election": 7
+  "office_election": 7,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/31/opposing/index.json
+++ b/build/candidate/31/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Narain",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/31/opposing/index.json
+++ b/build/candidate/31/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Narain",
   "ballot_item": 7,
   "office_election": 7,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/31/supporting/index.json
+++ b/build/candidate/31/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Narain",
   "ballot_item": 7,
   "office_election": 7,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/31/supporting/index.json
+++ b/build/candidate/31/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Narain",
   "ballot_item": 7,
   "office_election": 7,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/32/index.json
+++ b/build/candidate/32/index.json
@@ -7,5 +7,26 @@
   "first_name": "Michael",
   "last_name": "Hassid",
   "ballot_item": 9,
-  "office_election": 9
+  "office_election": 9,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/32/index.json
+++ b/build/candidate/32/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hassid",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/32/opposing/index.json
+++ b/build/candidate/32/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hassid",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/32/opposing/index.json
+++ b/build/candidate/32/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Hassid",
   "ballot_item": 9,
   "office_election": 9,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/32/supporting/index.json
+++ b/build/candidate/32/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hassid",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/32/supporting/index.json
+++ b/build/candidate/32/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Hassid",
   "ballot_item": 9,
   "office_election": 9,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/33/index.json
+++ b/build/candidate/33/index.json
@@ -7,5 +7,26 @@
   "first_name": "Michael",
   "last_name": "Hutchinson",
   "ballot_item": 9,
-  "office_election": 9
+  "office_election": 9,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/33/index.json
+++ b/build/candidate/33/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hutchinson",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/33/opposing/index.json
+++ b/build/candidate/33/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hutchinson",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/33/opposing/index.json
+++ b/build/candidate/33/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Hutchinson",
   "ballot_item": 9,
   "office_election": 9,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/33/supporting/index.json
+++ b/build/candidate/33/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Hutchinson",
   "ballot_item": 9,
   "office_election": 9,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/33/supporting/index.json
+++ b/build/candidate/33/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Hutchinson",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/34/index.json
+++ b/build/candidate/34/index.json
@@ -8,7 +8,7 @@
   "last_name": "Torres",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 6895.0,
     "total_contributions": 6895.0,
     "total_expenditures": 6673.3,
@@ -27,7 +27,7 @@
       "information technology costs (internet, e-mail)": 400.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 6895.0,

--- a/build/candidate/34/index.json
+++ b/build/candidate/34/index.json
@@ -7,5 +7,44 @@
   "first_name": "Roseann",
   "last_name": "Torres",
   "ballot_item": 9,
-  "office_election": 9
+  "office_election": 9,
+  "supporting_contribution_data": {
+    "contributions_received": 6895.0,
+    "total_contributions": 6895.0,
+    "total_expenditures": 6673.3,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 1700.0,
+      "Individual": 4150.0,
+      "Unitemized": 345.0,
+      "Other (includes Businesses)": 700.0
+    },
+    "expenditures_by_type": {
+      "office expenses": 107.05,
+      "fundraising events": 600.0,
+      "campaign consultants": 1130.0,
+      "professional services (legal, accounting)": 3626.34,
+      "information technology costs (internet, e-mail)": 400.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 6895.0,
+  "total_contributions": 6895.0,
+  "total_expenditures": 6673.3,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Committee": 1700.0,
+    "Individual": 4150.0,
+    "Unitemized": 345.0,
+    "Other (includes Businesses)": 700.0
+  },
+  "expenditures_by_type": {
+    "office expenses": 107.05,
+    "fundraising events": 600.0,
+    "campaign consultants": 1130.0,
+    "professional services (legal, accounting)": 3626.34,
+    "information technology costs (internet, e-mail)": 400.0
+  }
 }

--- a/build/candidate/34/opposing/index.json
+++ b/build/candidate/34/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Torres",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 6895.0,
     "total_contributions": 6895.0,
     "total_expenditures": 6673.3,
@@ -27,7 +27,7 @@
       "information technology costs (internet, e-mail)": 400.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 6895.0,

--- a/build/candidate/34/opposing/index.json
+++ b/build/candidate/34/opposing/index.json
@@ -8,5 +8,43 @@
   "last_name": "Torres",
   "ballot_item": 9,
   "office_election": 9,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": 6895.0,
+    "total_contributions": 6895.0,
+    "total_expenditures": 6673.3,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 1700.0,
+      "Individual": 4150.0,
+      "Unitemized": 345.0,
+      "Other (includes Businesses)": 700.0
+    },
+    "expenditures_by_type": {
+      "office expenses": 107.05,
+      "fundraising events": 600.0,
+      "campaign consultants": 1130.0,
+      "professional services (legal, accounting)": 3626.34,
+      "information technology costs (internet, e-mail)": 400.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 6895.0,
+  "total_contributions": 6895.0,
+  "total_expenditures": 6673.3,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Committee": 1700.0,
+    "Individual": 4150.0,
+    "Unitemized": 345.0,
+    "Other (includes Businesses)": 700.0
+  },
+  "expenditures_by_type": {
+    "office expenses": 107.05,
+    "fundraising events": 600.0,
+    "campaign consultants": 1130.0,
+    "professional services (legal, accounting)": 3626.34,
+    "information technology costs (internet, e-mail)": 400.0
+  }
 }

--- a/build/candidate/34/supporting/index.json
+++ b/build/candidate/34/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Torres",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 6895.0,
     "total_contributions": 6895.0,
     "total_expenditures": 6673.3,
@@ -27,7 +27,7 @@
       "information technology costs (internet, e-mail)": 400.0
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 6895.0,

--- a/build/candidate/34/supporting/index.json
+++ b/build/candidate/34/supporting/index.json
@@ -8,6 +8,28 @@
   "last_name": "Torres",
   "ballot_item": 9,
   "office_election": 9,
+  "supporting_contribution_data": {
+    "contributions_received": 6895.0,
+    "total_contributions": 6895.0,
+    "total_expenditures": 6673.3,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 1700.0,
+      "Individual": 4150.0,
+      "Unitemized": 345.0,
+      "Other (includes Businesses)": 700.0
+    },
+    "expenditures_by_type": {
+      "office expenses": 107.05,
+      "fundraising events": 600.0,
+      "campaign consultants": 1130.0,
+      "professional services (legal, accounting)": 3626.34,
+      "information technology costs (internet, e-mail)": 400.0
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": 6895.0,
   "total_contributions": 6895.0,
   "total_expenditures": 6673.3,

--- a/build/candidate/35/index.json
+++ b/build/candidate/35/index.json
@@ -7,5 +7,26 @@
   "first_name": "Huber",
   "last_name": "Trenado",
   "ballot_item": 9,
-  "office_election": 9
+  "office_election": 9,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/35/index.json
+++ b/build/candidate/35/index.json
@@ -8,7 +8,7 @@
   "last_name": "Trenado",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/35/opposing/index.json
+++ b/build/candidate/35/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Trenado",
   "ballot_item": 9,
   "office_election": 9,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/35/opposing/index.json
+++ b/build/candidate/35/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Trenado",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/35/supporting/index.json
+++ b/build/candidate/35/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Trenado",
   "ballot_item": 9,
   "office_election": 9,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/35/supporting/index.json
+++ b/build/candidate/35/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Trenado",
   "ballot_item": 9,
   "office_election": 9,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/36/index.json
+++ b/build/candidate/36/index.json
@@ -8,7 +8,7 @@
   "last_name": "Harris",
   "ballot_item": 6,
   "office_election": 6,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/36/index.json
+++ b/build/candidate/36/index.json
@@ -7,5 +7,26 @@
   "first_name": "James",
   "last_name": "Harris",
   "ballot_item": 6,
-  "office_election": 6
+  "office_election": 6,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/36/opposing/index.json
+++ b/build/candidate/36/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Harris",
   "ballot_item": 6,
   "office_election": 6,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/36/opposing/index.json
+++ b/build/candidate/36/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Harris",
   "ballot_item": 6,
   "office_election": 6,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/36/supporting/index.json
+++ b/build/candidate/36/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Harris",
   "ballot_item": 6,
   "office_election": 6,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/36/supporting/index.json
+++ b/build/candidate/36/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Harris",
   "ballot_item": 6,
   "office_election": 6,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/37/index.json
+++ b/build/candidate/37/index.json
@@ -8,7 +8,7 @@
   "last_name": "Jackson",
   "ballot_item": 6,
   "office_election": 6,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 5822.0,
     "total_contributions": 5822.0,
     "total_expenditures": 12413.89,
@@ -21,7 +21,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 5822.0,

--- a/build/candidate/37/index.json
+++ b/build/candidate/37/index.json
@@ -7,5 +7,32 @@
   "first_name": "Chris",
   "last_name": "Jackson",
   "ballot_item": 6,
-  "office_election": 6
+  "office_election": 6,
+  "supporting_contribution_data": {
+    "contributions_received": 5822.0,
+    "total_contributions": 5822.0,
+    "total_expenditures": 12413.89,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 1200.0,
+      "Individual": 2950.0,
+      "Unitemized": 1672.0
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 5822.0,
+  "total_contributions": 5822.0,
+  "total_expenditures": 12413.89,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Committee": 1200.0,
+    "Individual": 2950.0,
+    "Unitemized": 1672.0
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/37/opposing/index.json
+++ b/build/candidate/37/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Jackson",
   "ballot_item": 6,
   "office_election": 6,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 5822.0,
     "total_contributions": 5822.0,
     "total_expenditures": 12413.89,
@@ -21,7 +21,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 5822.0,

--- a/build/candidate/37/opposing/index.json
+++ b/build/candidate/37/opposing/index.json
@@ -8,5 +8,31 @@
   "last_name": "Jackson",
   "ballot_item": 6,
   "office_election": 6,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": 5822.0,
+    "total_contributions": 5822.0,
+    "total_expenditures": 12413.89,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 1200.0,
+      "Individual": 2950.0,
+      "Unitemized": 1672.0
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": 5822.0,
+  "total_contributions": 5822.0,
+  "total_expenditures": 12413.89,
+  "total_loans_received": 0.0,
+  "contributions_by_type": {
+    "Committee": 1200.0,
+    "Individual": 2950.0,
+    "Unitemized": 1672.0
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/37/supporting/index.json
+++ b/build/candidate/37/supporting/index.json
@@ -8,6 +8,22 @@
   "last_name": "Jackson",
   "ballot_item": 6,
   "office_election": 6,
+  "supporting_contribution_data": {
+    "contributions_received": 5822.0,
+    "total_contributions": 5822.0,
+    "total_expenditures": 12413.89,
+    "total_loans_received": 0.0,
+    "contributions_by_type": {
+      "Committee": 1200.0,
+      "Individual": 2950.0,
+      "Unitemized": 1672.0
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": 5822.0,
   "total_contributions": 5822.0,
   "total_expenditures": 12413.89,

--- a/build/candidate/37/supporting/index.json
+++ b/build/candidate/37/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Jackson",
   "ballot_item": 6,
   "office_election": 6,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": 5822.0,
     "total_contributions": 5822.0,
     "total_expenditures": 12413.89,
@@ -21,7 +21,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": 5822.0,

--- a/build/candidate/4/index.json
+++ b/build/candidate/4/index.json
@@ -7,5 +7,26 @@
   "first_name": "Nancy",
   "last_name": "Sidebotham",
   "ballot_item": 5,
-  "office_election": 5
+  "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/4/index.json
+++ b/build/candidate/4/index.json
@@ -8,7 +8,7 @@
   "last_name": "Sidebotham",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/4/opposing/index.json
+++ b/build/candidate/4/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Sidebotham",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/4/opposing/index.json
+++ b/build/candidate/4/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Sidebotham",
   "ballot_item": 5,
   "office_election": 5,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/4/supporting/index.json
+++ b/build/candidate/4/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Sidebotham",
   "ballot_item": 5,
   "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/4/supporting/index.json
+++ b/build/candidate/4/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Sidebotham",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/5/index.json
+++ b/build/candidate/5/index.json
@@ -7,5 +7,26 @@
   "first_name": "Francis",
   "last_name": "Matt Hummell",
   "ballot_item": 5,
-  "office_election": 5
+  "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/5/index.json
+++ b/build/candidate/5/index.json
@@ -8,7 +8,7 @@
   "last_name": "Matt Hummell",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/5/opposing/index.json
+++ b/build/candidate/5/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Matt Hummell",
   "ballot_item": 5,
   "office_election": 5,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/5/opposing/index.json
+++ b/build/candidate/5/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Matt Hummell",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/5/supporting/index.json
+++ b/build/candidate/5/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Matt Hummell",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/5/supporting/index.json
+++ b/build/candidate/5/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Matt Hummell",
   "ballot_item": 5,
   "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/6/index.json
+++ b/build/candidate/6/index.json
@@ -8,7 +8,7 @@
   "last_name": "Moore",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/6/index.json
+++ b/build/candidate/6/index.json
@@ -7,5 +7,26 @@
   "first_name": "Peggy",
   "last_name": "Moore",
   "ballot_item": 5,
-  "office_election": 5
+  "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/6/opposing/index.json
+++ b/build/candidate/6/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Moore",
   "ballot_item": 5,
   "office_election": 5,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/6/opposing/index.json
+++ b/build/candidate/6/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Moore",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/6/supporting/index.json
+++ b/build/candidate/6/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Moore",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/6/supporting/index.json
+++ b/build/candidate/6/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Moore",
   "ballot_item": 5,
   "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/7/index.json
+++ b/build/candidate/7/index.json
@@ -8,7 +8,7 @@
   "last_name": "Ellis",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/7/index.json
+++ b/build/candidate/7/index.json
@@ -7,5 +7,26 @@
   "first_name": "Patricia",
   "last_name": "Ellis",
   "ballot_item": 5,
-  "office_election": 5
+  "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/7/opposing/index.json
+++ b/build/candidate/7/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Ellis",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/7/opposing/index.json
+++ b/build/candidate/7/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Ellis",
   "ballot_item": 5,
   "office_election": 5,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/7/supporting/index.json
+++ b/build/candidate/7/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Ellis",
   "ballot_item": 5,
   "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/7/supporting/index.json
+++ b/build/candidate/7/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Ellis",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/8/index.json
+++ b/build/candidate/8/index.json
@@ -7,5 +7,26 @@
   "first_name": "Larry",
   "last_name": "Young Jr.",
   "ballot_item": 5,
-  "office_election": 5
+  "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/8/index.json
+++ b/build/candidate/8/index.json
@@ -8,7 +8,7 @@
   "last_name": "Young Jr.",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/8/opposing/index.json
+++ b/build/candidate/8/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Young Jr.",
   "ballot_item": 5,
   "office_election": 5,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/8/opposing/index.json
+++ b/build/candidate/8/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Young Jr.",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/8/supporting/index.json
+++ b/build/candidate/8/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Young Jr.",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/8/supporting/index.json
+++ b/build/candidate/8/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Young Jr.",
   "ballot_item": 5,
   "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/candidate/9/index.json
+++ b/build/candidate/9/index.json
@@ -7,5 +7,26 @@
   "first_name": "Manuel",
   "last_name": "Cabello",
   "ballot_item": 5,
-  "office_election": 5
+  "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/9/index.json
+++ b/build/candidate/9/index.json
@@ -8,7 +8,7 @@
   "last_name": "Cabello",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/9/opposing/index.json
+++ b/build/candidate/9/opposing/index.json
@@ -8,7 +8,7 @@
   "last_name": "Cabello",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/9/opposing/index.json
+++ b/build/candidate/9/opposing/index.json
@@ -8,5 +8,25 @@
   "last_name": "Cabello",
   "ballot_item": 5,
   "office_election": 5,
-  "contributions_received": 4567
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
+  "contributions_received": null,
+  "total_contributions": null,
+  "total_expenditures": null,
+  "total_loans_received": null,
+  "contributions_by_type": {
+  },
+  "expenditures_by_type": {
+  }
 }

--- a/build/candidate/9/supporting/index.json
+++ b/build/candidate/9/supporting/index.json
@@ -8,7 +8,7 @@
   "last_name": "Cabello",
   "ballot_item": 5,
   "office_election": 5,
-  "supporting_contribution_data": {
+  "supporting_money": {
     "contributions_received": null,
     "total_contributions": null,
     "total_expenditures": null,
@@ -18,7 +18,7 @@
     "expenditures_by_type": {
     }
   },
-  "opposing_contribution_data": {
+  "opposing_money": {
     "contributions_received": 4567
   },
   "contributions_received": null,

--- a/build/candidate/9/supporting/index.json
+++ b/build/candidate/9/supporting/index.json
@@ -8,6 +8,19 @@
   "last_name": "Cabello",
   "ballot_item": 5,
   "office_election": 5,
+  "supporting_contribution_data": {
+    "contributions_received": null,
+    "total_contributions": null,
+    "total_expenditures": null,
+    "total_loans_received": null,
+    "contributions_by_type": {
+    },
+    "expenditures_by_type": {
+    }
+  },
+  "opposing_contribution_data": {
+    "contributions_received": 4567
+  },
   "contributions_received": null,
   "total_contributions": null,
   "total_expenditures": null,

--- a/build/locality/2/current_ballot/index.json
+++ b/build/locality/2/current_ballot/index.json
@@ -16,7 +16,7 @@
           "last_name": "Macleay",
           "ballot_item": 1,
           "office_election": 1,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -26,7 +26,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -48,7 +48,7 @@
           "last_name": "London",
           "ballot_item": 1,
           "office_election": 1,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 5975.0,
             "total_contributions": 5975.0,
             "total_expenditures": 4826.78,
@@ -67,7 +67,7 @@
               "campaign literature and mailings": 850.0
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 5975.0,
@@ -105,7 +105,7 @@
           "last_name": "Parker",
           "ballot_item": 2,
           "office_election": 2,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 60871.0,
             "total_contributions": 60871.0,
             "total_expenditures": 7510.5,
@@ -119,7 +119,7 @@
               "campaign consultants": 7500.0
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 60871.0,
@@ -152,7 +152,7 @@
           "last_name": "Corbett",
           "ballot_item": 3,
           "office_election": 3,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 19375.0,
             "total_contributions": 19375.0,
             "total_expenditures": 8479.42,
@@ -165,7 +165,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 19375.0,
@@ -190,7 +190,7 @@
           "last_name": "Kalb",
           "ballot_item": 3,
           "office_election": 3,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 39058.66,
             "total_contributions": 39058.66,
             "total_expenditures": 6118.11,
@@ -207,7 +207,7 @@
               "information technology costs (internet, e-mail)": 404.03
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 39058.66,
@@ -243,7 +243,7 @@
           "last_name": "Brown",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -253,7 +253,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -275,7 +275,7 @@
           "last_name": "Gibson McElhaney",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 41597.08,
             "total_contributions": 41597.08,
             "total_expenditures": 9736.75,
@@ -295,7 +295,7 @@
               "information technology costs (internet, e-mail)": 942.85
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 41597.08,
@@ -327,7 +327,7 @@
           "last_name": "Session",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -337,7 +337,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -359,7 +359,7 @@
           "last_name": "Karamooz",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -369,7 +369,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -391,7 +391,7 @@
           "last_name": "McNeal",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -401,7 +401,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -423,7 +423,7 @@
           "last_name": "Jordan",
           "ballot_item": 4,
           "office_election": 4,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -433,7 +433,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -462,7 +462,7 @@
           "last_name": "Kaplan",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 52199.0,
             "total_contributions": 52199.0,
             "total_expenditures": 16219.89,
@@ -483,7 +483,7 @@
               "information technology costs (internet, e-mail)": 220.0
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 52199.0,
@@ -516,7 +516,7 @@
           "last_name": "Quan",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -526,7 +526,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -548,7 +548,7 @@
           "last_name": "Sidebotham",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -558,7 +558,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -580,7 +580,7 @@
           "last_name": "Matt Hummell",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -590,7 +590,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -612,7 +612,7 @@
           "last_name": "Moore",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -622,7 +622,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -644,7 +644,7 @@
           "last_name": "Ellis",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -654,7 +654,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -676,7 +676,7 @@
           "last_name": "Young Jr.",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -686,7 +686,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -708,7 +708,7 @@
           "last_name": "Cabello",
           "ballot_item": 5,
           "office_election": 5,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -718,7 +718,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -747,7 +747,7 @@
           "last_name": "Harris",
           "ballot_item": 6,
           "office_election": 6,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -757,7 +757,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -779,7 +779,7 @@
           "last_name": "Jackson",
           "ballot_item": 6,
           "office_election": 6,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 5822.0,
             "total_contributions": 5822.0,
             "total_expenditures": 12413.89,
@@ -792,7 +792,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 5822.0,
@@ -824,7 +824,7 @@
           "last_name": "Hinton Hodge",
           "ballot_item": 7,
           "office_election": 7,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -834,7 +834,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -856,7 +856,7 @@
           "last_name": "Lang",
           "ballot_item": 7,
           "office_election": 7,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -866,7 +866,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -888,7 +888,7 @@
           "last_name": "Wiginton",
           "ballot_item": 7,
           "office_election": 7,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -898,7 +898,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -920,7 +920,7 @@
           "last_name": "Narain",
           "ballot_item": 7,
           "office_election": 7,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -930,7 +930,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -959,7 +959,7 @@
           "last_name": "Hodge",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -969,7 +969,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -991,7 +991,7 @@
           "last_name": "Imara",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1001,7 +1001,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1023,7 +1023,7 @@
           "last_name": "Reid",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1033,7 +1033,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1055,7 +1055,7 @@
           "last_name": "Reid",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1065,7 +1065,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1087,7 +1087,7 @@
           "last_name": "Oliver-Benson",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1097,7 +1097,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1119,7 +1119,7 @@
           "last_name": "De Jimenez",
           "ballot_item": 8,
           "office_election": 8,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1129,7 +1129,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1158,7 +1158,7 @@
           "last_name": "Hassid",
           "ballot_item": 9,
           "office_election": 9,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1168,7 +1168,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1190,7 +1190,7 @@
           "last_name": "Hutchinson",
           "ballot_item": 9,
           "office_election": 9,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1200,7 +1200,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1222,7 +1222,7 @@
           "last_name": "Torres",
           "ballot_item": 9,
           "office_election": 9,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": 6895.0,
             "total_contributions": 6895.0,
             "total_expenditures": 6673.3,
@@ -1241,7 +1241,7 @@
               "information technology costs (internet, e-mail)": 400.0
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": 6895.0,
@@ -1272,7 +1272,7 @@
           "last_name": "Trenado",
           "ballot_item": 9,
           "office_election": 9,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1282,7 +1282,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1311,7 +1311,7 @@
           "last_name": "Gallo",
           "ballot_item": 10,
           "office_election": 10,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1321,7 +1321,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,
@@ -1343,7 +1343,7 @@
           "last_name": "Gonzales",
           "ballot_item": 10,
           "office_election": 10,
-          "supporting_contribution_data": {
+          "supporting_money": {
             "contributions_received": null,
             "total_contributions": null,
             "total_expenditures": null,
@@ -1353,7 +1353,7 @@
             "expenditures_by_type": {
             }
           },
-          "opposing_contribution_data": {
+          "opposing_money": {
             "contributions_received": 4567
           },
           "contributions_received": null,

--- a/build/locality/2/current_ballot/index.json
+++ b/build/locality/2/current_ballot/index.json
@@ -15,7 +15,28 @@
           "first_name": "Donald",
           "last_name": "Macleay",
           "ballot_item": 1,
-          "office_election": 1
+          "office_election": 1,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 27,
@@ -26,7 +47,46 @@
           "first_name": "Jody",
           "last_name": "London",
           "ballot_item": 1,
-          "office_election": 1
+          "office_election": 1,
+          "supporting_contribution_data": {
+            "contributions_received": 5975.0,
+            "total_contributions": 5975.0,
+            "total_expenditures": 4826.78,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Individual": 4000.0,
+              "Unitemized": 575.0,
+              "Other (includes Businesses)": 1400.0
+            },
+            "expenditures_by_type": {
+              "office expenses": 166.47,
+              "fundraising events": 475.05,
+              "campaign consultants": 1000.0,
+              "meetings and appearances": 437.32,
+              "campaign paraphernalia/misc.": 1397.94,
+              "campaign literature and mailings": 850.0
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 5975.0,
+          "total_contributions": 5975.0,
+          "total_expenditures": 4826.78,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Individual": 4000.0,
+            "Unitemized": 575.0,
+            "Other (includes Businesses)": 1400.0
+          },
+          "expenditures_by_type": {
+            "office expenses": 166.47,
+            "fundraising events": 475.05,
+            "campaign consultants": 1000.0,
+            "meetings and appearances": 437.32,
+            "campaign paraphernalia/misc.": 1397.94,
+            "campaign literature and mailings": 850.0
+          }
         }
       ]
     },
@@ -44,7 +104,36 @@
           "first_name": "Barbara",
           "last_name": "Parker",
           "ballot_item": 2,
-          "office_election": 2
+          "office_election": 2,
+          "supporting_contribution_data": {
+            "contributions_received": 60871.0,
+            "total_contributions": 60871.0,
+            "total_expenditures": 7510.5,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Individual": 55100.0,
+              "Unitemized": 355.0,
+              "Other (includes Businesses)": 5416.0
+            },
+            "expenditures_by_type": {
+              "campaign consultants": 7500.0
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 60871.0,
+          "total_contributions": 60871.0,
+          "total_expenditures": 7510.5,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Individual": 55100.0,
+            "Unitemized": 355.0,
+            "Other (includes Businesses)": 5416.0
+          },
+          "expenditures_by_type": {
+            "campaign consultants": 7500.0
+          }
         }
       ]
     },
@@ -62,7 +151,34 @@
           "first_name": "Kevin",
           "last_name": "Corbett",
           "ballot_item": 3,
-          "office_election": 3
+          "office_election": 3,
+          "supporting_contribution_data": {
+            "contributions_received": 19375.0,
+            "total_contributions": 19375.0,
+            "total_expenditures": 8479.42,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Individual": 16250.0,
+              "Unitemized": 675.0,
+              "Other (includes Businesses)": 2450.0
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 19375.0,
+          "total_contributions": 19375.0,
+          "total_expenditures": 8479.42,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Individual": 16250.0,
+            "Unitemized": 675.0,
+            "Other (includes Businesses)": 2450.0
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 11,
@@ -73,7 +189,42 @@
           "first_name": "Dan",
           "last_name": "Kalb",
           "ballot_item": 3,
-          "office_election": 3
+          "office_election": 3,
+          "supporting_contribution_data": {
+            "contributions_received": 39058.66,
+            "total_contributions": 39058.66,
+            "total_expenditures": 6118.11,
+            "total_loans_received": 9000.0,
+            "contributions_by_type": {
+              "Committee": 2400.0,
+              "Individual": 22487.0,
+              "Unitemized": 3521.66,
+              "Other (includes Businesses)": 1650.0
+            },
+            "expenditures_by_type": {
+              "fundraising events": 4749.38,
+              "campaign literature and mailings": 894.7,
+              "information technology costs (internet, e-mail)": 404.03
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 39058.66,
+          "total_contributions": 39058.66,
+          "total_expenditures": 6118.11,
+          "total_loans_received": 9000.0,
+          "contributions_by_type": {
+            "Committee": 2400.0,
+            "Individual": 22487.0,
+            "Unitemized": 3521.66,
+            "Other (includes Businesses)": 1650.0
+          },
+          "expenditures_by_type": {
+            "fundraising events": 4749.38,
+            "campaign literature and mailings": 894.7,
+            "information technology costs (internet, e-mail)": 404.03
+          }
         }
       ]
     },
@@ -91,7 +242,28 @@
           "first_name": "Alan",
           "last_name": "Brown",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 13,
@@ -102,7 +274,48 @@
           "first_name": "Lynette",
           "last_name": "Gibson McElhaney",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": 41597.08,
+            "total_contributions": 41597.08,
+            "total_expenditures": 9736.75,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Committee": 3250.0,
+              "Individual": 29188.16,
+              "Unitemized": 808.92,
+              "Other (includes Businesses)": 8350.0
+            },
+            "expenditures_by_type": {
+              "civic donations": 450.0,
+              "office expenses": 2340.51,
+              "fundraising events": 718.87,
+              "meetings and appearances": 184.17,
+              "professional services (legal, accounting)": 4318.35,
+              "information technology costs (internet, e-mail)": 942.85
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 41597.08,
+          "total_contributions": 41597.08,
+          "total_expenditures": 9736.75,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Committee": 3250.0,
+            "Individual": 29188.16,
+            "Unitemized": 808.92,
+            "Other (includes Businesses)": 8350.0
+          },
+          "expenditures_by_type": {
+            "civic donations": 450.0,
+            "office expenses": 2340.51,
+            "fundraising events": 718.87,
+            "meetings and appearances": 184.17,
+            "professional services (legal, accounting)": 4318.35,
+            "information technology costs (internet, e-mail)": 942.85
+          }
         },
         {
           "id": 14,
@@ -113,7 +326,28 @@
           "first_name": "Noni",
           "last_name": "Session",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 15,
@@ -124,7 +358,28 @@
           "first_name": "Saied",
           "last_name": "Karamooz",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 16,
@@ -135,7 +390,28 @@
           "first_name": "Anthony",
           "last_name": "McNeal",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 17,
@@ -146,7 +422,28 @@
           "first_name": "Tyron",
           "last_name": "Jordan",
           "ballot_item": 4,
-          "office_election": 4
+          "office_election": 4,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -164,7 +461,50 @@
           "first_name": "Rebecca",
           "last_name": "Kaplan",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": 52199.0,
+            "total_contributions": 52199.0,
+            "total_expenditures": 16219.89,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Committee": 4400.0,
+              "Individual": 39954.0,
+              "Unitemized": 1495.0,
+              "Other (includes Businesses)": 6350.0
+            },
+            "expenditures_by_type": {
+              "office expenses": 4936.55,
+              "fundraising events": 200.0,
+              "campaign paraphernalia/misc.": 1916.25,
+              "campaign literature and mailings": 4765.23,
+              "postage, delivery and messenger services": 1255.12,
+              "professional services (legal, accounting)": 1236.26,
+              "information technology costs (internet, e-mail)": 220.0
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 52199.0,
+          "total_contributions": 52199.0,
+          "total_expenditures": 16219.89,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Committee": 4400.0,
+            "Individual": 39954.0,
+            "Unitemized": 1495.0,
+            "Other (includes Businesses)": 6350.0
+          },
+          "expenditures_by_type": {
+            "office expenses": 4936.55,
+            "fundraising events": 200.0,
+            "campaign paraphernalia/misc.": 1916.25,
+            "campaign literature and mailings": 4765.23,
+            "postage, delivery and messenger services": 1255.12,
+            "professional services (legal, accounting)": 1236.26,
+            "information technology costs (internet, e-mail)": 220.0
+          }
         },
         {
           "id": 3,
@@ -175,7 +515,28 @@
           "first_name": "Bruce",
           "last_name": "Quan",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 4,
@@ -186,7 +547,28 @@
           "first_name": "Nancy",
           "last_name": "Sidebotham",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 5,
@@ -197,7 +579,28 @@
           "first_name": "Francis",
           "last_name": "Matt Hummell",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 6,
@@ -208,7 +611,28 @@
           "first_name": "Peggy",
           "last_name": "Moore",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 7,
@@ -219,7 +643,28 @@
           "first_name": "Patricia",
           "last_name": "Ellis",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 8,
@@ -230,7 +675,28 @@
           "first_name": "Larry",
           "last_name": "Young Jr.",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 9,
@@ -241,7 +707,28 @@
           "first_name": "Manuel",
           "last_name": "Cabello",
           "ballot_item": 5,
-          "office_election": 5
+          "office_election": 5,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -259,7 +746,28 @@
           "first_name": "James",
           "last_name": "Harris",
           "ballot_item": 6,
-          "office_election": 6
+          "office_election": 6,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 37,
@@ -270,7 +778,34 @@
           "first_name": "Chris",
           "last_name": "Jackson",
           "ballot_item": 6,
-          "office_election": 6
+          "office_election": 6,
+          "supporting_contribution_data": {
+            "contributions_received": 5822.0,
+            "total_contributions": 5822.0,
+            "total_expenditures": 12413.89,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Committee": 1200.0,
+              "Individual": 2950.0,
+              "Unitemized": 1672.0
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 5822.0,
+          "total_contributions": 5822.0,
+          "total_expenditures": 12413.89,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Committee": 1200.0,
+            "Individual": 2950.0,
+            "Unitemized": 1672.0
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -288,7 +823,28 @@
           "first_name": "Jumoke",
           "last_name": "Hinton Hodge",
           "ballot_item": 7,
-          "office_election": 7
+          "office_election": 7,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 29,
@@ -299,7 +855,28 @@
           "first_name": "Benjamin",
           "last_name": "Lang",
           "ballot_item": 7,
-          "office_election": 7
+          "office_election": 7,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 30,
@@ -310,7 +887,28 @@
           "first_name": "Kharyshi",
           "last_name": "Wiginton",
           "ballot_item": 7,
-          "office_election": 7
+          "office_election": 7,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 31,
@@ -321,7 +919,28 @@
           "first_name": "Lucky",
           "last_name": "Narain",
           "ballot_item": 7,
-          "office_election": 7
+          "office_election": 7,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -339,7 +958,28 @@
           "first_name": "Marcie",
           "last_name": "Hodge",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 21,
@@ -350,7 +990,28 @@
           "first_name": "Nehanda",
           "last_name": "Imara",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 22,
@@ -361,7 +1022,28 @@
           "first_name": "Larry",
           "last_name": "Reid",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 23,
@@ -372,7 +1054,28 @@
           "first_name": "Treva",
           "last_name": "Reid",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 24,
@@ -383,7 +1086,28 @@
           "first_name": "Maxine",
           "last_name": "Oliver-Benson",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 25,
@@ -394,7 +1118,28 @@
           "first_name": "Olivia",
           "last_name": "De Jimenez",
           "ballot_item": 8,
-          "office_election": 8
+          "office_election": 8,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -412,7 +1157,28 @@
           "first_name": "Michael",
           "last_name": "Hassid",
           "ballot_item": 9,
-          "office_election": 9
+          "office_election": 9,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 33,
@@ -423,7 +1189,28 @@
           "first_name": "Michael",
           "last_name": "Hutchinson",
           "ballot_item": 9,
-          "office_election": 9
+          "office_election": 9,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 34,
@@ -434,7 +1221,46 @@
           "first_name": "Roseann",
           "last_name": "Torres",
           "ballot_item": 9,
-          "office_election": 9
+          "office_election": 9,
+          "supporting_contribution_data": {
+            "contributions_received": 6895.0,
+            "total_contributions": 6895.0,
+            "total_expenditures": 6673.3,
+            "total_loans_received": 0.0,
+            "contributions_by_type": {
+              "Committee": 1700.0,
+              "Individual": 4150.0,
+              "Unitemized": 345.0,
+              "Other (includes Businesses)": 700.0
+            },
+            "expenditures_by_type": {
+              "office expenses": 107.05,
+              "fundraising events": 600.0,
+              "campaign consultants": 1130.0,
+              "professional services (legal, accounting)": 3626.34,
+              "information technology costs (internet, e-mail)": 400.0
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": 6895.0,
+          "total_contributions": 6895.0,
+          "total_expenditures": 6673.3,
+          "total_loans_received": 0.0,
+          "contributions_by_type": {
+            "Committee": 1700.0,
+            "Individual": 4150.0,
+            "Unitemized": 345.0,
+            "Other (includes Businesses)": 700.0
+          },
+          "expenditures_by_type": {
+            "office expenses": 107.05,
+            "fundraising events": 600.0,
+            "campaign consultants": 1130.0,
+            "professional services (legal, accounting)": 3626.34,
+            "information technology costs (internet, e-mail)": 400.0
+          }
         },
         {
           "id": 35,
@@ -445,7 +1271,28 @@
           "first_name": "Huber",
           "last_name": "Trenado",
           "ballot_item": 9,
-          "office_election": 9
+          "office_election": 9,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },
@@ -463,7 +1310,28 @@
           "first_name": "Noel",
           "last_name": "Gallo",
           "ballot_item": 10,
-          "office_election": 10
+          "office_election": 10,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         },
         {
           "id": 19,
@@ -474,7 +1342,28 @@
           "first_name": "Viola",
           "last_name": "Gonzales",
           "ballot_item": 10,
-          "office_election": 10
+          "office_election": 10,
+          "supporting_contribution_data": {
+            "contributions_received": null,
+            "total_contributions": null,
+            "total_expenditures": null,
+            "total_loans_received": null,
+            "contributions_by_type": {
+            },
+            "expenditures_by_type": {
+            }
+          },
+          "opposing_contribution_data": {
+            "contributions_received": 4567
+          },
+          "contributions_received": null,
+          "total_contributions": null,
+          "total_expenditures": null,
+          "total_loans_received": null,
+          "contributions_by_type": {
+          },
+          "expenditures_by_type": {
+          }
         }
       ]
     },

--- a/build/office_election/1/index.json
+++ b/build/office_election/1/index.json
@@ -13,7 +13,7 @@
       "last_name": "Macleay",
       "ballot_item": 1,
       "office_election": 1,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -23,7 +23,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -45,7 +45,7 @@
       "last_name": "London",
       "ballot_item": 1,
       "office_election": 1,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": 5975.0,
         "total_contributions": 5975.0,
         "total_expenditures": 4826.78,
@@ -64,7 +64,7 @@
           "campaign literature and mailings": 850.0
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": 5975.0,

--- a/build/office_election/1/index.json
+++ b/build/office_election/1/index.json
@@ -12,7 +12,28 @@
       "first_name": "Donald",
       "last_name": "Macleay",
       "ballot_item": 1,
-      "office_election": 1
+      "office_election": 1,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 27,
@@ -23,7 +44,46 @@
       "first_name": "Jody",
       "last_name": "London",
       "ballot_item": 1,
-      "office_election": 1
+      "office_election": 1,
+      "supporting_contribution_data": {
+        "contributions_received": 5975.0,
+        "total_contributions": 5975.0,
+        "total_expenditures": 4826.78,
+        "total_loans_received": 0.0,
+        "contributions_by_type": {
+          "Individual": 4000.0,
+          "Unitemized": 575.0,
+          "Other (includes Businesses)": 1400.0
+        },
+        "expenditures_by_type": {
+          "office expenses": 166.47,
+          "fundraising events": 475.05,
+          "campaign consultants": 1000.0,
+          "meetings and appearances": 437.32,
+          "campaign paraphernalia/misc.": 1397.94,
+          "campaign literature and mailings": 850.0
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": 5975.0,
+      "total_contributions": 5975.0,
+      "total_expenditures": 4826.78,
+      "total_loans_received": 0.0,
+      "contributions_by_type": {
+        "Individual": 4000.0,
+        "Unitemized": 575.0,
+        "Other (includes Businesses)": 1400.0
+      },
+      "expenditures_by_type": {
+        "office expenses": 166.47,
+        "fundraising events": 475.05,
+        "campaign consultants": 1000.0,
+        "meetings and appearances": 437.32,
+        "campaign paraphernalia/misc.": 1397.94,
+        "campaign literature and mailings": 850.0
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/10/index.json
+++ b/build/office_election/10/index.json
@@ -13,7 +13,7 @@
       "last_name": "Gallo",
       "ballot_item": 10,
       "office_election": 10,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -23,7 +23,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -45,7 +45,7 @@
       "last_name": "Gonzales",
       "ballot_item": 10,
       "office_election": 10,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -55,7 +55,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,

--- a/build/office_election/10/index.json
+++ b/build/office_election/10/index.json
@@ -12,7 +12,28 @@
       "first_name": "Noel",
       "last_name": "Gallo",
       "ballot_item": 10,
-      "office_election": 10
+      "office_election": 10,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 19,
@@ -23,7 +44,28 @@
       "first_name": "Viola",
       "last_name": "Gonzales",
       "ballot_item": 10,
-      "office_election": 10
+      "office_election": 10,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/2/index.json
+++ b/build/office_election/2/index.json
@@ -12,7 +12,36 @@
       "first_name": "Barbara",
       "last_name": "Parker",
       "ballot_item": 2,
-      "office_election": 2
+      "office_election": 2,
+      "supporting_contribution_data": {
+        "contributions_received": 60871.0,
+        "total_contributions": 60871.0,
+        "total_expenditures": 7510.5,
+        "total_loans_received": 0.0,
+        "contributions_by_type": {
+          "Individual": 55100.0,
+          "Unitemized": 355.0,
+          "Other (includes Businesses)": 5416.0
+        },
+        "expenditures_by_type": {
+          "campaign consultants": 7500.0
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": 60871.0,
+      "total_contributions": 60871.0,
+      "total_expenditures": 7510.5,
+      "total_loans_received": 0.0,
+      "contributions_by_type": {
+        "Individual": 55100.0,
+        "Unitemized": 355.0,
+        "Other (includes Businesses)": 5416.0
+      },
+      "expenditures_by_type": {
+        "campaign consultants": 7500.0
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/2/index.json
+++ b/build/office_election/2/index.json
@@ -13,7 +13,7 @@
       "last_name": "Parker",
       "ballot_item": 2,
       "office_election": 2,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": 60871.0,
         "total_contributions": 60871.0,
         "total_expenditures": 7510.5,
@@ -27,7 +27,7 @@
           "campaign consultants": 7500.0
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": 60871.0,

--- a/build/office_election/3/index.json
+++ b/build/office_election/3/index.json
@@ -13,7 +13,7 @@
       "last_name": "Corbett",
       "ballot_item": 3,
       "office_election": 3,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": 19375.0,
         "total_contributions": 19375.0,
         "total_expenditures": 8479.42,
@@ -26,7 +26,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": 19375.0,
@@ -51,7 +51,7 @@
       "last_name": "Kalb",
       "ballot_item": 3,
       "office_election": 3,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": 39058.66,
         "total_contributions": 39058.66,
         "total_expenditures": 6118.11,
@@ -68,7 +68,7 @@
           "information technology costs (internet, e-mail)": 404.03
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": 39058.66,

--- a/build/office_election/3/index.json
+++ b/build/office_election/3/index.json
@@ -12,7 +12,34 @@
       "first_name": "Kevin",
       "last_name": "Corbett",
       "ballot_item": 3,
-      "office_election": 3
+      "office_election": 3,
+      "supporting_contribution_data": {
+        "contributions_received": 19375.0,
+        "total_contributions": 19375.0,
+        "total_expenditures": 8479.42,
+        "total_loans_received": 0.0,
+        "contributions_by_type": {
+          "Individual": 16250.0,
+          "Unitemized": 675.0,
+          "Other (includes Businesses)": 2450.0
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": 19375.0,
+      "total_contributions": 19375.0,
+      "total_expenditures": 8479.42,
+      "total_loans_received": 0.0,
+      "contributions_by_type": {
+        "Individual": 16250.0,
+        "Unitemized": 675.0,
+        "Other (includes Businesses)": 2450.0
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 11,
@@ -23,7 +50,42 @@
       "first_name": "Dan",
       "last_name": "Kalb",
       "ballot_item": 3,
-      "office_election": 3
+      "office_election": 3,
+      "supporting_contribution_data": {
+        "contributions_received": 39058.66,
+        "total_contributions": 39058.66,
+        "total_expenditures": 6118.11,
+        "total_loans_received": 9000.0,
+        "contributions_by_type": {
+          "Committee": 2400.0,
+          "Individual": 22487.0,
+          "Unitemized": 3521.66,
+          "Other (includes Businesses)": 1650.0
+        },
+        "expenditures_by_type": {
+          "fundraising events": 4749.38,
+          "campaign literature and mailings": 894.7,
+          "information technology costs (internet, e-mail)": 404.03
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": 39058.66,
+      "total_contributions": 39058.66,
+      "total_expenditures": 6118.11,
+      "total_loans_received": 9000.0,
+      "contributions_by_type": {
+        "Committee": 2400.0,
+        "Individual": 22487.0,
+        "Unitemized": 3521.66,
+        "Other (includes Businesses)": 1650.0
+      },
+      "expenditures_by_type": {
+        "fundraising events": 4749.38,
+        "campaign literature and mailings": 894.7,
+        "information technology costs (internet, e-mail)": 404.03
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/4/index.json
+++ b/build/office_election/4/index.json
@@ -13,7 +13,7 @@
       "last_name": "Brown",
       "ballot_item": 4,
       "office_election": 4,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -23,7 +23,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -45,7 +45,7 @@
       "last_name": "Gibson McElhaney",
       "ballot_item": 4,
       "office_election": 4,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": 41597.08,
         "total_contributions": 41597.08,
         "total_expenditures": 9736.75,
@@ -65,7 +65,7 @@
           "information technology costs (internet, e-mail)": 942.85
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": 41597.08,
@@ -97,7 +97,7 @@
       "last_name": "Session",
       "ballot_item": 4,
       "office_election": 4,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -107,7 +107,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -129,7 +129,7 @@
       "last_name": "Karamooz",
       "ballot_item": 4,
       "office_election": 4,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -139,7 +139,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -161,7 +161,7 @@
       "last_name": "McNeal",
       "ballot_item": 4,
       "office_election": 4,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -171,7 +171,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -193,7 +193,7 @@
       "last_name": "Jordan",
       "ballot_item": 4,
       "office_election": 4,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -203,7 +203,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,

--- a/build/office_election/4/index.json
+++ b/build/office_election/4/index.json
@@ -12,7 +12,28 @@
       "first_name": "Alan",
       "last_name": "Brown",
       "ballot_item": 4,
-      "office_election": 4
+      "office_election": 4,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 13,
@@ -23,7 +44,48 @@
       "first_name": "Lynette",
       "last_name": "Gibson McElhaney",
       "ballot_item": 4,
-      "office_election": 4
+      "office_election": 4,
+      "supporting_contribution_data": {
+        "contributions_received": 41597.08,
+        "total_contributions": 41597.08,
+        "total_expenditures": 9736.75,
+        "total_loans_received": 0.0,
+        "contributions_by_type": {
+          "Committee": 3250.0,
+          "Individual": 29188.16,
+          "Unitemized": 808.92,
+          "Other (includes Businesses)": 8350.0
+        },
+        "expenditures_by_type": {
+          "civic donations": 450.0,
+          "office expenses": 2340.51,
+          "fundraising events": 718.87,
+          "meetings and appearances": 184.17,
+          "professional services (legal, accounting)": 4318.35,
+          "information technology costs (internet, e-mail)": 942.85
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": 41597.08,
+      "total_contributions": 41597.08,
+      "total_expenditures": 9736.75,
+      "total_loans_received": 0.0,
+      "contributions_by_type": {
+        "Committee": 3250.0,
+        "Individual": 29188.16,
+        "Unitemized": 808.92,
+        "Other (includes Businesses)": 8350.0
+      },
+      "expenditures_by_type": {
+        "civic donations": 450.0,
+        "office expenses": 2340.51,
+        "fundraising events": 718.87,
+        "meetings and appearances": 184.17,
+        "professional services (legal, accounting)": 4318.35,
+        "information technology costs (internet, e-mail)": 942.85
+      }
     },
     {
       "id": 14,
@@ -34,7 +96,28 @@
       "first_name": "Noni",
       "last_name": "Session",
       "ballot_item": 4,
-      "office_election": 4
+      "office_election": 4,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 15,
@@ -45,7 +128,28 @@
       "first_name": "Saied",
       "last_name": "Karamooz",
       "ballot_item": 4,
-      "office_election": 4
+      "office_election": 4,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 16,
@@ -56,7 +160,28 @@
       "first_name": "Anthony",
       "last_name": "McNeal",
       "ballot_item": 4,
-      "office_election": 4
+      "office_election": 4,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 17,
@@ -67,7 +192,28 @@
       "first_name": "Tyron",
       "last_name": "Jordan",
       "ballot_item": 4,
-      "office_election": 4
+      "office_election": 4,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/5/index.json
+++ b/build/office_election/5/index.json
@@ -13,7 +13,7 @@
       "last_name": "Kaplan",
       "ballot_item": 5,
       "office_election": 5,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": 52199.0,
         "total_contributions": 52199.0,
         "total_expenditures": 16219.89,
@@ -34,7 +34,7 @@
           "information technology costs (internet, e-mail)": 220.0
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": 52199.0,
@@ -67,7 +67,7 @@
       "last_name": "Quan",
       "ballot_item": 5,
       "office_election": 5,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -77,7 +77,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -99,7 +99,7 @@
       "last_name": "Sidebotham",
       "ballot_item": 5,
       "office_election": 5,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -109,7 +109,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -131,7 +131,7 @@
       "last_name": "Matt Hummell",
       "ballot_item": 5,
       "office_election": 5,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -141,7 +141,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -163,7 +163,7 @@
       "last_name": "Moore",
       "ballot_item": 5,
       "office_election": 5,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -173,7 +173,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -195,7 +195,7 @@
       "last_name": "Ellis",
       "ballot_item": 5,
       "office_election": 5,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -205,7 +205,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -227,7 +227,7 @@
       "last_name": "Young Jr.",
       "ballot_item": 5,
       "office_election": 5,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -237,7 +237,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -259,7 +259,7 @@
       "last_name": "Cabello",
       "ballot_item": 5,
       "office_election": 5,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -269,7 +269,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,

--- a/build/office_election/5/index.json
+++ b/build/office_election/5/index.json
@@ -12,7 +12,50 @@
       "first_name": "Rebecca",
       "last_name": "Kaplan",
       "ballot_item": 5,
-      "office_election": 5
+      "office_election": 5,
+      "supporting_contribution_data": {
+        "contributions_received": 52199.0,
+        "total_contributions": 52199.0,
+        "total_expenditures": 16219.89,
+        "total_loans_received": 0.0,
+        "contributions_by_type": {
+          "Committee": 4400.0,
+          "Individual": 39954.0,
+          "Unitemized": 1495.0,
+          "Other (includes Businesses)": 6350.0
+        },
+        "expenditures_by_type": {
+          "office expenses": 4936.55,
+          "fundraising events": 200.0,
+          "campaign paraphernalia/misc.": 1916.25,
+          "campaign literature and mailings": 4765.23,
+          "postage, delivery and messenger services": 1255.12,
+          "professional services (legal, accounting)": 1236.26,
+          "information technology costs (internet, e-mail)": 220.0
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": 52199.0,
+      "total_contributions": 52199.0,
+      "total_expenditures": 16219.89,
+      "total_loans_received": 0.0,
+      "contributions_by_type": {
+        "Committee": 4400.0,
+        "Individual": 39954.0,
+        "Unitemized": 1495.0,
+        "Other (includes Businesses)": 6350.0
+      },
+      "expenditures_by_type": {
+        "office expenses": 4936.55,
+        "fundraising events": 200.0,
+        "campaign paraphernalia/misc.": 1916.25,
+        "campaign literature and mailings": 4765.23,
+        "postage, delivery and messenger services": 1255.12,
+        "professional services (legal, accounting)": 1236.26,
+        "information technology costs (internet, e-mail)": 220.0
+      }
     },
     {
       "id": 3,
@@ -23,7 +66,28 @@
       "first_name": "Bruce",
       "last_name": "Quan",
       "ballot_item": 5,
-      "office_election": 5
+      "office_election": 5,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 4,
@@ -34,7 +98,28 @@
       "first_name": "Nancy",
       "last_name": "Sidebotham",
       "ballot_item": 5,
-      "office_election": 5
+      "office_election": 5,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 5,
@@ -45,7 +130,28 @@
       "first_name": "Francis",
       "last_name": "Matt Hummell",
       "ballot_item": 5,
-      "office_election": 5
+      "office_election": 5,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 6,
@@ -56,7 +162,28 @@
       "first_name": "Peggy",
       "last_name": "Moore",
       "ballot_item": 5,
-      "office_election": 5
+      "office_election": 5,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 7,
@@ -67,7 +194,28 @@
       "first_name": "Patricia",
       "last_name": "Ellis",
       "ballot_item": 5,
-      "office_election": 5
+      "office_election": 5,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 8,
@@ -78,7 +226,28 @@
       "first_name": "Larry",
       "last_name": "Young Jr.",
       "ballot_item": 5,
-      "office_election": 5
+      "office_election": 5,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 9,
@@ -89,7 +258,28 @@
       "first_name": "Manuel",
       "last_name": "Cabello",
       "ballot_item": 5,
-      "office_election": 5
+      "office_election": 5,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/6/index.json
+++ b/build/office_election/6/index.json
@@ -12,7 +12,28 @@
       "first_name": "James",
       "last_name": "Harris",
       "ballot_item": 6,
-      "office_election": 6
+      "office_election": 6,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 37,
@@ -23,7 +44,34 @@
       "first_name": "Chris",
       "last_name": "Jackson",
       "ballot_item": 6,
-      "office_election": 6
+      "office_election": 6,
+      "supporting_contribution_data": {
+        "contributions_received": 5822.0,
+        "total_contributions": 5822.0,
+        "total_expenditures": 12413.89,
+        "total_loans_received": 0.0,
+        "contributions_by_type": {
+          "Committee": 1200.0,
+          "Individual": 2950.0,
+          "Unitemized": 1672.0
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": 5822.0,
+      "total_contributions": 5822.0,
+      "total_expenditures": 12413.89,
+      "total_loans_received": 0.0,
+      "contributions_by_type": {
+        "Committee": 1200.0,
+        "Individual": 2950.0,
+        "Unitemized": 1672.0
+      },
+      "expenditures_by_type": {
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/6/index.json
+++ b/build/office_election/6/index.json
@@ -13,7 +13,7 @@
       "last_name": "Harris",
       "ballot_item": 6,
       "office_election": 6,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -23,7 +23,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -45,7 +45,7 @@
       "last_name": "Jackson",
       "ballot_item": 6,
       "office_election": 6,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": 5822.0,
         "total_contributions": 5822.0,
         "total_expenditures": 12413.89,
@@ -58,7 +58,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": 5822.0,

--- a/build/office_election/7/index.json
+++ b/build/office_election/7/index.json
@@ -12,7 +12,28 @@
       "first_name": "Jumoke",
       "last_name": "Hinton Hodge",
       "ballot_item": 7,
-      "office_election": 7
+      "office_election": 7,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 29,
@@ -23,7 +44,28 @@
       "first_name": "Benjamin",
       "last_name": "Lang",
       "ballot_item": 7,
-      "office_election": 7
+      "office_election": 7,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 30,
@@ -34,7 +76,28 @@
       "first_name": "Kharyshi",
       "last_name": "Wiginton",
       "ballot_item": 7,
-      "office_election": 7
+      "office_election": 7,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 31,
@@ -45,7 +108,28 @@
       "first_name": "Lucky",
       "last_name": "Narain",
       "ballot_item": 7,
-      "office_election": 7
+      "office_election": 7,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/7/index.json
+++ b/build/office_election/7/index.json
@@ -13,7 +13,7 @@
       "last_name": "Hinton Hodge",
       "ballot_item": 7,
       "office_election": 7,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -23,7 +23,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -45,7 +45,7 @@
       "last_name": "Lang",
       "ballot_item": 7,
       "office_election": 7,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -55,7 +55,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -77,7 +77,7 @@
       "last_name": "Wiginton",
       "ballot_item": 7,
       "office_election": 7,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -87,7 +87,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -109,7 +109,7 @@
       "last_name": "Narain",
       "ballot_item": 7,
       "office_election": 7,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -119,7 +119,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,

--- a/build/office_election/8/index.json
+++ b/build/office_election/8/index.json
@@ -12,7 +12,28 @@
       "first_name": "Marcie",
       "last_name": "Hodge",
       "ballot_item": 8,
-      "office_election": 8
+      "office_election": 8,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 21,
@@ -23,7 +44,28 @@
       "first_name": "Nehanda",
       "last_name": "Imara",
       "ballot_item": 8,
-      "office_election": 8
+      "office_election": 8,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 22,
@@ -34,7 +76,28 @@
       "first_name": "Larry",
       "last_name": "Reid",
       "ballot_item": 8,
-      "office_election": 8
+      "office_election": 8,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 23,
@@ -45,7 +108,28 @@
       "first_name": "Treva",
       "last_name": "Reid",
       "ballot_item": 8,
-      "office_election": 8
+      "office_election": 8,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 24,
@@ -56,7 +140,28 @@
       "first_name": "Maxine",
       "last_name": "Oliver-Benson",
       "ballot_item": 8,
-      "office_election": 8
+      "office_election": 8,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 25,
@@ -67,7 +172,28 @@
       "first_name": "Olivia",
       "last_name": "De Jimenez",
       "ballot_item": 8,
-      "office_election": 8
+      "office_election": 8,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/8/index.json
+++ b/build/office_election/8/index.json
@@ -13,7 +13,7 @@
       "last_name": "Hodge",
       "ballot_item": 8,
       "office_election": 8,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -23,7 +23,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -45,7 +45,7 @@
       "last_name": "Imara",
       "ballot_item": 8,
       "office_election": 8,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -55,7 +55,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -77,7 +77,7 @@
       "last_name": "Reid",
       "ballot_item": 8,
       "office_election": 8,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -87,7 +87,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -109,7 +109,7 @@
       "last_name": "Reid",
       "ballot_item": 8,
       "office_election": 8,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -119,7 +119,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -141,7 +141,7 @@
       "last_name": "Oliver-Benson",
       "ballot_item": 8,
       "office_election": 8,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -151,7 +151,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -173,7 +173,7 @@
       "last_name": "De Jimenez",
       "ballot_item": 8,
       "office_election": 8,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -183,7 +183,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,

--- a/build/office_election/9/index.json
+++ b/build/office_election/9/index.json
@@ -12,7 +12,28 @@
       "first_name": "Michael",
       "last_name": "Hassid",
       "ballot_item": 9,
-      "office_election": 9
+      "office_election": 9,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 33,
@@ -23,7 +44,28 @@
       "first_name": "Michael",
       "last_name": "Hutchinson",
       "ballot_item": 9,
-      "office_election": 9
+      "office_election": 9,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     },
     {
       "id": 34,
@@ -34,7 +76,46 @@
       "first_name": "Roseann",
       "last_name": "Torres",
       "ballot_item": 9,
-      "office_election": 9
+      "office_election": 9,
+      "supporting_contribution_data": {
+        "contributions_received": 6895.0,
+        "total_contributions": 6895.0,
+        "total_expenditures": 6673.3,
+        "total_loans_received": 0.0,
+        "contributions_by_type": {
+          "Committee": 1700.0,
+          "Individual": 4150.0,
+          "Unitemized": 345.0,
+          "Other (includes Businesses)": 700.0
+        },
+        "expenditures_by_type": {
+          "office expenses": 107.05,
+          "fundraising events": 600.0,
+          "campaign consultants": 1130.0,
+          "professional services (legal, accounting)": 3626.34,
+          "information technology costs (internet, e-mail)": 400.0
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": 6895.0,
+      "total_contributions": 6895.0,
+      "total_expenditures": 6673.3,
+      "total_loans_received": 0.0,
+      "contributions_by_type": {
+        "Committee": 1700.0,
+        "Individual": 4150.0,
+        "Unitemized": 345.0,
+        "Other (includes Businesses)": 700.0
+      },
+      "expenditures_by_type": {
+        "office expenses": 107.05,
+        "fundraising events": 600.0,
+        "campaign consultants": 1130.0,
+        "professional services (legal, accounting)": 3626.34,
+        "information technology costs (internet, e-mail)": 400.0
+      }
     },
     {
       "id": 35,
@@ -45,7 +126,28 @@
       "first_name": "Huber",
       "last_name": "Trenado",
       "ballot_item": 9,
-      "office_election": 9
+      "office_election": 9,
+      "supporting_contribution_data": {
+        "contributions_received": null,
+        "total_contributions": null,
+        "total_expenditures": null,
+        "total_loans_received": null,
+        "contributions_by_type": {
+        },
+        "expenditures_by_type": {
+        }
+      },
+      "opposing_contribution_data": {
+        "contributions_received": 4567
+      },
+      "contributions_received": null,
+      "total_contributions": null,
+      "total_expenditures": null,
+      "total_loans_received": null,
+      "contributions_by_type": {
+      },
+      "expenditures_by_type": {
+      }
     }
   ],
   "ballot_id": 1

--- a/build/office_election/9/index.json
+++ b/build/office_election/9/index.json
@@ -13,7 +13,7 @@
       "last_name": "Hassid",
       "ballot_item": 9,
       "office_election": 9,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -23,7 +23,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -45,7 +45,7 @@
       "last_name": "Hutchinson",
       "ballot_item": 9,
       "office_election": 9,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -55,7 +55,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,
@@ -77,7 +77,7 @@
       "last_name": "Torres",
       "ballot_item": 9,
       "office_election": 9,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": 6895.0,
         "total_contributions": 6895.0,
         "total_expenditures": 6673.3,
@@ -96,7 +96,7 @@
           "information technology costs (internet, e-mail)": 400.0
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": 6895.0,
@@ -127,7 +127,7 @@
       "last_name": "Trenado",
       "ballot_item": 9,
       "office_election": 9,
-      "supporting_contribution_data": {
+      "supporting_money": {
         "contributions_received": null,
         "total_contributions": null,
         "total_expenditures": null,
@@ -137,7 +137,7 @@
         "expenditures_by_type": {
         }
       },
-      "opposing_contribution_data": {
+      "opposing_money": {
         "contributions_received": 4567
       },
       "contributions_received": null,

--- a/models/oakland_candidate.rb
+++ b/models/oakland_candidate.rb
@@ -32,7 +32,7 @@ class OaklandCandidate < ActiveRecord::Base
       office_election: office_election.id,
 
       # contribution data
-      supporting_contribution_data: {
+      supporting_money: {
         contributions_received: calculation(:total_contributions).try(:to_f),
         total_contributions: calculation(:total_contributions).try(:to_f),
         total_expenditures: calculation(:total_expenditures).try(:to_f),
@@ -40,7 +40,7 @@ class OaklandCandidate < ActiveRecord::Base
         contributions_by_type: calculation(:contributions_by_type) || {},
         expenditures_by_type: calculation(:expenditures_by_type) || {},
       },
-      opposing_contribution_data: {
+      opposing_money: {
         contributions_received: 4567,
       },
 

--- a/models/oakland_candidate.rb
+++ b/models/oakland_candidate.rb
@@ -30,6 +30,29 @@ class OaklandCandidate < ActiveRecord::Base
       last_name: last_name,
       ballot_item: office_election.id,
       office_election: office_election.id,
+
+      # contribution data
+      supporting_contribution_data: {
+        contributions_received: calculation(:total_contributions).try(:to_f),
+        total_contributions: calculation(:total_contributions).try(:to_f),
+        total_expenditures: calculation(:total_expenditures).try(:to_f),
+        total_loans_received: calculation(:total_loans_received).try(:to_f),
+        contributions_by_type: calculation(:contributions_by_type) || {},
+        expenditures_by_type: calculation(:expenditures_by_type) || {},
+      },
+      opposing_contribution_data: {
+        contributions_received: 4567,
+      },
+
+      # for backwards compatibility, these should also be exposed at the
+      # top-level:
+      # TODO: remove once the frontend no longer uses this
+      contributions_received: calculation(:total_contributions).try(:to_f),
+      total_contributions: calculation(:total_contributions).try(:to_f),
+      total_expenditures: calculation(:total_expenditures).try(:to_f),
+      total_loans_received: calculation(:total_loans_received).try(:to_f),
+      contributions_by_type: calculation(:contributions_by_type) || {},
+      expenditures_by_type: calculation(:expenditures_by_type) || {},
     }
   end
 end

--- a/process.rb
+++ b/process.rb
@@ -81,25 +81,18 @@ OfficeElection.find_each do |office_election|
 end
 
 OaklandCandidate.includes(:office_election, :calculations).find_each do |candidate|
-  build_file("/candidate/#{candidate.id}") do |f|
-    f.puts candidate.to_json
-  end
-
-  build_file("/candidate/#{candidate.id}/supporting") do |f|
-    f.puts JSON.pretty_generate(candidate.as_json.merge(
-      contributions_received: candidate.calculation(:total_contributions).try(:to_f),
-      total_contributions: candidate.calculation(:total_contributions).try(:to_f),
-      total_expenditures: candidate.calculation(:total_expenditures).try(:to_f),
-      total_loans_received: candidate.calculation(:total_loans_received).try(:to_f),
-      contributions_by_type: candidate.calculation(:contributions_by_type) || {},
-      expenditures_by_type: candidate.calculation(:expenditures_by_type) || {},
-    ))
-  end
-
-  build_file("/candidate/#{candidate.id}/opposing") do |f|
-    f.puts JSON.pretty_generate(candidate.as_json.merge(
-      contributions_received: 4567,
-    ))
+  %W[
+    /candidate/#{candidate.id}
+    /candidate/#{candidate.id}/supporting
+    /candidate/#{candidate.id}/opposing
+  ].each do |candidate_filename|
+    build_file(candidate_filename) do |f|
+      #
+      # To add a field to one of these endpoints, add it to the '#as_json'
+      # method in models/oakland_candidate.rb
+      #
+      f.puts candidate.to_json
+    end
   end
 end
 


### PR DESCRIPTION
Always serialize OaklandCandidate with contribution calculations

By adding a `supporting_contribution_data` and
`opposing_contribution_data` to the candidate object's serialization, we
will make sure that we have top-line contribution numbers for any screen
we could need it. Plus it's not good API design to return two different
versions of the same object depending on the endpoint requested.

Fixes #17

cc @adborden @jnmarcus @kylew because of the backwards incompatibility