### PR TITLE
Filter all queries to the highest Report_Num value

### DIFF
--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -10,7 +10,7 @@
       "id": 5,
       "name": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
       "payee": "Committee to Protect Oakland Renters sponsored by labor and community organizations",
-      "amount": 190026.16
+      "amount": 95013.08
     }
   ],
   "total_contributions": 456,

--- a/build/referendum/4/supporting/index.json
+++ b/build/referendum/4/supporting/index.json
@@ -10,7 +10,7 @@
       "id": 2,
       "name": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "payee": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
-      "amount": 53630.57
+      "amount": 33930.57
     }
   ],
   "total_contributions": 456,

--- a/calculators/candidate_contributions_by_type.rb
+++ b/calculators/candidate_contributions_by_type.rb
@@ -46,17 +46,21 @@ class CandidateContributionsByType
   def contributions_by_candidate_by_type
     @_contributions_by_candidate_by_type ||= {}.tap do |hash|
       monetary_results = ActiveRecord::Base.connection.execute <<-SQL
-        SELECT "Filer_ID", "Entity_Cd", SUM("Tran_Amt1") AS "Total"
+        SELECT DISTINCT ON ("Entity_Cd", "Filer_ID")
+          "Filer_ID", "Entity_Cd", SUM("Tran_Amt1") AS "Total"
         FROM "efile_COAK_2016_A-Contributions"
         WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "','"}')
-        GROUP BY "Entity_Cd", "Filer_ID";
+        GROUP BY "Entity_Cd", "Filer_ID", "Report_Num"
+        ORDER BY "Entity_Cd", "Filer_ID", "Report_Num" DESC
       SQL
 
       in_kind_results = ActiveRecord::Base.connection.execute <<-SQL
-        SELECT "Filer_ID", "Entity_Cd", SUM("Tran_Amt1") AS "Total"
+        SELECT DISTINCT ON ("Entity_Cd", "Filer_ID")
+          "Filer_ID", "Entity_Cd", SUM("Tran_Amt1") AS "Total"
         FROM "efile_COAK_2016_C-Contributions"
         WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "','"}')
-        GROUP BY "Entity_Cd", "Filer_ID";
+        GROUP BY "Entity_Cd", "Filer_ID", "Report_Num"
+        ORDER BY "Entity_Cd", "Filer_ID", "Report_Num" DESC
       SQL
 
       (monetary_results.to_a + in_kind_results.to_a).each do |result|
@@ -72,9 +76,12 @@ class CandidateContributionsByType
   def unitemized_contributions_by_candidate
     @_unitemized_contributions_by_candidate ||= {}.tap do |hash|
       results = ActiveRecord::Base.connection.execute <<-SQL
-        SELECT "Filer_ID", "Amount_A" FROM "efile_COAK_2016_Summary"
+        SELECT DISTINCT ON ("Filer_ID", "Amount_A")
+          "Filer_ID", "Amount_A" FROM "efile_COAK_2016_Summary"
         WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "','"}')
           AND "Form_Type" = 'A' AND "Line_Item" = '2'
+        GROUP BY "Filer_ID", "Amount_A", "Report_Num"
+        ORDER BY "Filer_ID", "Amount_A", "Report_Num" DESC
       SQL
 
       hash.merge!(Hash[results.map { |row| row.values_at('Filer_ID', 'Amount_A') }])

--- a/calculators/candidate_expenditures_by_type.rb
+++ b/calculators/candidate_expenditures_by_type.rb
@@ -57,10 +57,12 @@ class CandidateExpendituresByType
   def expenditures_by_candidate_by_type
     @_expenditures_by_candidate_by_type ||= {}.tap do |hash|
       results = ActiveRecord::Base.connection.execute <<-SQL
-        SELECT "Filer_ID", "Expn_Code", SUM("Amount") AS "Total"
+        SELECT DISTINCT ON ("Expn_Code", "Filer_ID")
+          "Filer_ID", "Expn_Code", SUM("Amount") AS "Total"
         FROM "efile_COAK_2016_E-Expenditure"
         WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "','"}')
-        GROUP BY "Expn_Code", "Filer_ID";
+        GROUP BY "Expn_Code", "Filer_ID", "Report_Num"
+        ORDER BY "Expn_Code", "Filer_ID", "Report_Num" DESC
       SQL
 
       results.each do |result|

--- a/calculators/referendum_supporters_calculator.rb
+++ b/calculators/referendum_supporters_calculator.rb
@@ -7,11 +7,13 @@ class ReferendumSupportersCalculator
 
   def fetch
     expenditures = ActiveRecord::Base.connection.execute(<<-SQL)
-      SELECT "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd",
-             SUM("Amount") AS "Total_Amount"
-        FROM "efile_COAK_2016_E-Expenditure"
-       WHERE "Bal_Name" IS NOT NULL
-       GROUP BY "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd";
+      SELECT DISTINCT ON ("Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd")
+        "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd",
+        SUM("Amount") AS "Total_Amount"
+      FROM "efile_COAK_2016_E-Expenditure"
+      WHERE "Bal_Name" IS NOT NULL
+      GROUP BY "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd", "Report_Num"
+      ORDER BY "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd", "Report_Num" DESC
     SQL
 
     supporting_by_measure_name = {}

--- a/calculators/total_contributions_calculator.rb
+++ b/calculators/total_contributions_calculator.rb
@@ -8,10 +8,14 @@ class TotalContributionsCalculator
 
   def fetch
     @results = ActiveRecord::Base.connection.execute <<-SQL
-      SELECT "Filer_ID", "Amount_A" FROM "efile_COAK_2016_Summary"
-        WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "', '"}')
-          AND "Form_Type" = 'F460'
-          AND "Line_Item" = '5'
+      SELECT DISTINCT ON ("Filer_ID", "Amount_A")
+        "Filer_ID", "Amount_A"
+      FROM "efile_COAK_2016_Summary"
+      WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "', '"}')
+      AND "Form_Type" = 'F460'
+      AND "Line_Item" = '5'
+      GROUP BY "Filer_ID", "Amount_A", "Report_Num"
+      ORDER BY "Filer_ID", "Amount_A", "Report_Num" DESC
     SQL
 
     @results.each do |result|

--- a/calculators/total_expenditures_calculator.rb
+++ b/calculators/total_expenditures_calculator.rb
@@ -6,10 +6,14 @@ class TotalExpendituresCalculator
 
   def fetch
     @results = ActiveRecord::Base.connection.execute <<-SQL
-      SELECT "Filer_ID", "Amount_A" FROM "efile_COAK_2016_Summary"
-       WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "', '"}')
-         AND "Form_Type" = 'F460'
-         AND "Line_Item" = '11'
+      SELECT DISTINCT ON ("Filer_ID", "Amount_A")
+        "Filer_ID", "Amount_A"
+      FROM "efile_COAK_2016_Summary"
+      WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "', '"}')
+      AND "Form_Type" = 'F460'
+      AND "Line_Item" = '11'
+      GROUP BY "Filer_ID", "Amount_A", "Report_Num"
+      ORDER BY "Filer_ID", "Amount_A", "Report_Num" DESC
     SQL
 
     @results.each do |result|

--- a/calculators/total_loans_received_calculator.rb
+++ b/calculators/total_loans_received_calculator.rb
@@ -6,10 +6,14 @@ class TotalLoansReceivedCalculator
 
   def fetch
     @results = ActiveRecord::Base.connection.execute(<<-SQL)
-      SELECT "Filer_ID", "Amount_A" FROM "efile_COAK_2016_Summary"
-        WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "', '"}')
-          AND "Form_Type" = 'F460'
-          AND "Line_Item" = '2'
+      SELECT DISTINCT ON ("Filer_ID", "Amount_A")
+        "Filer_ID", "Amount_A"
+      FROM "efile_COAK_2016_Summary"
+      WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "', '"}')
+      AND "Form_Type" = 'F460'
+      AND "Line_Item" = '2'
+      GROUP BY "Filer_ID", "Amount_A", "Report_Num"
+      ORDER BY "Filer_ID", "Amount_A", "Report_Num" DESC
     SQL
 
     @results.each do |row|


### PR DESCRIPTION
This [Fixes #21] by using a postgres-specific "DISTINCT ON" clause to
return only the first distinct row for a set of columns matching the
previous GROUP BY column set. The new GROUP BY includes "Report_Num"
column. To ensure deterministic behavior, we also must add an ORDER BY
clause like:

  ORDER BY [...distinct on columns...], "Report_Num" DESC

See http://stackoverflow.com/a/13327987/910723 for more details.

I manually audited the two affected organizations -- Just Cause and the
Committee to Protect Oakland Renters -- to verify that the new totals
match the most recent report figures only.