### PR TITLE
Process Form 497 Page 2 (Late Expenditures)

### DIFF
--- a/build/referendum/4/supporting/index.json
+++ b/build/referendum/4/supporting/index.json
@@ -10,7 +10,7 @@
       "id": 2,
       "name": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "payee": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
-      "amount": 33930.57
+      "amount": 94470.86
     }
   ],
   "total_contributions": 456,

--- a/calculators/referendum_supporters_calculator.rb
+++ b/calculators/referendum_supporters_calculator.rb
@@ -16,6 +16,16 @@ class ReferendumSupportersCalculator
       ORDER BY "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd", "Report_Num" DESC
     SQL
 
+    late_expenditures = ActiveRecord::Base.connection.execute(<<-SQL)
+      SELECT DISTINCT ON ("Filer_ID", "Filer_NamL", "Bal_Name")
+        "Filer_ID", "Filer_NamL", "Bal_Name", SUM("Amount") AS "Total_Amount"
+      FROM "efile_COAK_2016_497"
+      WHERE "Bal_Name" IS NOT NULL
+      AND "Form_Type" = 'F497P2'
+      GROUP BY "Filer_ID", "Filer_NamL", "Bal_Name", "Report_Num"
+      ORDER BY "Filer_ID", "Filer_NamL", "Bal_Name", "Report_Num" DESC
+    SQL
+
     supporting_by_measure_name = {}
     opposing_by_measure_name = {}
 
@@ -26,6 +36,37 @@ class ReferendumSupportersCalculator
       elsif row['Sup_Opp_Cd'] == 'O'
         opposing_by_measure_name[row['Bal_Name']] ||= []
         opposing_by_measure_name[row['Bal_Name']] << row
+      end
+    end
+
+    late_expenditures.each do |row|
+      sup_opp_cd = guess_whether_committee_supports_measure(row['Filer_ID'], row['Bal_Name'])
+      if sup_opp_cd == 'S'
+        supporting_by_measure_name[row['Bal_Name']] ||= []
+        existing_idx = supporting_by_measure_name[row['Bal_Name']].find_index do |existing_row|
+          existing_row['Filer_ID'].to_s == row['Filer_ID'].to_s
+        end
+
+        if existing_idx
+          supporting_by_measure_name[row['Bal_Name']][existing_idx]['Total_Amount'] +=
+            row['Total_Amount']
+        else
+          supporting_by_measure_name[row['Bal_Name']] << row
+        end
+      elsif sup_opp_cd == 'O'
+        opposing_by_measure_name[row['Bal_Name']] ||= []
+        opposing_by_measure_name[row['Bal_Name']] << row
+
+        existing_idx = opposing_by_measure_name[row['Bal_Name']].find_index do |existing_row|
+          existing_row['Filer_ID'].to_s == row['Filer_ID'].to_s
+        end
+
+        if existing_idx
+          opposing_by_measure_name[row['Bal_Name']][existing_idx]['Total_Amount'] +=
+            row['Total_Amount']
+        else
+          opposing_by_measure_name[row['Bal_Name']] << row
+        end
       end
     end
 
@@ -76,5 +117,30 @@ class ReferendumSupportersCalculator
     end
 
     committee
+  end
+
+  # Form 497 Page 2 (Late Expenditures) includes the ballot measure name and
+  # committee ID, but does not indicate whether that expenditure was in support
+  # or opposition of the ballot measure.
+  #
+  # This is not perfect, but it should get us pretty close.
+  def guess_whether_committee_supports_measure(committee_id, bal_name)
+    @_guess_cache ||=
+      begin
+        guesses = ActiveRecord::Base.connection.execute(<<-SQL)
+          SELECT "Filer_ID", "Bal_Name", "Sup_Opp_Cd"
+          FROM "efile_COAK_2016_E-Expenditure"
+          WHERE "Bal_Name" IS NOT NULL
+          GROUP BY "Filer_ID", "Bal_Name", "Sup_Opp_Cd"
+        SQL
+
+        guesses.index_by do |row|
+          row.values_at('Filer_ID', 'Bal_Name').map(&:to_s)
+        end
+      end
+
+    if row = @_guess_cache[[committee_id.to_s, bal_name]]
+      row['Sup_Opp_Cd']
+    end
   end
 end

--- a/calculators/referendum_supporters_calculator.rb
+++ b/calculators/referendum_supporters_calculator.rb
@@ -55,8 +55,6 @@ class ReferendumSupportersCalculator
         end
       elsif sup_opp_cd == 'O'
         opposing_by_measure_name[row['Bal_Name']] ||= []
-        opposing_by_measure_name[row['Bal_Name']] << row
-
         existing_idx = opposing_by_measure_name[row['Bal_Name']].find_index do |existing_row|
           existing_row['Filer_ID'].to_s == row['Filer_ID'].to_s
         end


### PR DESCRIPTION
This adds Late Expenditures to:

1. referendum supporters/opponents calculator
2. total expenditures calculator
3. expenditures by type calculator

The first one is somewhat difficult since Form 497 has no "Sup_Opp_Cd" field, so we must infer it based on the Schedule E (Payments Made). (We could instead use Schedule D, but it seems like the data is more complete for E).

Not much changed for candidates, since there is only one candidate entry on the 497 and it is a contribution, not an expenditure.

[Fixes #27]