### PR TITLE
Update "opposing" contributions_received stub to zero

### DIFF
--- a/build/ballot/1/index.json
+++ b/build/ballot/1/index.json
@@ -30,7 +30,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 19375.0,
           "total_contributions": 19375.0,
@@ -72,7 +72,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 39058.66,
           "total_contributions": 39058.66,
@@ -128,7 +128,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 41597.08,
           "total_contributions": 41597.08,
@@ -170,7 +170,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -220,7 +220,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 52199.0,
           "total_contributions": 52199.0,
@@ -263,7 +263,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -295,7 +295,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -327,7 +327,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -359,7 +359,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -398,7 +398,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -433,7 +433,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 5822.0,
           "total_contributions": 5822.0,
@@ -479,7 +479,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 3488.0,
           "total_contributions": 3488.0,
@@ -515,7 +515,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -547,7 +547,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -579,7 +579,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -618,7 +618,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -659,7 +659,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 5975.0,
           "total_contributions": 5975.0,
@@ -707,7 +707,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -739,7 +739,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -771,7 +771,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -810,7 +810,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -842,7 +842,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -883,7 +883,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 6895.0,
           "total_contributions": 6895.0,
@@ -924,7 +924,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -967,7 +967,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 60871.0,
           "total_contributions": 60871.0,
@@ -1010,7 +1010,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -1042,7 +1042,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,

--- a/build/candidate/1/index.json
+++ b/build/candidate/1/index.json
@@ -23,7 +23,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 60871.0,
   "total_contributions": 60871.0,

--- a/build/candidate/1/opposing/index.json
+++ b/build/candidate/1/opposing/index.json
@@ -23,7 +23,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 60871.0,
   "total_contributions": 60871.0,

--- a/build/candidate/1/supporting/index.json
+++ b/build/candidate/1/supporting/index.json
@@ -23,7 +23,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 60871.0,
   "total_contributions": 60871.0,

--- a/build/candidate/10/index.json
+++ b/build/candidate/10/index.json
@@ -23,7 +23,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 3488.0,
   "total_contributions": 3488.0,

--- a/build/candidate/10/opposing/index.json
+++ b/build/candidate/10/opposing/index.json
@@ -23,7 +23,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 3488.0,
   "total_contributions": 3488.0,

--- a/build/candidate/10/supporting/index.json
+++ b/build/candidate/10/supporting/index.json
@@ -23,7 +23,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 3488.0,
   "total_contributions": 3488.0,

--- a/build/candidate/11/index.json
+++ b/build/candidate/11/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/11/opposing/index.json
+++ b/build/candidate/11/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/11/supporting/index.json
+++ b/build/candidate/11/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/12/index.json
+++ b/build/candidate/12/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/12/opposing/index.json
+++ b/build/candidate/12/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/12/supporting/index.json
+++ b/build/candidate/12/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/13/index.json
+++ b/build/candidate/13/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/13/opposing/index.json
+++ b/build/candidate/13/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/13/supporting/index.json
+++ b/build/candidate/13/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/14/index.json
+++ b/build/candidate/14/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/14/opposing/index.json
+++ b/build/candidate/14/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/14/supporting/index.json
+++ b/build/candidate/14/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/15/index.json
+++ b/build/candidate/15/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/15/opposing/index.json
+++ b/build/candidate/15/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/15/supporting/index.json
+++ b/build/candidate/15/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/16/index.json
+++ b/build/candidate/16/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/16/opposing/index.json
+++ b/build/candidate/16/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/16/supporting/index.json
+++ b/build/candidate/16/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/17/index.json
+++ b/build/candidate/17/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/17/opposing/index.json
+++ b/build/candidate/17/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/17/supporting/index.json
+++ b/build/candidate/17/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/18/index.json
+++ b/build/candidate/18/index.json
@@ -28,7 +28,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 5975.0,
   "total_contributions": 5975.0,

--- a/build/candidate/18/opposing/index.json
+++ b/build/candidate/18/opposing/index.json
@@ -28,7 +28,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 5975.0,
   "total_contributions": 5975.0,

--- a/build/candidate/18/supporting/index.json
+++ b/build/candidate/18/supporting/index.json
@@ -28,7 +28,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 5975.0,
   "total_contributions": 5975.0,

--- a/build/candidate/19/index.json
+++ b/build/candidate/19/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/19/opposing/index.json
+++ b/build/candidate/19/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/19/supporting/index.json
+++ b/build/candidate/19/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/2/index.json
+++ b/build/candidate/2/index.json
@@ -30,7 +30,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 52199.0,
   "total_contributions": 52199.0,

--- a/build/candidate/2/opposing/index.json
+++ b/build/candidate/2/opposing/index.json
@@ -30,7 +30,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 52199.0,
   "total_contributions": 52199.0,

--- a/build/candidate/2/supporting/index.json
+++ b/build/candidate/2/supporting/index.json
@@ -30,7 +30,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 52199.0,
   "total_contributions": 52199.0,

--- a/build/candidate/20/index.json
+++ b/build/candidate/20/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/20/opposing/index.json
+++ b/build/candidate/20/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/20/supporting/index.json
+++ b/build/candidate/20/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/21/index.json
+++ b/build/candidate/21/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/21/opposing/index.json
+++ b/build/candidate/21/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/21/supporting/index.json
+++ b/build/candidate/21/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/22/index.json
+++ b/build/candidate/22/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/22/opposing/index.json
+++ b/build/candidate/22/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/22/supporting/index.json
+++ b/build/candidate/22/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/23/index.json
+++ b/build/candidate/23/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/23/opposing/index.json
+++ b/build/candidate/23/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/23/supporting/index.json
+++ b/build/candidate/23/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/24/index.json
+++ b/build/candidate/24/index.json
@@ -28,7 +28,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 6895.0,
   "total_contributions": 6895.0,

--- a/build/candidate/24/opposing/index.json
+++ b/build/candidate/24/opposing/index.json
@@ -28,7 +28,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 6895.0,
   "total_contributions": 6895.0,

--- a/build/candidate/24/supporting/index.json
+++ b/build/candidate/24/supporting/index.json
@@ -28,7 +28,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 6895.0,
   "total_contributions": 6895.0,

--- a/build/candidate/25/index.json
+++ b/build/candidate/25/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/25/opposing/index.json
+++ b/build/candidate/25/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/25/supporting/index.json
+++ b/build/candidate/25/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/26/index.json
+++ b/build/candidate/26/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/26/opposing/index.json
+++ b/build/candidate/26/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/26/supporting/index.json
+++ b/build/candidate/26/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/27/index.json
+++ b/build/candidate/27/index.json
@@ -22,7 +22,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 5822.0,
   "total_contributions": 5822.0,

--- a/build/candidate/27/opposing/index.json
+++ b/build/candidate/27/opposing/index.json
@@ -22,7 +22,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 5822.0,
   "total_contributions": 5822.0,

--- a/build/candidate/27/supporting/index.json
+++ b/build/candidate/27/supporting/index.json
@@ -22,7 +22,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 5822.0,
   "total_contributions": 5822.0,

--- a/build/candidate/3/index.json
+++ b/build/candidate/3/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/3/opposing/index.json
+++ b/build/candidate/3/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/3/supporting/index.json
+++ b/build/candidate/3/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/4/index.json
+++ b/build/candidate/4/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/4/opposing/index.json
+++ b/build/candidate/4/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/4/supporting/index.json
+++ b/build/candidate/4/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/5/index.json
+++ b/build/candidate/5/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/5/opposing/index.json
+++ b/build/candidate/5/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/5/supporting/index.json
+++ b/build/candidate/5/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/6/index.json
+++ b/build/candidate/6/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/6/opposing/index.json
+++ b/build/candidate/6/opposing/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/6/supporting/index.json
+++ b/build/candidate/6/supporting/index.json
@@ -19,7 +19,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/7/index.json
+++ b/build/candidate/7/index.json
@@ -22,7 +22,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 19375.0,
   "total_contributions": 19375.0,

--- a/build/candidate/7/opposing/index.json
+++ b/build/candidate/7/opposing/index.json
@@ -22,7 +22,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 19375.0,
   "total_contributions": 19375.0,

--- a/build/candidate/7/supporting/index.json
+++ b/build/candidate/7/supporting/index.json
@@ -22,7 +22,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 19375.0,
   "total_contributions": 19375.0,

--- a/build/candidate/8/index.json
+++ b/build/candidate/8/index.json
@@ -26,7 +26,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 39058.66,
   "total_contributions": 39058.66,

--- a/build/candidate/8/opposing/index.json
+++ b/build/candidate/8/opposing/index.json
@@ -26,7 +26,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 39058.66,
   "total_contributions": 39058.66,

--- a/build/candidate/8/supporting/index.json
+++ b/build/candidate/8/supporting/index.json
@@ -26,7 +26,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 39058.66,
   "total_contributions": 39058.66,

--- a/build/candidate/9/index.json
+++ b/build/candidate/9/index.json
@@ -29,7 +29,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 41597.08,
   "total_contributions": 41597.08,

--- a/build/candidate/9/opposing/index.json
+++ b/build/candidate/9/opposing/index.json
@@ -29,7 +29,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 41597.08,
   "total_contributions": 41597.08,

--- a/build/candidate/9/supporting/index.json
+++ b/build/candidate/9/supporting/index.json
@@ -29,7 +29,7 @@
     }
   },
   "opposing_money": {
-    "contributions_received": 4567
+    "contributions_received": 0
   },
   "contributions_received": 41597.08,
   "total_contributions": 41597.08,

--- a/build/locality/2/current_ballot/index.json
+++ b/build/locality/2/current_ballot/index.json
@@ -30,7 +30,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 19375.0,
           "total_contributions": 19375.0,
@@ -72,7 +72,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 39058.66,
           "total_contributions": 39058.66,
@@ -128,7 +128,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 41597.08,
           "total_contributions": 41597.08,
@@ -170,7 +170,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -220,7 +220,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 52199.0,
           "total_contributions": 52199.0,
@@ -263,7 +263,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -295,7 +295,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -327,7 +327,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -359,7 +359,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -398,7 +398,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -433,7 +433,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 5822.0,
           "total_contributions": 5822.0,
@@ -479,7 +479,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 3488.0,
           "total_contributions": 3488.0,
@@ -515,7 +515,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -547,7 +547,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -579,7 +579,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -618,7 +618,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -659,7 +659,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 5975.0,
           "total_contributions": 5975.0,
@@ -707,7 +707,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -739,7 +739,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -771,7 +771,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -810,7 +810,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -842,7 +842,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -883,7 +883,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 6895.0,
           "total_contributions": 6895.0,
@@ -924,7 +924,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -967,7 +967,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": 60871.0,
           "total_contributions": 60871.0,
@@ -1010,7 +1010,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -1042,7 +1042,7 @@
             }
           },
           "opposing_money": {
-            "contributions_received": 4567
+            "contributions_received": 0
           },
           "contributions_received": null,
           "total_contributions": null,

--- a/build/office_election/1/index.json
+++ b/build/office_election/1/index.json
@@ -27,7 +27,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": 19375.0,
       "total_contributions": 19375.0,
@@ -69,7 +69,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": 39058.66,
       "total_contributions": 39058.66,

--- a/build/office_election/10/index.json
+++ b/build/office_election/10/index.json
@@ -24,7 +24,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -56,7 +56,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,

--- a/build/office_election/2/index.json
+++ b/build/office_election/2/index.json
@@ -34,7 +34,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": 41597.08,
       "total_contributions": 41597.08,
@@ -76,7 +76,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,

--- a/build/office_election/3/index.json
+++ b/build/office_election/3/index.json
@@ -35,7 +35,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": 52199.0,
       "total_contributions": 52199.0,
@@ -78,7 +78,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -110,7 +110,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -142,7 +142,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -174,7 +174,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,

--- a/build/office_election/4/index.json
+++ b/build/office_election/4/index.json
@@ -24,7 +24,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -59,7 +59,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": 5822.0,
       "total_contributions": 5822.0,

--- a/build/office_election/5/index.json
+++ b/build/office_election/5/index.json
@@ -28,7 +28,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": 3488.0,
       "total_contributions": 3488.0,
@@ -64,7 +64,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -96,7 +96,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -128,7 +128,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,

--- a/build/office_election/6/index.json
+++ b/build/office_election/6/index.json
@@ -24,7 +24,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -65,7 +65,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": 5975.0,
       "total_contributions": 5975.0,

--- a/build/office_election/7/index.json
+++ b/build/office_election/7/index.json
@@ -24,7 +24,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -56,7 +56,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -88,7 +88,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,

--- a/build/office_election/8/index.json
+++ b/build/office_election/8/index.json
@@ -24,7 +24,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -56,7 +56,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -97,7 +97,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": 6895.0,
       "total_contributions": 6895.0,
@@ -138,7 +138,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": null,
       "total_contributions": null,

--- a/build/office_election/9/index.json
+++ b/build/office_election/9/index.json
@@ -28,7 +28,7 @@
         }
       },
       "opposing_money": {
-        "contributions_received": 4567
+        "contributions_received": 0
       },
       "contributions_received": 60871.0,
       "total_contributions": 60871.0,

--- a/models/oakland_candidate.rb
+++ b/models/oakland_candidate.rb
@@ -41,7 +41,7 @@ class OaklandCandidate < ActiveRecord::Base
         expenditures_by_type: calculation(:expenditures_by_type) || {},
       },
       opposing_money: {
-        contributions_received: 4567,
+        contributions_received: 0,
       },
 
       # for backwards compatibility, these should also be exposed at the


### PR DESCRIPTION
Update contributions_received stub to zero

Since there are no current records where "Sup_Opp_Cd" = 'O' for a
candidate in Schedule D or E, I'm going to just change this stub to
zero, which should get us through the v1 milestone. (See #24 )

We also won't see any records in the 496/497 that can be easily
attributed to be against a candidate because those files don't have the
"Sup_Opp_Cd" column.