### PR TITLE
Fixes #29 dont count expenditures to other committees

### DIFF
--- a/calculators/referendum_expenditures_by_origin.rb
+++ b/calculators/referendum_expenditures_by_origin.rb
@@ -13,6 +13,7 @@ class ReferendumExpendituresByOrigin
       FROM "efile_COAK_2016_E-Expenditure",
         oakland_name_to_number
       WHERE "Bal_Name" = "Measure_Name"
+      AND "Cmte_ID" IS NULL
       GROUP BY "Measure_Number", "Sup_Opp_Cd";
     SQL
 


### PR DESCRIPTION
@tdooner Dont count expenditures to other committees.  Ran this query manually, and it just exclude the Causa Justa expenditures.

I don't know if we need to edit the other expenditure calcuations too??