### PR TITLE
Remove duplicate 497 transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ import: inputs/efile_COAK_2016_A-Contributions.csv inputs/oakland_candidates.csv
 	./latest_only.sh efile_COAK_2016_H-Loans
 	./latest_only.sh efile_COAK_2016_I-Contributions
 	./latest_only.sh efile_COAK_2016_Summary
+	./remove_duplicate_transactions.sh
 
 inputs/efile_COAK_%_A-Contributions.csv: downloads/efile_COAK_%.xlsx
 	ssconvert -S $< inputs/$(subst .xlsx,_%s.csv,$(shell basename $<))

--- a/build/ballot/1/index.json
+++ b/build/ballot/1/index.json
@@ -520,12 +520,12 @@
           "party_affiliation": null,
           "filer_id": 1387803,
           "supporting_money": {
-            "contributions_received": 13336.0,
-            "total_contributions": 13336.0,
+            "contributions_received": 11836.0,
+            "total_contributions": 11836.0,
             "total_expenditures": 6170.1,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 3000.0,
+              "Committee": 1500.0,
               "Individual": 10286.0,
               "Unitemized": 50.0
             },
@@ -541,12 +541,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 13336.0,
-          "total_contributions": 13336.0,
+          "contributions_received": 11836.0,
+          "total_contributions": 11836.0,
           "total_expenditures": 6170.1,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 3000.0,
+            "Committee": 1500.0,
             "Individual": 10286.0,
             "Unitemized": 50.0
           },
@@ -577,12 +577,12 @@
           "party_affiliation": null,
           "filer_id": 1384926,
           "supporting_money": {
-            "contributions_received": 10622.0,
-            "total_contributions": 10622.0,
+            "contributions_received": 9622.0,
+            "total_contributions": 9622.0,
             "total_expenditures": 14468.79,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 5200.0,
+              "Committee": 4200.0,
               "Individual": 3450.0,
               "Unitemized": 1672.0
             },
@@ -596,12 +596,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 10622.0,
-          "total_contributions": 10622.0,
+          "contributions_received": 9622.0,
+          "total_contributions": 9622.0,
           "total_expenditures": 14468.79,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 5200.0,
+            "Committee": 4200.0,
             "Individual": 3450.0,
             "Unitemized": 1672.0
           },
@@ -968,12 +968,12 @@
           "party_affiliation": null,
           "filer_id": 1386932,
           "supporting_money": {
-            "contributions_received": 13004.0,
-            "total_contributions": 13004.0,
+            "contributions_received": 11504.0,
+            "total_contributions": 11504.0,
             "total_expenditures": 2774.63,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 3200.0,
+              "Committee": 1700.0,
               "Individual": 8650.0,
               "Unitemized": 1154.0
             },
@@ -984,12 +984,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 13004.0,
-          "total_contributions": 13004.0,
+          "contributions_received": 11504.0,
+          "total_contributions": 11504.0,
           "total_expenditures": 2774.63,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 3200.0,
+            "Committee": 1700.0,
             "Individual": 8650.0,
             "Unitemized": 1154.0
           },
@@ -1222,14 +1222,14 @@
           "party_affiliation": "Democrat",
           "filer_id": 1386749,
           "supporting_money": {
-            "contributions_received": 17840.48,
-            "total_contributions": 17840.48,
+            "contributions_received": 16340.48,
+            "total_contributions": 16340.48,
             "total_expenditures": 5863.54,
             "total_loans_received": 1600.0,
             "contributions_by_type": {
               "Individual": 11763.31,
               "Unitemized": 1453.0,
-              "Other (includes Businesses)": 3000.0
+              "Other (includes Businesses)": 1500.0
             },
             "expenditures_by_type": {
               "Not Stated": 26256.98,
@@ -1244,14 +1244,14 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 17840.48,
-          "total_contributions": 17840.48,
+          "contributions_received": 16340.48,
+          "total_contributions": 16340.48,
           "total_expenditures": 5863.54,
           "total_loans_received": 1600.0,
           "contributions_by_type": {
             "Individual": 11763.31,
             "Unitemized": 1453.0,
-            "Other (includes Businesses)": 3000.0
+            "Other (includes Businesses)": 1500.0
           },
           "expenditures_by_type": {
             "Not Stated": 26256.98,
@@ -1387,12 +1387,12 @@
           "party_affiliation": "Democrat",
           "filer_id": 1387192,
           "supporting_money": {
-            "contributions_received": 45105.73,
-            "total_contributions": 45105.73,
+            "contributions_received": 43705.73,
+            "total_contributions": 43705.73,
             "total_expenditures": 4653.49,
             "total_loans_received": 10000.0,
             "contributions_by_type": {
-              "Committee": 3300.0,
+              "Committee": 1900.0,
               "Individual": 30012.92,
               "Unitemized": 992.81,
               "Other (includes Businesses)": 800.0
@@ -1407,12 +1407,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 45105.73,
-          "total_contributions": 45105.73,
+          "contributions_received": 43705.73,
+          "total_contributions": 43705.73,
           "total_expenditures": 4653.49,
           "total_loans_received": 10000.0,
           "contributions_by_type": {
-            "Committee": 3300.0,
+            "Committee": 1900.0,
             "Individual": 30012.92,
             "Unitemized": 992.81,
             "Other (includes Businesses)": 800.0

--- a/build/candidate/12/index.json
+++ b/build/candidate/12/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": "Democrat",
   "filer_id": 1387192,
   "supporting_money": {
-    "contributions_received": 45105.73,
-    "total_contributions": 45105.73,
+    "contributions_received": 43705.73,
+    "total_contributions": 43705.73,
     "total_expenditures": 4653.49,
     "total_loans_received": 10000.0,
     "contributions_by_type": {
-      "Committee": 3300.0,
+      "Committee": 1900.0,
       "Individual": 30012.92,
       "Unitemized": 992.81,
       "Other (includes Businesses)": 800.0
@@ -36,12 +36,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 45105.73,
-  "total_contributions": 45105.73,
+  "contributions_received": 43705.73,
+  "total_contributions": 43705.73,
   "total_expenditures": 4653.49,
   "total_loans_received": 10000.0,
   "contributions_by_type": {
-    "Committee": 3300.0,
+    "Committee": 1900.0,
     "Individual": 30012.92,
     "Unitemized": 992.81,
     "Other (includes Businesses)": 800.0

--- a/build/candidate/12/opposing/index.json
+++ b/build/candidate/12/opposing/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": "Democrat",
   "filer_id": 1387192,
   "supporting_money": {
-    "contributions_received": 45105.73,
-    "total_contributions": 45105.73,
+    "contributions_received": 43705.73,
+    "total_contributions": 43705.73,
     "total_expenditures": 4653.49,
     "total_loans_received": 10000.0,
     "contributions_by_type": {
-      "Committee": 3300.0,
+      "Committee": 1900.0,
       "Individual": 30012.92,
       "Unitemized": 992.81,
       "Other (includes Businesses)": 800.0
@@ -36,12 +36,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 45105.73,
-  "total_contributions": 45105.73,
+  "contributions_received": 43705.73,
+  "total_contributions": 43705.73,
   "total_expenditures": 4653.49,
   "total_loans_received": 10000.0,
   "contributions_by_type": {
-    "Committee": 3300.0,
+    "Committee": 1900.0,
     "Individual": 30012.92,
     "Unitemized": 992.81,
     "Other (includes Businesses)": 800.0

--- a/build/candidate/12/supporting/index.json
+++ b/build/candidate/12/supporting/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": "Democrat",
   "filer_id": 1387192,
   "supporting_money": {
-    "contributions_received": 45105.73,
-    "total_contributions": 45105.73,
+    "contributions_received": 43705.73,
+    "total_contributions": 43705.73,
     "total_expenditures": 4653.49,
     "total_loans_received": 10000.0,
     "contributions_by_type": {
-      "Committee": 3300.0,
+      "Committee": 1900.0,
       "Individual": 30012.92,
       "Unitemized": 992.81,
       "Other (includes Businesses)": 800.0
@@ -36,12 +36,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 45105.73,
-  "total_contributions": 45105.73,
+  "contributions_received": 43705.73,
+  "total_contributions": 43705.73,
   "total_expenditures": 4653.49,
   "total_loans_received": 10000.0,
   "contributions_by_type": {
-    "Committee": 3300.0,
+    "Committee": 1900.0,
     "Individual": 30012.92,
     "Unitemized": 992.81,
     "Other (includes Businesses)": 800.0

--- a/build/candidate/14/index.json
+++ b/build/candidate/14/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1386932,
   "supporting_money": {
-    "contributions_received": 13004.0,
-    "total_contributions": 13004.0,
+    "contributions_received": 11504.0,
+    "total_contributions": 11504.0,
     "total_expenditures": 2774.63,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 3200.0,
+      "Committee": 1700.0,
       "Individual": 8650.0,
       "Unitemized": 1154.0
     },
@@ -32,12 +32,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 13004.0,
-  "total_contributions": 13004.0,
+  "contributions_received": 11504.0,
+  "total_contributions": 11504.0,
   "total_expenditures": 2774.63,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 3200.0,
+    "Committee": 1700.0,
     "Individual": 8650.0,
     "Unitemized": 1154.0
   },

--- a/build/candidate/14/opposing/index.json
+++ b/build/candidate/14/opposing/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1386932,
   "supporting_money": {
-    "contributions_received": 13004.0,
-    "total_contributions": 13004.0,
+    "contributions_received": 11504.0,
+    "total_contributions": 11504.0,
     "total_expenditures": 2774.63,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 3200.0,
+      "Committee": 1700.0,
       "Individual": 8650.0,
       "Unitemized": 1154.0
     },
@@ -32,12 +32,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 13004.0,
-  "total_contributions": 13004.0,
+  "contributions_received": 11504.0,
+  "total_contributions": 11504.0,
   "total_expenditures": 2774.63,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 3200.0,
+    "Committee": 1700.0,
     "Individual": 8650.0,
     "Unitemized": 1154.0
   },

--- a/build/candidate/14/supporting/index.json
+++ b/build/candidate/14/supporting/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1386932,
   "supporting_money": {
-    "contributions_received": 13004.0,
-    "total_contributions": 13004.0,
+    "contributions_received": 11504.0,
+    "total_contributions": 11504.0,
     "total_expenditures": 2774.63,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 3200.0,
+      "Committee": 1700.0,
       "Individual": 8650.0,
       "Unitemized": 1154.0
     },
@@ -32,12 +32,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 13004.0,
-  "total_contributions": 13004.0,
+  "contributions_received": 11504.0,
+  "total_contributions": 11504.0,
   "total_expenditures": 2774.63,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 3200.0,
+    "Committee": 1700.0,
     "Individual": 8650.0,
     "Unitemized": 1154.0
   },

--- a/build/candidate/25/index.json
+++ b/build/candidate/25/index.json
@@ -16,14 +16,14 @@
   "party_affiliation": "Democrat",
   "filer_id": 1386749,
   "supporting_money": {
-    "contributions_received": 17840.48,
-    "total_contributions": 17840.48,
+    "contributions_received": 16340.48,
+    "total_contributions": 16340.48,
     "total_expenditures": 5863.54,
     "total_loans_received": 1600.0,
     "contributions_by_type": {
       "Individual": 11763.31,
       "Unitemized": 1453.0,
-      "Other (includes Businesses)": 3000.0
+      "Other (includes Businesses)": 1500.0
     },
     "expenditures_by_type": {
       "Not Stated": 26256.98,
@@ -38,14 +38,14 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 17840.48,
-  "total_contributions": 17840.48,
+  "contributions_received": 16340.48,
+  "total_contributions": 16340.48,
   "total_expenditures": 5863.54,
   "total_loans_received": 1600.0,
   "contributions_by_type": {
     "Individual": 11763.31,
     "Unitemized": 1453.0,
-    "Other (includes Businesses)": 3000.0
+    "Other (includes Businesses)": 1500.0
   },
   "expenditures_by_type": {
     "Not Stated": 26256.98,

--- a/build/candidate/25/opposing/index.json
+++ b/build/candidate/25/opposing/index.json
@@ -16,14 +16,14 @@
   "party_affiliation": "Democrat",
   "filer_id": 1386749,
   "supporting_money": {
-    "contributions_received": 17840.48,
-    "total_contributions": 17840.48,
+    "contributions_received": 16340.48,
+    "total_contributions": 16340.48,
     "total_expenditures": 5863.54,
     "total_loans_received": 1600.0,
     "contributions_by_type": {
       "Individual": 11763.31,
       "Unitemized": 1453.0,
-      "Other (includes Businesses)": 3000.0
+      "Other (includes Businesses)": 1500.0
     },
     "expenditures_by_type": {
       "Not Stated": 26256.98,
@@ -38,14 +38,14 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 17840.48,
-  "total_contributions": 17840.48,
+  "contributions_received": 16340.48,
+  "total_contributions": 16340.48,
   "total_expenditures": 5863.54,
   "total_loans_received": 1600.0,
   "contributions_by_type": {
     "Individual": 11763.31,
     "Unitemized": 1453.0,
-    "Other (includes Businesses)": 3000.0
+    "Other (includes Businesses)": 1500.0
   },
   "expenditures_by_type": {
     "Not Stated": 26256.98,

--- a/build/candidate/25/supporting/index.json
+++ b/build/candidate/25/supporting/index.json
@@ -16,14 +16,14 @@
   "party_affiliation": "Democrat",
   "filer_id": 1386749,
   "supporting_money": {
-    "contributions_received": 17840.48,
-    "total_contributions": 17840.48,
+    "contributions_received": 16340.48,
+    "total_contributions": 16340.48,
     "total_expenditures": 5863.54,
     "total_loans_received": 1600.0,
     "contributions_by_type": {
       "Individual": 11763.31,
       "Unitemized": 1453.0,
-      "Other (includes Businesses)": 3000.0
+      "Other (includes Businesses)": 1500.0
     },
     "expenditures_by_type": {
       "Not Stated": 26256.98,
@@ -38,14 +38,14 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 17840.48,
-  "total_contributions": 17840.48,
+  "contributions_received": 16340.48,
+  "total_contributions": 16340.48,
   "total_expenditures": 5863.54,
   "total_loans_received": 1600.0,
   "contributions_by_type": {
     "Individual": 11763.31,
     "Unitemized": 1453.0,
-    "Other (includes Businesses)": 3000.0
+    "Other (includes Businesses)": 1500.0
   },
   "expenditures_by_type": {
     "Not Stated": 26256.98,

--- a/build/candidate/26/index.json
+++ b/build/candidate/26/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1387803,
   "supporting_money": {
-    "contributions_received": 13336.0,
-    "total_contributions": 13336.0,
+    "contributions_received": 11836.0,
+    "total_contributions": 11836.0,
     "total_expenditures": 6170.1,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 3000.0,
+      "Committee": 1500.0,
       "Individual": 10286.0,
       "Unitemized": 50.0
     },
@@ -37,12 +37,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 13336.0,
-  "total_contributions": 13336.0,
+  "contributions_received": 11836.0,
+  "total_contributions": 11836.0,
   "total_expenditures": 6170.1,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 3000.0,
+    "Committee": 1500.0,
     "Individual": 10286.0,
     "Unitemized": 50.0
   },

--- a/build/candidate/26/opposing/index.json
+++ b/build/candidate/26/opposing/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1387803,
   "supporting_money": {
-    "contributions_received": 13336.0,
-    "total_contributions": 13336.0,
+    "contributions_received": 11836.0,
+    "total_contributions": 11836.0,
     "total_expenditures": 6170.1,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 3000.0,
+      "Committee": 1500.0,
       "Individual": 10286.0,
       "Unitemized": 50.0
     },
@@ -37,12 +37,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 13336.0,
-  "total_contributions": 13336.0,
+  "contributions_received": 11836.0,
+  "total_contributions": 11836.0,
   "total_expenditures": 6170.1,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 3000.0,
+    "Committee": 1500.0,
     "Individual": 10286.0,
     "Unitemized": 50.0
   },

--- a/build/candidate/26/supporting/index.json
+++ b/build/candidate/26/supporting/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1387803,
   "supporting_money": {
-    "contributions_received": 13336.0,
-    "total_contributions": 13336.0,
+    "contributions_received": 11836.0,
+    "total_contributions": 11836.0,
     "total_expenditures": 6170.1,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 3000.0,
+      "Committee": 1500.0,
       "Individual": 10286.0,
       "Unitemized": 50.0
     },
@@ -37,12 +37,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 13336.0,
-  "total_contributions": 13336.0,
+  "contributions_received": 11836.0,
+  "total_contributions": 11836.0,
   "total_expenditures": 6170.1,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 3000.0,
+    "Committee": 1500.0,
     "Individual": 10286.0,
     "Unitemized": 50.0
   },

--- a/build/candidate/27/index.json
+++ b/build/candidate/27/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1384926,
   "supporting_money": {
-    "contributions_received": 10622.0,
-    "total_contributions": 10622.0,
+    "contributions_received": 9622.0,
+    "total_contributions": 9622.0,
     "total_expenditures": 14468.79,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 5200.0,
+      "Committee": 4200.0,
       "Individual": 3450.0,
       "Unitemized": 1672.0
     },
@@ -35,12 +35,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 10622.0,
-  "total_contributions": 10622.0,
+  "contributions_received": 9622.0,
+  "total_contributions": 9622.0,
   "total_expenditures": 14468.79,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 5200.0,
+    "Committee": 4200.0,
     "Individual": 3450.0,
     "Unitemized": 1672.0
   },

--- a/build/candidate/27/opposing/index.json
+++ b/build/candidate/27/opposing/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1384926,
   "supporting_money": {
-    "contributions_received": 10622.0,
-    "total_contributions": 10622.0,
+    "contributions_received": 9622.0,
+    "total_contributions": 9622.0,
     "total_expenditures": 14468.79,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 5200.0,
+      "Committee": 4200.0,
       "Individual": 3450.0,
       "Unitemized": 1672.0
     },
@@ -35,12 +35,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 10622.0,
-  "total_contributions": 10622.0,
+  "contributions_received": 9622.0,
+  "total_contributions": 9622.0,
   "total_expenditures": 14468.79,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 5200.0,
+    "Committee": 4200.0,
     "Individual": 3450.0,
     "Unitemized": 1672.0
   },

--- a/build/candidate/27/supporting/index.json
+++ b/build/candidate/27/supporting/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1384926,
   "supporting_money": {
-    "contributions_received": 10622.0,
-    "total_contributions": 10622.0,
+    "contributions_received": 9622.0,
+    "total_contributions": 9622.0,
     "total_expenditures": 14468.79,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 5200.0,
+      "Committee": 4200.0,
       "Individual": 3450.0,
       "Unitemized": 1672.0
     },
@@ -35,12 +35,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 10622.0,
-  "total_contributions": 10622.0,
+  "contributions_received": 9622.0,
+  "total_contributions": 9622.0,
   "total_expenditures": 14468.79,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 5200.0,
+    "Committee": 4200.0,
     "Individual": 3450.0,
     "Unitemized": 1672.0
   },

--- a/build/committee/1342695/contributions/index.json
+++ b/build/committee/1342695/contributions/index.json
@@ -1,24 +1,17 @@
 [
   {
     "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Ambassador Aparments"
+  },
+  {
+    "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
     "Tran_Date": "2016-04-22",
     "Tran_NamF": null,
     "Tran_NamL": "Ambassador Aparments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Ambassador Aparments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Anthony Associates"
   },
   {
     "Filer_ID": "1342695",
@@ -29,14 +22,21 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Anthony Associates"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-03-04",
     "Tran_NamF": null,
     "Tran_NamL": "Beacon Properties"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-03-04",
     "Tran_NamF": null,
     "Tran_NamL": "Beacon Properties"
@@ -57,14 +57,14 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "Laurie",
     "Tran_NamL": "Burke"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "Laurie",
     "Tran_NamL": "Burke"
@@ -85,13 +85,6 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "East 18th Street Assoc. /Oakbrook Manor"
-  },
-  {
-    "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
     "Tran_Date": "2016-01-15",
     "Tran_NamF": null,
@@ -100,9 +93,9 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-22",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Faussner"
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "East 18th Street Assoc. /Oakbrook Manor"
   },
   {
     "Filer_ID": "1342695",
@@ -114,13 +107,20 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-03-22",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Faussner"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-05-06",
     "Tran_NamF": null,
     "Tran_NamL": "Foxfire Property Management"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-05-06",
     "Tran_NamF": null,
     "Tran_NamL": "Foxfire Property Management"
@@ -176,13 +176,6 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-02-08",
-    "Tran_NamF": "Diane",
-    "Tran_NamL": "Henry"
-  },
-  {
-    "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
     "Tran_Date": "2016-02-08",
     "Tran_NamF": "Diane",
@@ -191,13 +184,20 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-02-08",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Henry"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-04-08",
     "Tran_NamF": null,
     "Tran_NamL": "Hillcrest Management/Commodore Apartments"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-04-08",
     "Tran_NamF": null,
     "Tran_NamL": "Hillcrest Management/Commodore Apartments"
@@ -218,14 +218,14 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-01-13",
     "Tran_NamF": "Sidhardha",
     "Tran_NamL": "Lakireddy"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-01-13",
     "Tran_NamF": "Sidhardha",
     "Tran_NamL": "Lakireddy"
@@ -260,14 +260,14 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-06-10",
     "Tran_NamF": null,
     "Tran_NamL": "Library Gardens"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-06-10",
     "Tran_NamF": null,
     "Tran_NamL": "Library Gardens"
@@ -288,14 +288,14 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-03-18",
     "Tran_NamF": null,
     "Tran_NamL": "Melba Lake Apts"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-03-18",
     "Tran_NamF": null,
     "Tran_NamL": "Melba Lake Apts"

--- a/build/committee/1364564/contributions/index.json
+++ b/build/committee/1364564/contributions/index.json
@@ -22,8 +22,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": -3000.0,
+    "Tran_Date": "2016-05-10",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
@@ -36,8 +36,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": -3000.0,
-    "Tran_Date": "2016-05-10",
+    "Tran_Amt1": 3000.0,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
@@ -64,36 +64,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 59089.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 59000.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 35000.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1020.82,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 13315.74,
-    "Tran_Date": "2016-01-01",
+    "Tran_Amt1": 519.47,
+    "Tran_Date": "2016-08-15",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -101,6 +73,13 @@
     "Filer_ID": "1364564",
     "Tran_Amt1": 10000.0,
     "Tran_Date": "2016-09-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 35000.0,
+    "Tran_Date": "2016-09-23",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -134,6 +113,20 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 59000.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 13315.74,
+    "Tran_Date": "2016-01-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 89.0,
     "Tran_Date": "2016-09-09",
     "Tran_NamF": null,
@@ -141,8 +134,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 519.47,
-    "Tran_Date": "2016-08-15",
+    "Tran_Amt1": 1020.82,
+    "Tran_Date": "2016-08-29",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -372,15 +365,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-11",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-05",
     "Tran_NamF": "Alanya",
     "Tran_NamL": "Snyder"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-05",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-11",
     "Tran_NamF": "Alanya",
     "Tran_NamL": "Snyder"
   },

--- a/build/committee/1386145/contributions/index.json
+++ b/build/committee/1386145/contributions/index.json
@@ -365,7 +365,7 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 2.85,
+    "Tran_Amt1": 1.65,
     "Tran_Date": "2016-01-26",
     "Tran_NamF": "Len",
     "Tran_NamL": "Raphael"
@@ -386,7 +386,7 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 1.65,
+    "Tran_Amt1": 2.85,
     "Tran_Date": "2016-01-26",
     "Tran_NamF": "Len",
     "Tran_NamL": "Raphael"

--- a/build/committee/1387983/contributions/index.json
+++ b/build/committee/1387983/contributions/index.json
@@ -36,13 +36,6 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "At&t California Employee PAC"
-  },
-  {
-    "Filer_ID": "1387983",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-09-07",
     "Tran_NamF": "John",
@@ -229,13 +222,6 @@
     "Tran_Date": "2016-09-27",
     "Tran_NamF": "Alexis",
     "Tran_NamL": "Pelosi"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "San Francisco Laborer's Local 261"
   },
   {
     "Filer_ID": "1387983",

--- a/build/locality/2/current_ballot/index.json
+++ b/build/locality/2/current_ballot/index.json
@@ -520,12 +520,12 @@
           "party_affiliation": null,
           "filer_id": 1387803,
           "supporting_money": {
-            "contributions_received": 13336.0,
-            "total_contributions": 13336.0,
+            "contributions_received": 11836.0,
+            "total_contributions": 11836.0,
             "total_expenditures": 6170.1,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 3000.0,
+              "Committee": 1500.0,
               "Individual": 10286.0,
               "Unitemized": 50.0
             },
@@ -541,12 +541,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 13336.0,
-          "total_contributions": 13336.0,
+          "contributions_received": 11836.0,
+          "total_contributions": 11836.0,
           "total_expenditures": 6170.1,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 3000.0,
+            "Committee": 1500.0,
             "Individual": 10286.0,
             "Unitemized": 50.0
           },
@@ -577,12 +577,12 @@
           "party_affiliation": null,
           "filer_id": 1384926,
           "supporting_money": {
-            "contributions_received": 10622.0,
-            "total_contributions": 10622.0,
+            "contributions_received": 9622.0,
+            "total_contributions": 9622.0,
             "total_expenditures": 14468.79,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 5200.0,
+              "Committee": 4200.0,
               "Individual": 3450.0,
               "Unitemized": 1672.0
             },
@@ -596,12 +596,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 10622.0,
-          "total_contributions": 10622.0,
+          "contributions_received": 9622.0,
+          "total_contributions": 9622.0,
           "total_expenditures": 14468.79,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 5200.0,
+            "Committee": 4200.0,
             "Individual": 3450.0,
             "Unitemized": 1672.0
           },
@@ -968,12 +968,12 @@
           "party_affiliation": null,
           "filer_id": 1386932,
           "supporting_money": {
-            "contributions_received": 13004.0,
-            "total_contributions": 13004.0,
+            "contributions_received": 11504.0,
+            "total_contributions": 11504.0,
             "total_expenditures": 2774.63,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 3200.0,
+              "Committee": 1700.0,
               "Individual": 8650.0,
               "Unitemized": 1154.0
             },
@@ -984,12 +984,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 13004.0,
-          "total_contributions": 13004.0,
+          "contributions_received": 11504.0,
+          "total_contributions": 11504.0,
           "total_expenditures": 2774.63,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 3200.0,
+            "Committee": 1700.0,
             "Individual": 8650.0,
             "Unitemized": 1154.0
           },
@@ -1222,14 +1222,14 @@
           "party_affiliation": "Democrat",
           "filer_id": 1386749,
           "supporting_money": {
-            "contributions_received": 17840.48,
-            "total_contributions": 17840.48,
+            "contributions_received": 16340.48,
+            "total_contributions": 16340.48,
             "total_expenditures": 5863.54,
             "total_loans_received": 1600.0,
             "contributions_by_type": {
               "Individual": 11763.31,
               "Unitemized": 1453.0,
-              "Other (includes Businesses)": 3000.0
+              "Other (includes Businesses)": 1500.0
             },
             "expenditures_by_type": {
               "Not Stated": 26256.98,
@@ -1244,14 +1244,14 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 17840.48,
-          "total_contributions": 17840.48,
+          "contributions_received": 16340.48,
+          "total_contributions": 16340.48,
           "total_expenditures": 5863.54,
           "total_loans_received": 1600.0,
           "contributions_by_type": {
             "Individual": 11763.31,
             "Unitemized": 1453.0,
-            "Other (includes Businesses)": 3000.0
+            "Other (includes Businesses)": 1500.0
           },
           "expenditures_by_type": {
             "Not Stated": 26256.98,
@@ -1387,12 +1387,12 @@
           "party_affiliation": "Democrat",
           "filer_id": 1387192,
           "supporting_money": {
-            "contributions_received": 45105.73,
-            "total_contributions": 45105.73,
+            "contributions_received": 43705.73,
+            "total_contributions": 43705.73,
             "total_expenditures": 4653.49,
             "total_loans_received": 10000.0,
             "contributions_by_type": {
-              "Committee": 3300.0,
+              "Committee": 1900.0,
               "Individual": 30012.92,
               "Unitemized": 992.81,
               "Other (includes Businesses)": 800.0
@@ -1407,12 +1407,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 45105.73,
-          "total_contributions": 45105.73,
+          "contributions_received": 43705.73,
+          "total_contributions": 43705.73,
           "total_expenditures": 4653.49,
           "total_loans_received": 10000.0,
           "contributions_by_type": {
-            "Committee": 3300.0,
+            "Committee": 1900.0,
             "Individual": 30012.92,
             "Unitemized": 992.81,
             "Other (includes Businesses)": 800.0

--- a/build/office_election/10/index.json
+++ b/build/office_election/10/index.json
@@ -62,12 +62,12 @@
       "party_affiliation": "Democrat",
       "filer_id": 1387192,
       "supporting_money": {
-        "contributions_received": 45105.73,
-        "total_contributions": 45105.73,
+        "contributions_received": 43705.73,
+        "total_contributions": 43705.73,
         "total_expenditures": 4653.49,
         "total_loans_received": 10000.0,
         "contributions_by_type": {
-          "Committee": 3300.0,
+          "Committee": 1900.0,
           "Individual": 30012.92,
           "Unitemized": 992.81,
           "Other (includes Businesses)": 800.0
@@ -82,12 +82,12 @@
       "opposing_money": {
         "contributions_received": 0
       },
-      "contributions_received": 45105.73,
-      "total_contributions": 45105.73,
+      "contributions_received": 43705.73,
+      "total_contributions": 43705.73,
       "total_expenditures": 4653.49,
       "total_loans_received": 10000.0,
       "contributions_by_type": {
-        "Committee": 3300.0,
+        "Committee": 1900.0,
         "Individual": 30012.92,
         "Unitemized": 992.81,
         "Other (includes Businesses)": 800.0

--- a/build/office_election/4/index.json
+++ b/build/office_election/4/index.json
@@ -21,12 +21,12 @@
       "party_affiliation": null,
       "filer_id": 1387803,
       "supporting_money": {
-        "contributions_received": 13336.0,
-        "total_contributions": 13336.0,
+        "contributions_received": 11836.0,
+        "total_contributions": 11836.0,
         "total_expenditures": 6170.1,
         "total_loans_received": 0.0,
         "contributions_by_type": {
-          "Committee": 3000.0,
+          "Committee": 1500.0,
           "Individual": 10286.0,
           "Unitemized": 50.0
         },
@@ -42,12 +42,12 @@
       "opposing_money": {
         "contributions_received": 0
       },
-      "contributions_received": 13336.0,
-      "total_contributions": 13336.0,
+      "contributions_received": 11836.0,
+      "total_contributions": 11836.0,
       "total_expenditures": 6170.1,
       "total_loans_received": 0.0,
       "contributions_by_type": {
-        "Committee": 3000.0,
+        "Committee": 1500.0,
         "Individual": 10286.0,
         "Unitemized": 50.0
       },
@@ -78,12 +78,12 @@
       "party_affiliation": null,
       "filer_id": 1384926,
       "supporting_money": {
-        "contributions_received": 10622.0,
-        "total_contributions": 10622.0,
+        "contributions_received": 9622.0,
+        "total_contributions": 9622.0,
         "total_expenditures": 14468.79,
         "total_loans_received": 0.0,
         "contributions_by_type": {
-          "Committee": 5200.0,
+          "Committee": 4200.0,
           "Individual": 3450.0,
           "Unitemized": 1672.0
         },
@@ -97,12 +97,12 @@
       "opposing_money": {
         "contributions_received": 0
       },
-      "contributions_received": 10622.0,
-      "total_contributions": 10622.0,
+      "contributions_received": 9622.0,
+      "total_contributions": 9622.0,
       "total_expenditures": 14468.79,
       "total_loans_received": 0.0,
       "contributions_by_type": {
-        "Committee": 5200.0,
+        "Committee": 4200.0,
         "Individual": 3450.0,
         "Unitemized": 1672.0
       },

--- a/build/office_election/7/index.json
+++ b/build/office_election/7/index.json
@@ -60,12 +60,12 @@
       "party_affiliation": null,
       "filer_id": 1386932,
       "supporting_money": {
-        "contributions_received": 13004.0,
-        "total_contributions": 13004.0,
+        "contributions_received": 11504.0,
+        "total_contributions": 11504.0,
         "total_expenditures": 2774.63,
         "total_loans_received": 0.0,
         "contributions_by_type": {
-          "Committee": 3200.0,
+          "Committee": 1700.0,
           "Individual": 8650.0,
           "Unitemized": 1154.0
         },
@@ -76,12 +76,12 @@
       "opposing_money": {
         "contributions_received": 0
       },
-      "contributions_received": 13004.0,
-      "total_contributions": 13004.0,
+      "contributions_received": 11504.0,
+      "total_contributions": 11504.0,
       "total_expenditures": 2774.63,
       "total_loans_received": 0.0,
       "contributions_by_type": {
-        "Committee": 3200.0,
+        "Committee": 1700.0,
         "Individual": 8650.0,
         "Unitemized": 1154.0
       },

--- a/build/office_election/8/index.json
+++ b/build/office_election/8/index.json
@@ -168,14 +168,14 @@
       "party_affiliation": "Democrat",
       "filer_id": 1386749,
       "supporting_money": {
-        "contributions_received": 17840.48,
-        "total_contributions": 17840.48,
+        "contributions_received": 16340.48,
+        "total_contributions": 16340.48,
         "total_expenditures": 5863.54,
         "total_loans_received": 1600.0,
         "contributions_by_type": {
           "Individual": 11763.31,
           "Unitemized": 1453.0,
-          "Other (includes Businesses)": 3000.0
+          "Other (includes Businesses)": 1500.0
         },
         "expenditures_by_type": {
           "Not Stated": 26256.98,
@@ -190,14 +190,14 @@
       "opposing_money": {
         "contributions_received": 0
       },
-      "contributions_received": 17840.48,
-      "total_contributions": 17840.48,
+      "contributions_received": 16340.48,
+      "total_contributions": 16340.48,
       "total_expenditures": 5863.54,
       "total_loans_received": 1600.0,
       "contributions_by_type": {
         "Individual": 11763.31,
         "Unitemized": 1453.0,
-        "Other (includes Businesses)": 3000.0
+        "Other (includes Businesses)": 1500.0
       },
       "expenditures_by_type": {
         "Not Stated": 26256.98,

--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -16,7 +16,7 @@
       "id": "1385949",
       "name": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "payee": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
-      "amount": 247330.76
+      "amount": 178330.76
     }
   ],
   "total_contributions": 160146.25,

--- a/calculators/candidate_contributions_by_type.rb
+++ b/calculators/candidate_contributions_by_type.rb
@@ -61,6 +61,9 @@ class CandidateContributionsByType
         ORDER BY "Entity_Cd", "Filer_ID"
       SQL
 
+      # NOTE: We remove duplicate transactions on 497 that are also reported on
+      # Schedule A during a preprocssing script. (See
+      # `./../remove_duplicate_transactionts.sh`)
       late_results = ActiveRecord::Base.connection.execute(<<-SQL)
         SELECT "Filer_ID", "Entity_Cd", SUM("Amount") AS "Total"
         FROM "efile_COAK_2016_497"
@@ -69,9 +72,6 @@ class CandidateContributionsByType
         GROUP BY "Entity_Cd", "Filer_ID"
         ORDER BY "Entity_Cd", "Filer_ID"
       SQL
-
-      # TODO: we need to subtract `late_results` that are also present in
-      # `monetary_results` so as to not duplicate transactions!
 
       (monetary_results.to_a + in_kind_results.to_a + late_results.to_a).each do |result|
         filer_id = result['Filer_ID'].to_s

--- a/calculators/committee_contribution_list_calculator.rb
+++ b/calculators/committee_contribution_list_calculator.rb
@@ -18,7 +18,6 @@ class CommitteeContributionListCalculator
       UNION
 
       -- Form 497 Late Contributions
-      -- TODO: we will need to dedupe this against the other forms
       SELECT
         "Filer_ID"::varchar,
         "Amount" AS "Tran_Amt1",

--- a/calculators/total_contributions_calculator.rb
+++ b/calculators/total_contributions_calculator.rb
@@ -25,6 +25,9 @@ class TotalContributionsCalculator
       contributions_by_filer_id[filer_id] += result['Amount_A'].to_f
     end
 
+    # NOTE: We remove duplicate transactions on 497 that are also reported on
+    # Schedule A during a preprocssing script. (See
+    # `./../remove_duplicate_transactionts.sh`)
     late_results = ActiveRecord::Base.connection.execute(<<-SQL)
       SELECT "Filer_ID", SUM("Amount") AS "Total"
       FROM "efile_COAK_2016_497"
@@ -38,10 +41,6 @@ class TotalContributionsCalculator
       contributions_by_filer_id[filer_id] ||= 0
       contributions_by_filer_id[filer_id] += result['Total'].to_f
     end
-
-    # TODO: We will have to remove any late_results that are also included on
-    # the Schedule A since they are included in the Summary's "Total
-    # Contributions" line item if reported on Schedule A.
 
     contributions_by_filer_id.each do |filer_id, total_contributions|
       candidate = @candidates_by_filer_id[filer_id]

--- a/remove_duplicate_transactions.sh
+++ b/remove_duplicate_transactions.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# 1. delete duplicate A/497 contributions
+cat <<-QUERY | psql disclosure-backend
+DELETE FROM "efile_COAK_2016_497"
+USING "efile_COAK_2016_A-Contributions" contributions
+WHERE contributions."Filer_ID"::varchar = "efile_COAK_2016_497"."Filer_ID"::varchar
+AND contributions."Tran_ID" = "efile_COAK_2016_497"."Tran_ID"
+AND "efile_COAK_2016_497"."Form_Type" = 'F497P1';
+QUERY
+
+# 2. delete duplicate E/497 expenditures
+cat <<-QUERY | psql disclosure-backend
+DELETE FROM "efile_COAK_2016_497"
+USING "efile_COAK_2016_E-Expenditure" expenditures
+WHERE expenditures."Filer_ID"::varchar = "efile_COAK_2016_497"."Filer_ID"::varchar
+AND expenditures."Tran_ID" = "efile_COAK_2016_497"."Tran_ID"
+AND "efile_COAK_2016_497"."Form_Type" = 'F497P2';
+QUERY


### PR DESCRIPTION
This adds a pre-processing step which removes duplicate transactions on the 497 with Schedule A and Schedule E. It does this by assuming that for a given Filer_ID, the Trans_ID will be the same on Schedule A and 497 if the transaction is duplicated.

We probably need to do this with 496 too, but 497 is more pressing.

cc @mikeubell @michaelliu2 