### PR TITLE
Fix accidentally using only one committee's referendum total

### DIFF
--- a/build/ballot/1/index.json
+++ b/build/ballot/1/index.json
@@ -147,12 +147,12 @@
           "party_affiliation": "Democrat",
           "filer_id": 1375179,
           "supporting_money": {
-            "contributions_received": 53706.08,
-            "total_contributions": 53706.08,
+            "contributions_received": 52306.08,
+            "total_contributions": 52306.08,
             "total_expenditures": 26680.4,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 6300.0,
+              "Committee": 4900.0,
               "Individual": 33483.16,
               "Unitemized": 2722.92,
               "Other (includes Businesses)": 11200.0
@@ -172,12 +172,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 53706.08,
-          "total_contributions": 53706.08,
+          "contributions_received": 52306.08,
+          "total_contributions": 52306.08,
           "total_expenditures": 26680.4,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 6300.0,
+            "Committee": 4900.0,
             "Individual": 33483.16,
             "Unitemized": 2722.92,
             "Other (includes Businesses)": 11200.0
@@ -1045,12 +1045,12 @@
           "party_affiliation": null,
           "filer_id": 1387905,
           "supporting_money": {
-            "contributions_received": 39776.0,
-            "total_contributions": 39776.0,
+            "contributions_received": 38376.0,
+            "total_contributions": 38376.0,
             "total_expenditures": 4952.89,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 1930.0,
+              "Committee": 530.0,
               "Individual": 30550.0,
               "Unitemized": 496.0,
               "Other (includes Businesses)": 6800.0
@@ -1064,12 +1064,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 39776.0,
-          "total_contributions": 39776.0,
+          "contributions_received": 38376.0,
+          "total_contributions": 38376.0,
           "total_expenditures": 4952.89,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 1930.0,
+            "Committee": 530.0,
             "Individual": 30550.0,
             "Unitemized": 496.0,
             "Other (includes Businesses)": 6800.0
@@ -1391,6 +1391,7 @@
               "Other (includes Businesses)": 6400.0
             },
             "expenditures_by_type": {
+              "Not Stated": 3685.75,
               "Campaign Paraphernalia/Misc.": 4162.06,
               "Campaign Literature and Mailings": 6000.0
             }
@@ -1409,6 +1410,7 @@
             "Other (includes Businesses)": 6400.0
           },
           "expenditures_by_type": {
+            "Not Stated": 3685.75,
             "Campaign Paraphernalia/Misc.": 4162.06,
             "Campaign Literature and Mailings": 6000.0
           }

--- a/build/candidate/11/index.json
+++ b/build/candidate/11/index.json
@@ -27,6 +27,7 @@
       "Other (includes Businesses)": 6400.0
     },
     "expenditures_by_type": {
+      "Not Stated": 3685.75,
       "Campaign Paraphernalia/Misc.": 4162.06,
       "Campaign Literature and Mailings": 6000.0
     }
@@ -45,6 +46,7 @@
     "Other (includes Businesses)": 6400.0
   },
   "expenditures_by_type": {
+    "Not Stated": 3685.75,
     "Campaign Paraphernalia/Misc.": 4162.06,
     "Campaign Literature and Mailings": 6000.0
   }

--- a/build/candidate/11/opposing/index.json
+++ b/build/candidate/11/opposing/index.json
@@ -27,6 +27,7 @@
       "Other (includes Businesses)": 6400.0
     },
     "expenditures_by_type": {
+      "Not Stated": 3685.75,
       "Campaign Paraphernalia/Misc.": 4162.06,
       "Campaign Literature and Mailings": 6000.0
     }
@@ -45,6 +46,7 @@
     "Other (includes Businesses)": 6400.0
   },
   "expenditures_by_type": {
+    "Not Stated": 3685.75,
     "Campaign Paraphernalia/Misc.": 4162.06,
     "Campaign Literature and Mailings": 6000.0
   }

--- a/build/candidate/11/supporting/index.json
+++ b/build/candidate/11/supporting/index.json
@@ -27,6 +27,7 @@
       "Other (includes Businesses)": 6400.0
     },
     "expenditures_by_type": {
+      "Not Stated": 3685.75,
       "Campaign Paraphernalia/Misc.": 4162.06,
       "Campaign Literature and Mailings": 6000.0
     }
@@ -45,6 +46,7 @@
     "Other (includes Businesses)": 6400.0
   },
   "expenditures_by_type": {
+    "Not Stated": 3685.75,
     "Campaign Paraphernalia/Misc.": 4162.06,
     "Campaign Literature and Mailings": 6000.0
   }

--- a/build/candidate/15/index.json
+++ b/build/candidate/15/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1387905,
   "supporting_money": {
-    "contributions_received": 39776.0,
-    "total_contributions": 39776.0,
+    "contributions_received": 38376.0,
+    "total_contributions": 38376.0,
     "total_expenditures": 4952.89,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 1930.0,
+      "Committee": 530.0,
       "Individual": 30550.0,
       "Unitemized": 496.0,
       "Other (includes Businesses)": 6800.0
@@ -35,12 +35,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 39776.0,
-  "total_contributions": 39776.0,
+  "contributions_received": 38376.0,
+  "total_contributions": 38376.0,
   "total_expenditures": 4952.89,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 1930.0,
+    "Committee": 530.0,
     "Individual": 30550.0,
     "Unitemized": 496.0,
     "Other (includes Businesses)": 6800.0

--- a/build/candidate/15/opposing/index.json
+++ b/build/candidate/15/opposing/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1387905,
   "supporting_money": {
-    "contributions_received": 39776.0,
-    "total_contributions": 39776.0,
+    "contributions_received": 38376.0,
+    "total_contributions": 38376.0,
     "total_expenditures": 4952.89,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 1930.0,
+      "Committee": 530.0,
       "Individual": 30550.0,
       "Unitemized": 496.0,
       "Other (includes Businesses)": 6800.0
@@ -35,12 +35,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 39776.0,
-  "total_contributions": 39776.0,
+  "contributions_received": 38376.0,
+  "total_contributions": 38376.0,
   "total_expenditures": 4952.89,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 1930.0,
+    "Committee": 530.0,
     "Individual": 30550.0,
     "Unitemized": 496.0,
     "Other (includes Businesses)": 6800.0

--- a/build/candidate/15/supporting/index.json
+++ b/build/candidate/15/supporting/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": null,
   "filer_id": 1387905,
   "supporting_money": {
-    "contributions_received": 39776.0,
-    "total_contributions": 39776.0,
+    "contributions_received": 38376.0,
+    "total_contributions": 38376.0,
     "total_expenditures": 4952.89,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 1930.0,
+      "Committee": 530.0,
       "Individual": 30550.0,
       "Unitemized": 496.0,
       "Other (includes Businesses)": 6800.0
@@ -35,12 +35,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 39776.0,
-  "total_contributions": 39776.0,
+  "contributions_received": 38376.0,
+  "total_contributions": 38376.0,
   "total_expenditures": 4952.89,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 1930.0,
+    "Committee": 530.0,
     "Individual": 30550.0,
     "Unitemized": 496.0,
     "Other (includes Businesses)": 6800.0

--- a/build/candidate/9/index.json
+++ b/build/candidate/9/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": "Democrat",
   "filer_id": 1375179,
   "supporting_money": {
-    "contributions_received": 53706.08,
-    "total_contributions": 53706.08,
+    "contributions_received": 52306.08,
+    "total_contributions": 52306.08,
     "total_expenditures": 26680.4,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 6300.0,
+      "Committee": 4900.0,
       "Individual": 33483.16,
       "Unitemized": 2722.92,
       "Other (includes Businesses)": 11200.0
@@ -41,12 +41,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 53706.08,
-  "total_contributions": 53706.08,
+  "contributions_received": 52306.08,
+  "total_contributions": 52306.08,
   "total_expenditures": 26680.4,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 6300.0,
+    "Committee": 4900.0,
     "Individual": 33483.16,
     "Unitemized": 2722.92,
     "Other (includes Businesses)": 11200.0

--- a/build/candidate/9/opposing/index.json
+++ b/build/candidate/9/opposing/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": "Democrat",
   "filer_id": 1375179,
   "supporting_money": {
-    "contributions_received": 53706.08,
-    "total_contributions": 53706.08,
+    "contributions_received": 52306.08,
+    "total_contributions": 52306.08,
     "total_expenditures": 26680.4,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 6300.0,
+      "Committee": 4900.0,
       "Individual": 33483.16,
       "Unitemized": 2722.92,
       "Other (includes Businesses)": 11200.0
@@ -41,12 +41,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 53706.08,
-  "total_contributions": 53706.08,
+  "contributions_received": 52306.08,
+  "total_contributions": 52306.08,
   "total_expenditures": 26680.4,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 6300.0,
+    "Committee": 4900.0,
     "Individual": 33483.16,
     "Unitemized": 2722.92,
     "Other (includes Businesses)": 11200.0

--- a/build/candidate/9/supporting/index.json
+++ b/build/candidate/9/supporting/index.json
@@ -16,12 +16,12 @@
   "party_affiliation": "Democrat",
   "filer_id": 1375179,
   "supporting_money": {
-    "contributions_received": 53706.08,
-    "total_contributions": 53706.08,
+    "contributions_received": 52306.08,
+    "total_contributions": 52306.08,
     "total_expenditures": 26680.4,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Committee": 6300.0,
+      "Committee": 4900.0,
       "Individual": 33483.16,
       "Unitemized": 2722.92,
       "Other (includes Businesses)": 11200.0
@@ -41,12 +41,12 @@
   "opposing_money": {
     "contributions_received": 0
   },
-  "contributions_received": 53706.08,
-  "total_contributions": 53706.08,
+  "contributions_received": 52306.08,
+  "total_contributions": 52306.08,
   "total_expenditures": 26680.4,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Committee": 6300.0,
+    "Committee": 4900.0,
     "Individual": 33483.16,
     "Unitemized": 2722.92,
     "Other (includes Businesses)": 11200.0

--- a/build/committee/1375179/contributions/index.json
+++ b/build/committee/1375179/contributions/index.json
@@ -120,15 +120,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-25",
+    "Tran_Amt1": -100.0,
+    "Tran_Date": "2016-07-27",
     "Tran_NamF": "Elaine",
     "Tran_NamL": "Brown"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": -100.0,
-    "Tran_Date": "2016-07-27",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-25",
     "Tran_NamF": "Elaine",
     "Tran_NamL": "Brown"
   },
@@ -309,15 +309,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 118.04,
-    "Tran_Date": "2016-04-22",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-29",
     "Tran_NamF": "Donald",
     "Tran_NamL": "Gilmore"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-29",
+    "Tran_Amt1": 118.04,
+    "Tran_Date": "2016-04-22",
     "Tran_NamF": "Donald",
     "Tran_NamL": "Gilmore"
   },
@@ -505,15 +505,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-30",
     "Tran_NamF": null,
     "Tran_NamL": "Keith Carson For Alameda County Supervisor"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-30",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "Keith Carson For Alameda County Supervisor"
   },
@@ -589,13 +589,6 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1375179",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-04-27",
     "Tran_NamF": "Yui Hay",
@@ -606,6 +599,13 @@
     "Tran_Amt1": -700.0,
     "Tran_Date": "2016-06-17",
     "Tran_NamF": "Yui Hay",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Jeffrey",
     "Tran_NamL": "Lee"
   },
   {
@@ -638,6 +638,13 @@
   },
   {
     "Filer_ID": "1375179",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Larry",
+    "Tran_NamL": "Manning"
+  },
+  {
+    "Filer_ID": "1375179",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "Larry",
@@ -647,13 +654,6 @@
     "Filer_ID": "1375179",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Larry",
-    "Tran_NamL": "Manning"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-29",
     "Tran_NamF": "Larry",
     "Tran_NamL": "Manning"
   },
@@ -733,13 +733,6 @@
     "Tran_Date": "2016-09-22",
     "Tran_NamF": null,
     "Tran_NamL": "Northern California Construction Teamsters PAC"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce (OakPAC)"
   },
   {
     "Filer_ID": "1375179",

--- a/build/committee/1381041/contributions/index.json
+++ b/build/committee/1381041/contributions/index.json
@@ -29,15 +29,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-29",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-25",
     "Tran_NamF": "VICKI",
     "Tran_NamL": "ALEXANDER"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-25",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-29",
     "Tran_NamF": "VICKI",
     "Tran_NamL": "ALEXANDER"
   },
@@ -71,6 +71,20 @@
   },
   {
     "Filer_ID": "1381041",
+    "Tran_Amt1": 504040.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 348155.5,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
     "Tran_Amt1": 440955.5,
     "Tran_Date": "2016-08-31",
     "Tran_NamF": "MICHAEL",
@@ -85,13 +99,6 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 348155.5,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
     "Tran_Amt1": 487496.5,
     "Tran_Date": "2016-09-14",
     "Tran_NamF": "MICHAEL",
@@ -101,13 +108,6 @@
     "Filer_ID": "1381041",
     "Tran_Amt1": 75000.0,
     "Tran_Date": "2016-07-14",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 504040.0,
-    "Tran_Date": "2016-09-27",
     "Tran_NamF": "MICHAEL",
     "Tran_NamL": "BLOOMBERG"
   },
@@ -296,14 +296,14 @@
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
+    "Tran_Date": "2016-06-27",
     "Tran_NamF": "EILEEN",
     "Tran_NamL": "ESPEJO"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-27",
+    "Tran_Date": "2016-09-09",
     "Tran_NamF": "EILEEN",
     "Tran_NamL": "ESPEJO"
   },
@@ -533,15 +533,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-21",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-18",
     "Tran_NamF": "KAREN",
     "Tran_NamL": "MERYASH"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-18",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-21",
     "Tran_NamF": "KAREN",
     "Tran_NamL": "MERYASH"
   },
@@ -565,13 +565,6 @@
     "Tran_Date": "2016-09-02",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "MEYERS"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "OAKLAND POLICE OFFICERS ASSOCIATION POLITICAL ACTION COMMITTEE"
   },
   {
     "Filer_ID": "1381041",
@@ -687,8 +680,8 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-03-23",
+    "Tran_Amt1": 80.0,
+    "Tran_Date": "2016-06-24",
     "Tran_NamF": "LYNN",
     "Tran_NamL": "SILVER"
   },
@@ -701,8 +694,8 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-06-24",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-03-23",
     "Tran_NamF": "LYNN",
     "Tran_NamL": "SILVER"
   },

--- a/build/committee/1387905/contributions/index.json
+++ b/build/committee/1387905/contributions/index.json
@@ -24,14 +24,14 @@
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Kate",
+    "Tran_NamF": "Peggy",
     "Tran_NamL": "Arenchild"
   },
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Peggy",
+    "Tran_NamF": "Kate",
     "Tran_NamL": "Arenchild"
   },
   {
@@ -285,13 +285,6 @@
     "Tran_Date": "2016-09-24",
     "Tran_NamF": null,
     "Tran_NamL": "OKP Land Holdings LLC"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce (OakPAC)"
   },
   {
     "Filer_ID": "1387905",

--- a/build/committee/1387983/contributions/index.json
+++ b/build/committee/1387983/contributions/index.json
@@ -57,13 +57,6 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bridge Housing Corporation"
-  },
-  {
-    "Filer_ID": "1387983",
     "Tran_Amt1": 120.0,
     "Tran_Date": "2016-09-01",
     "Tran_NamF": "Abbigail",
@@ -82,13 +75,6 @@
     "Tran_Date": "2016-08-29",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Cashman"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "Condon-Johnson And Associates, Inc."
   },
   {
     "Filer_ID": "1387983",
@@ -218,13 +204,6 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "O.C. Jones & Sons, Inc. General Engineering Contractor"
-  },
-  {
-    "Filer_ID": "1387983",
     "Tran_Amt1": 10000.0,
     "Tran_Date": "2016-09-29",
     "Tran_NamF": null,
@@ -236,13 +215,6 @@
     "Tran_Date": "2016-09-27",
     "Tran_NamF": "Alexis",
     "Tran_NamL": "Pelosi"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "Redgwick Construction Company"
   },
   {
     "Filer_ID": "1387983",

--- a/build/locality/2/current_ballot/index.json
+++ b/build/locality/2/current_ballot/index.json
@@ -147,12 +147,12 @@
           "party_affiliation": "Democrat",
           "filer_id": 1375179,
           "supporting_money": {
-            "contributions_received": 53706.08,
-            "total_contributions": 53706.08,
+            "contributions_received": 52306.08,
+            "total_contributions": 52306.08,
             "total_expenditures": 26680.4,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 6300.0,
+              "Committee": 4900.0,
               "Individual": 33483.16,
               "Unitemized": 2722.92,
               "Other (includes Businesses)": 11200.0
@@ -172,12 +172,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 53706.08,
-          "total_contributions": 53706.08,
+          "contributions_received": 52306.08,
+          "total_contributions": 52306.08,
           "total_expenditures": 26680.4,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 6300.0,
+            "Committee": 4900.0,
             "Individual": 33483.16,
             "Unitemized": 2722.92,
             "Other (includes Businesses)": 11200.0
@@ -1045,12 +1045,12 @@
           "party_affiliation": null,
           "filer_id": 1387905,
           "supporting_money": {
-            "contributions_received": 39776.0,
-            "total_contributions": 39776.0,
+            "contributions_received": 38376.0,
+            "total_contributions": 38376.0,
             "total_expenditures": 4952.89,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Committee": 1930.0,
+              "Committee": 530.0,
               "Individual": 30550.0,
               "Unitemized": 496.0,
               "Other (includes Businesses)": 6800.0
@@ -1064,12 +1064,12 @@
           "opposing_money": {
             "contributions_received": 0
           },
-          "contributions_received": 39776.0,
-          "total_contributions": 39776.0,
+          "contributions_received": 38376.0,
+          "total_contributions": 38376.0,
           "total_expenditures": 4952.89,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Committee": 1930.0,
+            "Committee": 530.0,
             "Individual": 30550.0,
             "Unitemized": 496.0,
             "Other (includes Businesses)": 6800.0
@@ -1391,6 +1391,7 @@
               "Other (includes Businesses)": 6400.0
             },
             "expenditures_by_type": {
+              "Not Stated": 3685.75,
               "Campaign Paraphernalia/Misc.": 4162.06,
               "Campaign Literature and Mailings": 6000.0
             }
@@ -1409,6 +1410,7 @@
             "Other (includes Businesses)": 6400.0
           },
           "expenditures_by_type": {
+            "Not Stated": 3685.75,
             "Campaign Paraphernalia/Misc.": 4162.06,
             "Campaign Literature and Mailings": 6000.0
           }

--- a/build/office_election/10/index.json
+++ b/build/office_election/10/index.json
@@ -32,6 +32,7 @@
           "Other (includes Businesses)": 6400.0
         },
         "expenditures_by_type": {
+          "Not Stated": 3685.75,
           "Campaign Paraphernalia/Misc.": 4162.06,
           "Campaign Literature and Mailings": 6000.0
         }
@@ -50,6 +51,7 @@
         "Other (includes Businesses)": 6400.0
       },
       "expenditures_by_type": {
+        "Not Stated": 3685.75,
         "Campaign Paraphernalia/Misc.": 4162.06,
         "Campaign Literature and Mailings": 6000.0
       }

--- a/build/office_election/2/index.json
+++ b/build/office_election/2/index.json
@@ -21,12 +21,12 @@
       "party_affiliation": "Democrat",
       "filer_id": 1375179,
       "supporting_money": {
-        "contributions_received": 53706.08,
-        "total_contributions": 53706.08,
+        "contributions_received": 52306.08,
+        "total_contributions": 52306.08,
         "total_expenditures": 26680.4,
         "total_loans_received": 0.0,
         "contributions_by_type": {
-          "Committee": 6300.0,
+          "Committee": 4900.0,
           "Individual": 33483.16,
           "Unitemized": 2722.92,
           "Other (includes Businesses)": 11200.0
@@ -46,12 +46,12 @@
       "opposing_money": {
         "contributions_received": 0
       },
-      "contributions_received": 53706.08,
-      "total_contributions": 53706.08,
+      "contributions_received": 52306.08,
+      "total_contributions": 52306.08,
       "total_expenditures": 26680.4,
       "total_loans_received": 0.0,
       "contributions_by_type": {
-        "Committee": 6300.0,
+        "Committee": 4900.0,
         "Individual": 33483.16,
         "Unitemized": 2722.92,
         "Other (includes Businesses)": 11200.0

--- a/build/office_election/7/index.json
+++ b/build/office_election/7/index.json
@@ -113,12 +113,12 @@
       "party_affiliation": null,
       "filer_id": 1387905,
       "supporting_money": {
-        "contributions_received": 39776.0,
-        "total_contributions": 39776.0,
+        "contributions_received": 38376.0,
+        "total_contributions": 38376.0,
         "total_expenditures": 4952.89,
         "total_loans_received": 0.0,
         "contributions_by_type": {
-          "Committee": 1930.0,
+          "Committee": 530.0,
           "Individual": 30550.0,
           "Unitemized": 496.0,
           "Other (includes Businesses)": 6800.0
@@ -132,12 +132,12 @@
       "opposing_money": {
         "contributions_received": 0
       },
-      "contributions_received": 39776.0,
-      "total_contributions": 39776.0,
+      "contributions_received": 38376.0,
+      "total_contributions": 38376.0,
       "total_expenditures": 4952.89,
       "total_loans_received": 0.0,
       "contributions_by_type": {
-        "Committee": 1930.0,
+        "Committee": 530.0,
         "Individual": 30550.0,
         "Unitemized": 496.0,
         "Other (includes Businesses)": 6800.0

--- a/build/referendum/1/supporting/index.json
+++ b/build/referendum/1/supporting/index.json
@@ -13,7 +13,7 @@
       "amount": 114655.46
     }
   ],
-  "total_contributions": 2428442.5,
+  "total_contributions": 2423442.5,
   "contributions_by_region": [
     {
       "amount": 2357002.5,
@@ -24,7 +24,7 @@
       "locale": "Within California"
     },
     {
-      "amount": 48630.0,
+      "amount": 43630.0,
       "locale": "Within Oakland"
     }
   ]

--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -19,18 +19,18 @@
       "amount": 143330.76
     }
   ],
-  "total_contributions": 216354.63,
+  "total_contributions": 261754.63,
   "contributions_by_region": [
     {
       "amount": 4000.0,
       "locale": "Out of State"
     },
     {
-      "amount": 4500.0,
+      "amount": 48900.0,
       "locale": "Within California"
     },
     {
-      "amount": 207854.63,
+      "amount": 208854.63,
       "locale": "Within Oakland"
     }
   ]

--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -16,7 +16,7 @@
       "id": "1385949",
       "name": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "payee": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
-      "amount": 145927.24
+      "amount": 143330.76
     }
   ],
   "total_contributions": 216354.63,

--- a/build/referendum/4/supporting/index.json
+++ b/build/referendum/4/supporting/index.json
@@ -13,18 +13,18 @@
       "amount": 24683.59
     }
   ],
-  "total_contributions": 229215.78,
+  "total_contributions": 209715.78,
   "contributions_by_region": [
     {
       "amount": 5000.0,
       "locale": "Out of State"
     },
     {
-      "amount": 75600.0,
+      "amount": 58600.0,
       "locale": "Within California"
     },
     {
-      "amount": 148615.78,
+      "amount": 146115.78,
       "locale": "Within Oakland"
     }
   ]

--- a/calculators/referendum_expenditures_by_origin.rb
+++ b/calculators/referendum_expenditures_by_origin.rb
@@ -36,7 +36,7 @@ class ReferendumExpendituresByOrigin
         expenditures."Measure_Number",
         expenditures."Sup_Opp_Cd",
         contributions_by_locale.locale,
-        contributions_by_locale.total
+        SUM(contributions_by_locale.total) as total
       FROM (
         SELECT DISTINCT "Filer_ID", "Measure_Number", "Sup_Opp_Cd"
         FROM "efile_COAK_2016_E-Expenditure"
@@ -71,13 +71,15 @@ class ReferendumExpendituresByOrigin
           SELECT "Filer_ID"::varchar,
             "Enty_City" as "Tran_City",
             "Enty_ST" as "Tran_State",
-            "Amount" as "Tran_Amt1", "Tran_ID"
+            "Amount" as "Tran_Amt1",
+            "Tran_ID"
           FROM "efile_COAK_2016_497"
           WHERE "Form_Type" = 'F497P1'
         ) contributions
         GROUP BY "Filer_ID", locale
       ) contributions_by_locale
       WHERE expenditures."Filer_ID" = contributions_by_locale."Filer_ID"
+      GROUP BY expenditures."Measure_Number", expenditures."Sup_Opp_Cd", contributions_by_locale.locale
       ORDER BY expenditures."Measure_Number", expenditures."Sup_Opp_Cd", contributions_by_locale.locale;
     SQL
 


### PR DESCRIPTION
The inner query returned possibly multiple rows per ballot measure (one
row per committee, since the inner query groups by Filer_ID). This means
we would iterate through the results and take only the last total.

Changing the query to no longer GROUP BY Filer_ID seems to have brought
the total for our most-incorrect ballot measure more in-line with
reality.

Fixes #53 