### PR TITLE
Clean up ballot measure expenditures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ import: inputs/efile_COAK_2016_A-Contributions.csv inputs/oakland_candidates.csv
 	echo 'ALTER TABLE "oakland_committees" ADD COLUMN id SERIAL PRIMARY KEY;' | psql disclosure-backend
 	echo 'CREATE TABLE "office_elections" (id SERIAL PRIMARY KEY, name VARCHAR(255));' | psql disclosure-backend
 	echo 'CREATE TABLE "calculations" (id SERIAL PRIMARY KEY, subject_id integer, subject_type varchar(30), name varchar(40), value jsonb);' | psql disclosure-backend
+	./make_view.sh
 	./latest_only.sh efile_COAK_2016_496
 	./latest_only.sh efile_COAK_2016_497
 	./latest_only.sh efile_COAK_2016_A-Contributions

--- a/build/committee/1362261/contributions/index.json
+++ b/build/committee/1362261/contributions/index.json
@@ -1,0 +1,884 @@
+[
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "2 FB, Inc."
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "Willam",
+    "Tran_NamL": "Abbott"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Ablon"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-20",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Alexander"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Alexander"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Annalee",
+    "Tran_NamL": "Allen"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "Roy",
+    "Tran_NamL": "Alper"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "American Foy Larue Inc."
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Tim",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-17",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Anthony"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Avery"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Justin",
+    "Tran_NamL": "Bank"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Barr"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Base Ventures LLC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bay Area Citizens PAC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Rochelle",
+    "Tran_NamL": "Benning"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "Shefali",
+    "Tran_NamL": "Billon"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "Larry",
+    "Tran_NamL": "Bodner"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Catherine",
+    "Tran_NamL": "Bracy"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Liz",
+    "Tran_NamL": "Brisson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Matt",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Pam",
+    "Tran_NamL": "Clemmons"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Colbruno"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Ralph",
+    "Tran_NamL": "Cooke Iii"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Core Security Solutions, LLC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Cox"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Cranston"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "DMC Real Estate Consulting LLC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-20",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Davies"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Sean",
+    "Tran_NamL": "Donahoe"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Douglas"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Dreisbach"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Marianne",
+    "Tran_NamL": "Dreisbach"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Jean",
+    "Tran_NamL": "Driscoll"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 1300.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Drive Committee"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Lori",
+    "Tran_NamL": "Durbin"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Matt",
+    "Tran_NamL": "Ewing"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Avril",
+    "Tran_NamL": "Fitzgerald"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-21",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Jennie",
+    "Tran_NamL": "Gerard"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Gooding"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Greenfield"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Charlie",
+    "Tran_NamL": "Hale"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Haley"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Harden"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Renee",
+    "Tran_NamL": "Heider"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Julie",
+    "Tran_NamL": "Hess"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Heywood"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Holmgren"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Hopkins"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Victoria",
+    "Tran_NamL": "Howell"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 1300.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Association of Firefighters, Local 55 PAC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 750.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Federation of Professional and Technical Engineers (IFPTE) Local 21 TJ Anthony PAC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Ireland"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Jessee"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Vivian",
+    "Tran_NamL": "Kahn"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Joanne",
+    "Tran_NamL": "Karchmer"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Kershaw"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Jack",
+    "Tran_NamL": "Klingelhofer"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Isaac",
+    "Tran_NamL": "Kos-Read"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Lacaunoguera"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Vincent",
+    "Tran_NamL": "Leung"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Mia",
+    "Tran_NamL": "Levy"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Levy"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Terrance",
+    "Tran_NamL": "Lim"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Pelayo A.",
+    "Tran_NamL": "Llamas Jr."
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Lyman"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Monica",
+    "Tran_NamL": "Marcone"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Marshall"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Arabella",
+    "Tran_NamL": "Martinez"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Arabella",
+    "Tran_NamL": "Martinez"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Mcpherson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Lloyd Kirk",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Arpad",
+    "Tran_NamL": "Molnar"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Susanne",
+    "Tran_NamL": "Monson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Helen",
+    "Tran_NamL": "Nicholas"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Nye"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "O'Malley"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Timothy",
+    "Tran_NamL": "O'Reilly"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Jen",
+    "Tran_NamL": "Pahlka"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "ParkSmart, Inc."
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Peterson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Erich",
+    "Tran_NamL": "Pfuehler"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Moon",
+    "Tran_NamL": "Pham"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Bill",
+    "Tran_NamL": "Phua"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Lisa",
+    "Tran_NamL": "Pingatore"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Plumbers and Steamfitters Union Local 342 PAC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Allyson",
+    "Tran_NamL": "Purcell"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Reenie",
+    "Tran_NamL": "Raschke"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Rasmussen"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Lee",
+    "Tran_NamL": "Richter"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Rick",
+    "Tran_NamL": "Rickard"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Jim",
+    "Tran_NamL": "Ross"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Lorraine",
+    "Tran_NamL": "Sadler"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Sanchez"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Priya",
+    "Tran_NamL": "Sanger"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Schaaf Schock"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Melissa",
+    "Tran_NamL": "Schoen"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Ralph",
+    "Tran_NamL": "Sklar"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Christina",
+    "Tran_NamL": "Stearns"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Stephens"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Story"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Stroup"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "Miye",
+    "Tran_NamL": "Takagi"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Tawasha"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Becky",
+    "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "The Next Generation"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Alexandra Yolles",
+    "Tran_NamL": "Thede"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Christian",
+    "Tran_NamL": "Thede"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Tina",
+    "Tran_NamL": "Thomas"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Kim",
+    "Tran_NamL": "Thompson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Brook",
+    "Tran_NamL": "Turner"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "United Food & Commercial Workers Local 5 PAC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Phillip",
+    "Tran_NamL": "Usher"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Danny",
+    "Tran_NamL": "Wan"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Nanine",
+    "Tran_NamL": "Watson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Webber"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Terri",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "YHLA Architects Inc."
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Zimmer"
+  }
+]

--- a/build/committee/1362261/index.json
+++ b/build/committee/1362261/index.json
@@ -1,0 +1,11 @@
+{
+  "id": 43,
+  "filer_id": "1362261",
+  "name": "Mayor Libby Schaaf 2014 Officeholder Committee",
+  "website_url": null,
+  "city": null,
+  "committee_type": null,
+  "description": null,
+  "ballot_measure": null,
+  "facebook": null
+}

--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -7,19 +7,19 @@
   "number": "JJ",
   "supporting_organizations": [
     {
-      "id": "1364564",
-      "name": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
-      "payee": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
-      "amount": 158964.4
-    },
-    {
       "id": "1385949",
       "name": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "payee": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "amount": 146105.24
+    },
+    {
+      "id": "1364564",
+      "name": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
+      "payee": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
+      "amount": 158964.4
     }
   ],
-  "total_contributions": 261754.63,
+  "total_contributions": 299698.92,
   "contributions_by_region": [
     {
       "amount": 4000.0,
@@ -32,6 +32,10 @@
     {
       "amount": 208854.63,
       "locale": "Within Oakland"
+    },
+    {
+      "amount": 37944.28999999998,
+      "locale": "Unknown"
     }
   ]
 }

--- a/build/referendum/5/supporting/index.json
+++ b/build/referendum/5/supporting/index.json
@@ -10,7 +10,7 @@
       "id": "1386145",
       "name": "Coalition for Police Accountability Yes on LL",
       "payee": "Coalition for Police Accountability Yes on LL",
-      "amount": 0.0
+      "amount": 4956.64
     }
   ],
   "total_contributions": 9891.5,

--- a/build/referendum/6/supporting/index.json
+++ b/build/referendum/6/supporting/index.json
@@ -10,13 +10,22 @@
       "id": "1331137",
       "name": "Families and Educators for Public Education, Sponsored by Go Public Schools Advocates",
       "payee": "Families and Educators for Public Education, Sponsored by Go Public Schools Advocates",
-      "amount": 2327.63
+      "amount": 5327.63
     }
   ],
-  "total_contributions": [
-
-  ],
+  "total_contributions": 147246.01,
   "contributions_by_region": [
-
+    {
+      "amount": 641.63,
+      "locale": "Out of State"
+    },
+    {
+      "amount": 72376.87,
+      "locale": "Within California"
+    },
+    {
+      "amount": 74227.51,
+      "locale": "Within Oakland"
+    }
   ]
 }

--- a/calculators/referendum_expenditures_by_origin.rb
+++ b/calculators/referendum_expenditures_by_origin.rb
@@ -10,24 +10,7 @@ class ReferendumExpendituresByOrigin
     # then the remainder will be from "Unknown" locale.
     expenditures = ActiveRecord::Base.connection.execute(<<-SQL)
       SELECT "Measure_Number", "Sup_Opp_Cd", sum("Amount") AS total
-      FROM
-      (
-        SELECT "Measure_Number", "Sup_Opp_Cd", "Amount"
-        FROM
-          "efile_COAK_2016_E-Expenditure", oakland_name_to_number
-        WHERE LOWER("Bal_Name") = LOWER("Measure_Name")
-        AND "Cmte_ID" IS NULL
-        AND "Sup_Opp_Cd" IS NOT NULL
-        UNION ALL
-        SELECT "Ballot_Measure" as "Measure_Number",
-          "Support_Or_Oppose" as "Sup_Opp_Cd", "Amount"
-        FROM
-          "efile_COAK_2016_E-Expenditure" expend,
-          oakland_committees committee
-        WHERE "Sup_Opp_Cd" IS NULL
-          AND expend."Filer_ID" = committee."Filer_ID"
-          AND "Ballot_Measure" IS NOT NULL
-      ) AS U
+      FROM "Measure_Expenditures"
       GROUP BY "Measure_Number", "Sup_Opp_Cd"
     SQL
 
@@ -39,19 +22,7 @@ class ReferendumExpendituresByOrigin
         SUM(contributions_by_locale.total) as total
       FROM (
         SELECT DISTINCT "Filer_ID", "Measure_Number", "Sup_Opp_Cd"
-        FROM "efile_COAK_2016_E-Expenditure"
-        INNER JOIN oakland_name_to_number
-          ON LOWER("Bal_Name") = LOWER("Measure_Name")
-        WHERE "Bal_Name" IS NOT NULL
-        UNION ALL
-        SELECT DISTINCT expend."Filer_ID", "Ballot_Measure" as "Measure_Number",
-          "Support_Or_Oppose" as "Sup_Opp_Cd"
-        FROM
-          "efile_COAK_2016_E-Expenditure" expend,
-          oakland_committees committee
-        WHERE "Sup_Opp_Cd" IS NULL
-          AND expend."Filer_ID" = committee."Filer_ID"
-          AND "Ballot_Measure" IS NOT NULL
+        FROM "Measure_Expenditures"
       ) expenditures,
       (
         SELECT "Filer_ID",

--- a/calculators/referendum_supporters_calculator.rb
+++ b/calculators/referendum_supporters_calculator.rb
@@ -8,31 +8,10 @@ class ReferendumSupportersCalculator
   def fetch
     # UNION Schedle E with the 24-Hour IEs from 496.
     expenditures = ActiveRecord::Base.connection.execute(<<-SQL)
-      SELECT "Filer_ID"::varchar, "Filer_NamL", "Measure_Number", "Bal_Name", "Sup_Opp_Cd",
+      SELECT "Filer_ID", "Filer_NamL", "Measure_Number", "Bal_Name", "Sup_Opp_Cd",
         SUM("Amount") AS "Total_Amount"
-      FROM (
-        SELECT "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd", "Amount"
-        FROM "efile_COAK_2016_E-Expenditure"
-        WHERE "Bal_Name" IS NOT NULL
-        UNION ALL
-        SELECT "Filer_ID"::varchar, "Filer_NamL", "Bal_Name", "Sup_Opp_Cd", "Amount"
-        FROM "efile_COAK_2016_496"
-        WHERE "Bal_Name" IS NOT NULL
-      ) as U LEFT OUTER JOIN "oakland_name_to_number"
-      ON LOWER(U."Bal_Name") = LOWER("Measure_Name")
-      GROUP BY "Filer_ID", "Measure_Number", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd"
-
-      UNION ALL
-      SELECT "Filer_ID"::varchar, "Filer_NamL",
-        "Measure_Number", "Bal_Name", 'Unknown' as "Sup_Opp_Cd",
-        SUM("Amount") AS "Total_Amount"
-      FROM "efile_COAK_2016_497" LEFT OUTER JOIN "oakland_name_to_number"
-      ON LOWER("Bal_Name") = LOWER("Measure_Name")
-      WHERE "Bal_Name" IS NOT NULL
-      AND "Form_Type" = 'F497P2'
-      GROUP BY "Filer_ID", "Measure_Number", "Filer_NamL", "Bal_Name"
-
-      ORDER BY "Filer_ID", "Filer_NamL"
+      FROM "Measure_Expenditures"
+      GROUP BY "Filer_ID", "Filer_NamL", "Measure_Number", "Bal_Name", "Sup_Opp_Cd"
     SQL
 
     supporting_by_measure_name = {}
@@ -41,7 +20,6 @@ class ReferendumSupportersCalculator
     expenditures.each do |row|
       committee = committee_from_expenditure(row)
       bal_num = row['Measure_Number']
-      printf("%s %s %s\n", bal_num, row['Bal_Name'], row['Sup_Opp_Cd'])
 
       unless bal_num
         $stderr.puts "COULD NOT FIND BALLOT MEASURE: #{row['Bal_Name'].inspect}"
@@ -59,7 +37,6 @@ class ReferendumSupportersCalculator
       end
 
       if row['Sup_Opp_Cd'] == 'S'
-        printf("S:%s %s\n", bal_num, row['Bal_Name'])
         supporting_by_measure_name[bal_num] ||= {}
         supporting_by_measure_name[bal_num][row['Filer_ID']] ||= {
           id: committee ? committee['Filer_ID'] : nil,

--- a/calculators/referendum_supporters_calculator.rb
+++ b/calculators/referendum_supporters_calculator.rb
@@ -8,7 +8,7 @@ class ReferendumSupportersCalculator
   def fetch
     # UNION Schedle E with the 24-Hour IEs from 496.
     expenditures = ActiveRecord::Base.connection.execute(<<-SQL)
-      SELECT "Filer_ID"::varchar, "Filer_NamL", "Bal_Name", "Sup_Opp_Cd",
+      SELECT "Filer_ID"::varchar, "Filer_NamL", "Measure_Number", "Bal_Name", "Sup_Opp_Cd",
         SUM("Amount") AS "Total_Amount"
       FROM (
         SELECT "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd", "Amount"
@@ -18,16 +18,19 @@ class ReferendumSupportersCalculator
         SELECT "Filer_ID"::varchar, "Filer_NamL", "Bal_Name", "Sup_Opp_Cd", "Amount"
         FROM "efile_COAK_2016_496"
         WHERE "Bal_Name" IS NOT NULL
-      ) as U
-      GROUP BY "Filer_ID", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd"
+      ) as U LEFT OUTER JOIN "oakland_name_to_number"
+      ON LOWER(U."Bal_Name") = LOWER("Measure_Name")
+      GROUP BY "Filer_ID", "Measure_Number", "Filer_NamL", "Bal_Name", "Sup_Opp_Cd"
 
       UNION ALL
-      SELECT "Filer_ID"::varchar, "Filer_NamL", "Bal_Name", 'Unknown' as "Sup_Opp_Cd",
+      SELECT "Filer_ID"::varchar, "Filer_NamL",
+        "Measure_Number", "Bal_Name", 'Unknown' as "Sup_Opp_Cd",
         SUM("Amount") AS "Total_Amount"
-      FROM "efile_COAK_2016_497"
+      FROM "efile_COAK_2016_497" LEFT OUTER JOIN "oakland_name_to_number"
+      ON LOWER("Bal_Name") = LOWER("Measure_Name")
       WHERE "Bal_Name" IS NOT NULL
       AND "Form_Type" = 'F497P2'
-      GROUP BY "Filer_ID", "Filer_NamL", "Bal_Name"
+      GROUP BY "Filer_ID", "Measure_Number", "Filer_NamL", "Bal_Name"
 
       ORDER BY "Filer_ID", "Filer_NamL"
     SQL
@@ -37,11 +40,12 @@ class ReferendumSupportersCalculator
 
     expenditures.each do |row|
       committee = committee_from_expenditure(row)
-      bal_num = OaklandReferendum.name_to_measure_number(row['Bal_Name'])
+      bal_num = row['Measure_Number']
+      printf("%s %s %s\n", bal_num, row['Bal_Name'], row['Sup_Opp_Cd'])
 
       unless bal_num
         $stderr.puts "COULD NOT FIND BALLOT MEASURE: #{row['Bal_Name'].inspect}"
-        $stderr.puts "  Add it to the lookup keys in models/oakland_referendum.rb"
+        $stderr.puts "  Add it to the Oakland Candidates spreadsheet"
         $stderr.puts "  Debug: #{row.inspect}"
         next
       end
@@ -55,6 +59,7 @@ class ReferendumSupportersCalculator
       end
 
       if row['Sup_Opp_Cd'] == 'S'
+        printf("S:%s %s\n", bal_num, row['Bal_Name'])
         supporting_by_measure_name[bal_num] ||= {}
         supporting_by_measure_name[bal_num][row['Filer_ID']] ||= {
           id: committee ? committee['Filer_ID'] : nil,

--- a/make_view.sh
+++ b/make_view.sh
@@ -1,0 +1,44 @@
+psql disclosure-backend << SQL
+/*
+** View to capture all expenditures for ballot measures.
+** Some committees formed to support/oppose a measure do
+** do not report their expenditures ass supporting/opposing
+** The measure
+*/
+CREATE VIEW "Measure_Expenditures" AS
+-- Map names to numbers as ballot numbers are often missing
+SELECT "Filer_ID"::varchar, "Filer_NamL",
+  "Bal_Name", "Measure_Number", "Sup_Opp_Cd", "Amount"
+FROM
+  "efile_COAK_2016_E-Expenditure", oakland_name_to_number
+WHERE LOWER("Bal_Name") = LOWER("Measure_Name")
+AND "Sup_Opp_Cd" IS NOT NULL
+-- Get IE 
+UNION ALL
+SELECT "Filer_ID"::varchar, "Filer_NamL",
+  "Bal_Name", "Measure_Number", "Sup_Opp_Cd", "Amount"
+FROM
+  "efile_COAK_2016_496", oakland_name_to_number
+WHERE LOWER("Bal_Name") = LOWER("Measure_Name")
+AND "Sup_Opp_Cd" IS NOT NULL
+UNION ALL
+-- Get support/oppose information from committee
+SELECT expend."Filer_ID"::varchar, expend."Filer_NamL",
+  "Bal_Name",
+  "Ballot_Measure" as "Measure_Number",
+  "Support_Or_Oppose" as "Sup_Opp_Cd", "Amount"
+FROM
+  "efile_COAK_2016_E-Expenditure" expend,
+  oakland_committees committee
+WHERE "Sup_Opp_Cd" IS NULL
+  AND expend."Filer_ID" = committee."Filer_ID"
+  AND "Ballot_Measure" IS NOT NULL
+UNION ALL
+-- Get 24hr report expenditures. There is no S/O information!
+SELECT "Filer_ID"::varchar, "Filer_NamL",
+  "Bal_Name", "Measure_Number", 'Unknown' as "Sup_Opp_Cd", "Amount"
+FROM "efile_COAK_2016_497" LEFT OUTER JOIN "oakland_name_to_number"
+ON LOWER("Bal_Name") = LOWER("Measure_Name")
+WHERE "Bal_Name" IS NOT NULL
+AND "Form_Type" = 'F497P2'
+SQL

--- a/models/oakland_referendum.rb
+++ b/models/oakland_referendum.rb
@@ -1,29 +1,4 @@
 class OaklandReferendum < ActiveRecord::Base
-  NETFILE_NAMES_TO_MEASURE_NUMBER = {
-    'City of Oakland Soda Tax' => 'HH',
-    'CITY OF OAKLAND SODA TAX' => 'HH',
-    'MEASURE HH' => 'HH',
-    'SUGAR-SWEETENED DRINKS DISTRIBUTOR TAX' => 'HH',
-
-    'Proposed amendments to residental rent adjustments and evictions ordinance' => 'JJ',
-    'City of Oakland Renters Upgrade Act' => 'JJ',
-
-    'MEASURE G1' => 'G1',
-    "Oakland Infrastructure and Housing Bond Measure" => 'KK',
-    'Investing in Oakland?s Infrastructure and Affordable Housing' => 'KK',
-    'Oversight of Police Department' => 'LL',
-
-    # Non-Oakland measures: (Skip these because we don't want them to collide.)
-    # TODO: scope these ballot measures by jurisdiction
-    "Renewal of the Utility User's Tax, Measure D" => 'SKIP',
-    "Alameda County Affordable Housing Bond" => 'SKIP',
-    "BART Safety, Reliability and Traffic Relief" => 'SKIP',
-  }
-
-  def self.name_to_measure_number(name)
-    NETFILE_NAMES_TO_MEASURE_NUMBER[name]
-  end
-
   has_many :calculations, as: :subject
 
   def calculation(name)


### PR DESCRIPTION
Remove the static ballot measure name to number map and always used the information in the table.
Create a view to standardize the analysis of ballot measure expenditures.