### PR TITLE
Fix referendum spending and contributions

### DIFF
--- a/build/ballot/1/index.json
+++ b/build/ballot/1/index.json
@@ -100,7 +100,7 @@
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 12800.0
+            "opposing_expenditures": 12416.96
           },
           "contributions_received": 70053.66,
           "total_contributions": 70053.66,
@@ -555,7 +555,7 @@
               "Self Funding": 300.0
             },
             "expenditures_by_type": {
-              "Not Stated": 35916.83,
+              "Not Stated": 43846.83,
               "Fundraising Events": 300.8,
               "Campaign Consultants": 2500.0,
               "Campaign Paraphernalia/Misc.": 1095.75,
@@ -577,7 +577,7 @@
             "Self Funding": 300.0
           },
           "expenditures_by_type": {
-            "Not Stated": 35916.83,
+            "Not Stated": 43846.83,
             "Fundraising Events": 300.8,
             "Campaign Consultants": 2500.0,
             "Campaign Paraphernalia/Misc.": 1095.75,
@@ -1004,13 +1004,13 @@
           "party_affiliation": null,
           "filer_id": 1386932,
           "supporting_money": {
-            "contributions_received": 11504.0,
-            "total_contributions": 11504.0,
+            "contributions_received": 13504.0,
+            "total_contributions": 13504.0,
             "total_expenditures": 2774.63,
             "total_loans_received": 0.0,
             "contributions_by_type": {
               "Committee": 1700.0,
-              "Individual": 8650.0,
+              "Individual": 10650.0,
               "Unitemized": 1154.0
             },
             "expenditures_by_type": {
@@ -1020,13 +1020,13 @@
           "opposing_money": {
             "opposing_expenditures": null
           },
-          "contributions_received": 11504.0,
-          "total_contributions": 11504.0,
+          "contributions_received": 13504.0,
+          "total_contributions": 13504.0,
           "total_expenditures": 2774.63,
           "total_loans_received": 0.0,
           "contributions_by_type": {
             "Committee": 1700.0,
-            "Individual": 8650.0,
+            "Individual": 10650.0,
             "Unitemized": 1154.0
           },
           "expenditures_by_type": {
@@ -1271,7 +1271,7 @@
               "Other (includes Businesses)": 1500.0
             },
             "expenditures_by_type": {
-              "Not Stated": 26256.98,
+              "Not Stated": 33276.98,
               "Fundraising Events": 126.9,
               "Voter Registration": 1600.0,
               "Campaign Paraphernalia/Misc.": 856.05,
@@ -1294,7 +1294,7 @@
             "Other (includes Businesses)": 1500.0
           },
           "expenditures_by_type": {
-            "Not Stated": 26256.98,
+            "Not Stated": 33276.98,
             "Fundraising Events": 126.9,
             "Voter Registration": 1600.0,
             "Campaign Paraphernalia/Misc.": 856.05,
@@ -1402,7 +1402,7 @@
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 16800.0
+            "opposing_expenditures": 23375.65
           },
           "contributions_received": 28085.0,
           "total_contributions": 28085.0,

--- a/build/candidate/11/index.json
+++ b/build/candidate/11/index.json
@@ -32,7 +32,7 @@
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 16800.0
+    "opposing_expenditures": 23375.65
   },
   "contributions_received": 28085.0,
   "total_contributions": 28085.0,

--- a/build/candidate/11/opposing/index.json
+++ b/build/candidate/11/opposing/index.json
@@ -32,7 +32,7 @@
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 16800.0
+    "opposing_expenditures": 23375.65
   },
   "contributions_received": 28085.0,
   "total_contributions": 28085.0,

--- a/build/candidate/11/supporting/index.json
+++ b/build/candidate/11/supporting/index.json
@@ -32,7 +32,7 @@
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 16800.0
+    "opposing_expenditures": 23375.65
   },
   "contributions_received": 28085.0,
   "total_contributions": 28085.0,

--- a/build/candidate/14/index.json
+++ b/build/candidate/14/index.json
@@ -16,13 +16,13 @@
   "party_affiliation": null,
   "filer_id": 1386932,
   "supporting_money": {
-    "contributions_received": 11504.0,
-    "total_contributions": 11504.0,
+    "contributions_received": 13504.0,
+    "total_contributions": 13504.0,
     "total_expenditures": 2774.63,
     "total_loans_received": 0.0,
     "contributions_by_type": {
       "Committee": 1700.0,
-      "Individual": 8650.0,
+      "Individual": 10650.0,
       "Unitemized": 1154.0
     },
     "expenditures_by_type": {
@@ -32,13 +32,13 @@
   "opposing_money": {
     "opposing_expenditures": null
   },
-  "contributions_received": 11504.0,
-  "total_contributions": 11504.0,
+  "contributions_received": 13504.0,
+  "total_contributions": 13504.0,
   "total_expenditures": 2774.63,
   "total_loans_received": 0.0,
   "contributions_by_type": {
     "Committee": 1700.0,
-    "Individual": 8650.0,
+    "Individual": 10650.0,
     "Unitemized": 1154.0
   },
   "expenditures_by_type": {

--- a/build/candidate/14/opposing/index.json
+++ b/build/candidate/14/opposing/index.json
@@ -16,13 +16,13 @@
   "party_affiliation": null,
   "filer_id": 1386932,
   "supporting_money": {
-    "contributions_received": 11504.0,
-    "total_contributions": 11504.0,
+    "contributions_received": 13504.0,
+    "total_contributions": 13504.0,
     "total_expenditures": 2774.63,
     "total_loans_received": 0.0,
     "contributions_by_type": {
       "Committee": 1700.0,
-      "Individual": 8650.0,
+      "Individual": 10650.0,
       "Unitemized": 1154.0
     },
     "expenditures_by_type": {
@@ -32,13 +32,13 @@
   "opposing_money": {
     "opposing_expenditures": null
   },
-  "contributions_received": 11504.0,
-  "total_contributions": 11504.0,
+  "contributions_received": 13504.0,
+  "total_contributions": 13504.0,
   "total_expenditures": 2774.63,
   "total_loans_received": 0.0,
   "contributions_by_type": {
     "Committee": 1700.0,
-    "Individual": 8650.0,
+    "Individual": 10650.0,
     "Unitemized": 1154.0
   },
   "expenditures_by_type": {

--- a/build/candidate/14/supporting/index.json
+++ b/build/candidate/14/supporting/index.json
@@ -16,13 +16,13 @@
   "party_affiliation": null,
   "filer_id": 1386932,
   "supporting_money": {
-    "contributions_received": 11504.0,
-    "total_contributions": 11504.0,
+    "contributions_received": 13504.0,
+    "total_contributions": 13504.0,
     "total_expenditures": 2774.63,
     "total_loans_received": 0.0,
     "contributions_by_type": {
       "Committee": 1700.0,
-      "Individual": 8650.0,
+      "Individual": 10650.0,
       "Unitemized": 1154.0
     },
     "expenditures_by_type": {
@@ -32,13 +32,13 @@
   "opposing_money": {
     "opposing_expenditures": null
   },
-  "contributions_received": 11504.0,
-  "total_contributions": 11504.0,
+  "contributions_received": 13504.0,
+  "total_contributions": 13504.0,
   "total_expenditures": 2774.63,
   "total_loans_received": 0.0,
   "contributions_by_type": {
     "Committee": 1700.0,
-    "Individual": 8650.0,
+    "Individual": 10650.0,
     "Unitemized": 1154.0
   },
   "expenditures_by_type": {

--- a/build/candidate/25/index.json
+++ b/build/candidate/25/index.json
@@ -27,7 +27,7 @@
       "Other (includes Businesses)": 1500.0
     },
     "expenditures_by_type": {
-      "Not Stated": 26256.98,
+      "Not Stated": 33276.98,
       "Fundraising Events": 126.9,
       "Voter Registration": 1600.0,
       "Campaign Paraphernalia/Misc.": 856.05,
@@ -50,7 +50,7 @@
     "Other (includes Businesses)": 1500.0
   },
   "expenditures_by_type": {
-    "Not Stated": 26256.98,
+    "Not Stated": 33276.98,
     "Fundraising Events": 126.9,
     "Voter Registration": 1600.0,
     "Campaign Paraphernalia/Misc.": 856.05,

--- a/build/candidate/25/opposing/index.json
+++ b/build/candidate/25/opposing/index.json
@@ -27,7 +27,7 @@
       "Other (includes Businesses)": 1500.0
     },
     "expenditures_by_type": {
-      "Not Stated": 26256.98,
+      "Not Stated": 33276.98,
       "Fundraising Events": 126.9,
       "Voter Registration": 1600.0,
       "Campaign Paraphernalia/Misc.": 856.05,
@@ -50,7 +50,7 @@
     "Other (includes Businesses)": 1500.0
   },
   "expenditures_by_type": {
-    "Not Stated": 26256.98,
+    "Not Stated": 33276.98,
     "Fundraising Events": 126.9,
     "Voter Registration": 1600.0,
     "Campaign Paraphernalia/Misc.": 856.05,

--- a/build/candidate/25/supporting/index.json
+++ b/build/candidate/25/supporting/index.json
@@ -27,7 +27,7 @@
       "Other (includes Businesses)": 1500.0
     },
     "expenditures_by_type": {
-      "Not Stated": 26256.98,
+      "Not Stated": 33276.98,
       "Fundraising Events": 126.9,
       "Voter Registration": 1600.0,
       "Campaign Paraphernalia/Misc.": 856.05,
@@ -50,7 +50,7 @@
     "Other (includes Businesses)": 1500.0
   },
   "expenditures_by_type": {
-    "Not Stated": 26256.98,
+    "Not Stated": 33276.98,
     "Fundraising Events": 126.9,
     "Voter Registration": 1600.0,
     "Campaign Paraphernalia/Misc.": 856.05,

--- a/build/candidate/26/index.json
+++ b/build/candidate/26/index.json
@@ -27,7 +27,7 @@
       "Self Funding": 300.0
     },
     "expenditures_by_type": {
-      "Not Stated": 35916.83,
+      "Not Stated": 43846.83,
       "Fundraising Events": 300.8,
       "Campaign Consultants": 2500.0,
       "Campaign Paraphernalia/Misc.": 1095.75,
@@ -49,7 +49,7 @@
     "Self Funding": 300.0
   },
   "expenditures_by_type": {
-    "Not Stated": 35916.83,
+    "Not Stated": 43846.83,
     "Fundraising Events": 300.8,
     "Campaign Consultants": 2500.0,
     "Campaign Paraphernalia/Misc.": 1095.75,

--- a/build/candidate/26/opposing/index.json
+++ b/build/candidate/26/opposing/index.json
@@ -27,7 +27,7 @@
       "Self Funding": 300.0
     },
     "expenditures_by_type": {
-      "Not Stated": 35916.83,
+      "Not Stated": 43846.83,
       "Fundraising Events": 300.8,
       "Campaign Consultants": 2500.0,
       "Campaign Paraphernalia/Misc.": 1095.75,
@@ -49,7 +49,7 @@
     "Self Funding": 300.0
   },
   "expenditures_by_type": {
-    "Not Stated": 35916.83,
+    "Not Stated": 43846.83,
     "Fundraising Events": 300.8,
     "Campaign Consultants": 2500.0,
     "Campaign Paraphernalia/Misc.": 1095.75,

--- a/build/candidate/26/supporting/index.json
+++ b/build/candidate/26/supporting/index.json
@@ -27,7 +27,7 @@
       "Self Funding": 300.0
     },
     "expenditures_by_type": {
-      "Not Stated": 35916.83,
+      "Not Stated": 43846.83,
       "Fundraising Events": 300.8,
       "Campaign Consultants": 2500.0,
       "Campaign Paraphernalia/Misc.": 1095.75,
@@ -49,7 +49,7 @@
     "Self Funding": 300.0
   },
   "expenditures_by_type": {
-    "Not Stated": 35916.83,
+    "Not Stated": 43846.83,
     "Fundraising Events": 300.8,
     "Campaign Consultants": 2500.0,
     "Campaign Paraphernalia/Misc.": 1095.75,

--- a/build/candidate/8/index.json
+++ b/build/candidate/8/index.json
@@ -37,7 +37,7 @@
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 12800.0
+    "opposing_expenditures": 12416.96
   },
   "contributions_received": 70053.66,
   "total_contributions": 70053.66,

--- a/build/candidate/8/opposing/index.json
+++ b/build/candidate/8/opposing/index.json
@@ -37,7 +37,7 @@
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 12800.0
+    "opposing_expenditures": 12416.96
   },
   "contributions_received": 70053.66,
   "total_contributions": 70053.66,

--- a/build/candidate/8/supporting/index.json
+++ b/build/candidate/8/supporting/index.json
@@ -37,7 +37,7 @@
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 12800.0
+    "opposing_expenditures": 12416.96
   },
   "contributions_received": 70053.66,
   "total_contributions": 70053.66,

--- a/build/committee/1364564/contributions/index.json
+++ b/build/committee/1364564/contributions/index.json
@@ -1,15 +1,15 @@
 [
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 40000.0,
-    "Tran_Date": "2016-09-12",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-04-14",
     "Tran_NamF": null,
     "Tran_NamL": "ACCE Institute"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-04-14",
+    "Tran_Amt1": 40000.0,
+    "Tran_Date": "2016-09-12",
     "Tran_NamF": null,
     "Tran_NamL": "ACCE Institute"
   },
@@ -36,15 +36,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": -3000.0,
+    "Tran_Date": "2016-05-10",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": -3000.0,
-    "Tran_Date": "2016-05-10",
+    "Tran_Amt1": 3000.0,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
@@ -78,8 +78,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 59000.0,
-    "Tran_Date": "2016-09-09",
+    "Tran_Amt1": 519.47,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 4585.65,
+    "Tran_Date": "2016-10-09",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -92,8 +99,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 19700.0,
-    "Tran_Date": "2016-04-11",
+    "Tran_Amt1": 311.52,
+    "Tran_Date": "2016-04-02",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -106,43 +113,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 311.52,
-    "Tran_Date": "2016-04-02",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 89.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 35000.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 519.47,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 13315.74,
-    "Tran_Date": "2016-01-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1020.82,
-    "Tran_Date": "2016-08-29",
+    "Tran_Amt1": 19700.0,
+    "Tran_Date": "2016-04-11",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -155,8 +127,43 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 35000.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 13315.74,
+    "Tran_Date": "2016-01-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 1144.95,
     "Tran_Date": "2016-09-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 59000.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 89.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1020.82,
+    "Tran_Date": "2016-08-29",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -176,6 +183,13 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Mary Quinn",
+    "Tran_NamL": "Delaney"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 2000.0,
     "Tran_Date": "2016-04-22",
     "Tran_NamF": null,
@@ -187,6 +201,13 @@
     "Tran_Date": "2016-06-13",
     "Tran_NamF": null,
     "Tran_NamL": "East Bay Housing Organization"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Enterprise Community Investment, Inc."
   },
   {
     "Filer_ID": "1364564",
@@ -211,16 +232,16 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Marc",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Mark",
     "Tran_NamL": "Janowitz"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Mark",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Marc",
     "Tran_NamL": "Janowitz"
   },
   {
@@ -352,20 +373,20 @@
   {
     "Filer_ID": "1364564",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Schacher"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-08-06",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Schacher"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 2900.48,
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Schacher"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1450.24,
     "Tran_Date": "2016-01-08",
     "Tran_NamF": null,
     "Tran_NamL": "Service Employees International Union Local 1021"
@@ -379,22 +400,22 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 1450.24,
+    "Tran_Amt1": 2900.48,
     "Tran_Date": "2016-01-08",
     "Tran_NamF": null,
     "Tran_NamL": "Service Employees International Union Local 1021"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 21000.0,
-    "Tran_Date": "2016-05-19",
+    "Tran_Amt1": 12000.0,
+    "Tran_Date": "2016-09-21",
     "Tran_NamF": null,
     "Tran_NamL": "Service Employees International Union Local 1021 Issues PAC"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 12000.0,
-    "Tran_Date": "2016-09-21",
+    "Tran_Amt1": 21000.0,
+    "Tran_Date": "2016-05-19",
     "Tran_NamF": null,
     "Tran_NamL": "Service Employees International Union Local 1021 Issues PAC"
   },

--- a/build/committee/1381041/contributions/index.json
+++ b/build/committee/1381041/contributions/index.json
@@ -71,6 +71,27 @@
   },
   {
     "Filer_ID": "1381041",
+    "Tran_Amt1": 440955.5,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 501546.51,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 10150.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
     "Tran_Amt1": 588670.5,
     "Tran_Date": "2016-10-04",
     "Tran_NamF": "MICHAEL",
@@ -92,13 +113,6 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 487496.5,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
     "Tran_Amt1": 75000.0,
     "Tran_Date": "2016-07-14",
     "Tran_NamF": "MICHAEL",
@@ -106,8 +120,8 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 10150.0,
-    "Tran_Date": "2016-10-07",
+    "Tran_Amt1": 487496.5,
+    "Tran_Date": "2016-09-14",
     "Tran_NamF": "MICHAEL",
     "Tran_NamL": "BLOOMBERG"
   },
@@ -115,13 +129,6 @@
     "Filer_ID": "1381041",
     "Tran_Amt1": 348155.5,
     "Tran_Date": "2016-09-07",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 440955.5,
-    "Tran_Date": "2016-08-31",
     "Tran_NamF": "MICHAEL",
     "Tran_NamL": "BLOOMBERG"
   },
@@ -225,15 +232,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 28750.0,
-    "Tran_Date": "2016-08-05",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-03",
     "Tran_NamF": null,
     "Tran_NamL": "California Dental Association"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-03",
+    "Tran_Amt1": 28750.0,
+    "Tran_Date": "2016-08-05",
     "Tran_NamF": null,
     "Tran_NamL": "California Dental Association"
   },
@@ -547,6 +554,13 @@
   },
   {
     "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "KAREN",
+    "Tran_NamL": "MERYASH"
+  },
+  {
+    "Filer_ID": "1381041",
     "Tran_Amt1": 1000.0,
     "Tran_Date": "2016-09-18",
     "Tran_NamF": "KAREN",
@@ -554,10 +568,10 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "KAREN",
-    "Tran_NamL": "MERYASH"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "MEYERS"
   },
   {
     "Filer_ID": "1381041",
@@ -570,13 +584,6 @@
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-16",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "MEYERS"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-02",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "MEYERS"
   },
@@ -702,14 +709,14 @@
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-05-14",
+    "Tran_Date": "2016-06-24",
     "Tran_NamF": "LYNN",
     "Tran_NamL": "SILVER"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-06-24",
+    "Tran_Date": "2016-05-14",
     "Tran_NamF": "LYNN",
     "Tran_NamL": "SILVER"
   },

--- a/build/committee/1382408/opposing/index.json
+++ b/build/committee/1382408/opposing/index.json
@@ -1,13 +1,13 @@
 [
   {
-    "total": 10156.99,
-    "Exp_Date": "2016-10-06",
+    "total": 2259.97,
+    "Exp_Date": "2016-10-11",
     "Filer_ID": 1382408,
     "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
   },
   {
-    "total": 2259.97,
-    "Exp_Date": "2016-10-11",
+    "total": 10156.99,
+    "Exp_Date": "2016-10-06",
     "Filer_ID": 1382408,
     "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
   }

--- a/build/committee/1382408/opposing/index.json
+++ b/build/committee/1382408/opposing/index.json
@@ -1,7 +1,13 @@
 [
   {
-    "total": 12800.0,
+    "total": 10156.99,
     "Exp_Date": "2016-10-06",
+    "Filer_ID": 1382408,
+    "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
+  },
+  {
+    "total": 2259.97,
+    "Exp_Date": "2016-10-11",
     "Filer_ID": 1382408,
     "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
   }

--- a/build/committee/1386145/contributions/index.json
+++ b/build/committee/1386145/contributions/index.json
@@ -106,6 +106,13 @@
   },
   {
     "Filer_ID": "1386145",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Mary Quinn",
+    "Tran_NamL": "Delaney"
+  },
+  {
+    "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-08-29",
     "Tran_NamF": "Jackie",
@@ -358,8 +365,8 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 1.65,
-    "Tran_Date": "2016-01-26",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-11",
     "Tran_NamF": "Len",
     "Tran_NamL": "Raphael"
   },
@@ -372,8 +379,8 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-11",
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-03-29",
     "Tran_NamF": "Len",
     "Tran_NamL": "Raphael"
   },
@@ -386,8 +393,8 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 600.0,
-    "Tran_Date": "2016-03-29",
+    "Tran_Amt1": 1.65,
+    "Tran_Date": "2016-01-26",
     "Tran_NamF": "Len",
     "Tran_NamL": "Raphael"
   },
@@ -436,6 +443,13 @@
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-02-04",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Shawl"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-03-19",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Shawl"
@@ -444,13 +458,6 @@
     "Filer_ID": "1386145",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Shawl"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-02-04",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Shawl"
   },

--- a/build/committee/1386932/contributions/index.json
+++ b/build/committee/1386932/contributions/index.json
@@ -1,15 +1,15 @@
 [
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-08-18",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
     "Tran_NamF": "Ernesto Jose",
     "Tran_NamL": "Arevalo"
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-08-18",
     "Tran_NamF": "Ernesto Jose",
     "Tran_NamL": "Arevalo"
   },
@@ -103,6 +103,13 @@
     "Tran_Date": "2016-08-03",
     "Tran_NamF": "Carolyn",
     "Tran_NamL": "Holloway"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Nehanda Z.",
+    "Tran_NamL": "Imara"
   },
   {
     "Filer_ID": "1386932",
@@ -211,15 +218,15 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-24",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-02",
     "Tran_NamF": "Sharon A.",
     "Tran_NamL": "Rice"
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-02",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Sharon A.",
     "Tran_NamL": "Rice"
   },

--- a/build/committee/1387983/contributions/index.json
+++ b/build/committee/1387983/contributions/index.json
@@ -190,10 +190,24 @@
   },
   {
     "Filer_ID": "1387983",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mag Trucking"
+  },
+  {
+    "Filer_ID": "1387983",
     "Tran_Amt1": 1000.0,
     "Tran_Date": "2016-08-26",
     "Tran_NamF": "John",
     "Tran_NamL": "Marcone"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 36075.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mayor Libby Schaaf for Oakland"
   },
   {
     "Filer_ID": "1387983",
@@ -271,6 +285,13 @@
     "Tran_Date": "2016-09-23",
     "Tran_NamF": null,
     "Tran_NamL": "Shorenstein Realty Services, LP"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "Silverado Contractors, Inc."
   },
   {
     "Filer_ID": "1387983",

--- a/build/committee/1388641/opposing/index.json
+++ b/build/committee/1388641/opposing/index.json
@@ -1,5 +1,11 @@
 [
   {
+    "total": 8400.0,
+    "Exp_Date": "2016-09-29",
+    "Filer_ID": 1388641,
+    "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
+  },
+  {
     "total": 7449.26,
     "Exp_Date": "2016-10-11",
     "Filer_ID": 1388641,
@@ -8,12 +14,6 @@
   {
     "total": 7526.39,
     "Exp_Date": "2016-10-06",
-    "Filer_ID": 1388641,
-    "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
-  },
-  {
-    "total": 8400.0,
-    "Exp_Date": "2016-09-29",
     "Filer_ID": 1388641,
     "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
   }

--- a/build/committee/1388641/opposing/index.json
+++ b/build/committee/1388641/opposing/index.json
@@ -1,13 +1,19 @@
 [
   {
-    "total": 8400.0,
-    "Exp_Date": "2016-09-29",
+    "total": 7449.26,
+    "Exp_Date": "2016-10-11",
+    "Filer_ID": 1388641,
+    "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
+  },
+  {
+    "total": 7526.39,
+    "Exp_Date": "2016-10-06",
     "Filer_ID": 1388641,
     "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
   },
   {
     "total": 8400.0,
-    "Exp_Date": "2016-10-06",
+    "Exp_Date": "2016-09-29",
     "Filer_ID": 1388641,
     "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
   }

--- a/build/locality/2/current_ballot/index.json
+++ b/build/locality/2/current_ballot/index.json
@@ -100,7 +100,7 @@
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 12800.0
+            "opposing_expenditures": 12416.96
           },
           "contributions_received": 70053.66,
           "total_contributions": 70053.66,
@@ -555,7 +555,7 @@
               "Self Funding": 300.0
             },
             "expenditures_by_type": {
-              "Not Stated": 35916.83,
+              "Not Stated": 43846.83,
               "Fundraising Events": 300.8,
               "Campaign Consultants": 2500.0,
               "Campaign Paraphernalia/Misc.": 1095.75,
@@ -577,7 +577,7 @@
             "Self Funding": 300.0
           },
           "expenditures_by_type": {
-            "Not Stated": 35916.83,
+            "Not Stated": 43846.83,
             "Fundraising Events": 300.8,
             "Campaign Consultants": 2500.0,
             "Campaign Paraphernalia/Misc.": 1095.75,
@@ -1004,13 +1004,13 @@
           "party_affiliation": null,
           "filer_id": 1386932,
           "supporting_money": {
-            "contributions_received": 11504.0,
-            "total_contributions": 11504.0,
+            "contributions_received": 13504.0,
+            "total_contributions": 13504.0,
             "total_expenditures": 2774.63,
             "total_loans_received": 0.0,
             "contributions_by_type": {
               "Committee": 1700.0,
-              "Individual": 8650.0,
+              "Individual": 10650.0,
               "Unitemized": 1154.0
             },
             "expenditures_by_type": {
@@ -1020,13 +1020,13 @@
           "opposing_money": {
             "opposing_expenditures": null
           },
-          "contributions_received": 11504.0,
-          "total_contributions": 11504.0,
+          "contributions_received": 13504.0,
+          "total_contributions": 13504.0,
           "total_expenditures": 2774.63,
           "total_loans_received": 0.0,
           "contributions_by_type": {
             "Committee": 1700.0,
-            "Individual": 8650.0,
+            "Individual": 10650.0,
             "Unitemized": 1154.0
           },
           "expenditures_by_type": {
@@ -1271,7 +1271,7 @@
               "Other (includes Businesses)": 1500.0
             },
             "expenditures_by_type": {
-              "Not Stated": 26256.98,
+              "Not Stated": 33276.98,
               "Fundraising Events": 126.9,
               "Voter Registration": 1600.0,
               "Campaign Paraphernalia/Misc.": 856.05,
@@ -1294,7 +1294,7 @@
             "Other (includes Businesses)": 1500.0
           },
           "expenditures_by_type": {
-            "Not Stated": 26256.98,
+            "Not Stated": 33276.98,
             "Fundraising Events": 126.9,
             "Voter Registration": 1600.0,
             "Campaign Paraphernalia/Misc.": 856.05,
@@ -1402,7 +1402,7 @@
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 16800.0
+            "opposing_expenditures": 23375.65
           },
           "contributions_received": 28085.0,
           "total_contributions": 28085.0,

--- a/build/office_election/1/index.json
+++ b/build/office_election/1/index.json
@@ -97,7 +97,7 @@
         }
       },
       "opposing_money": {
-        "opposing_expenditures": 12800.0
+        "opposing_expenditures": 12416.96
       },
       "contributions_received": 70053.66,
       "total_contributions": 70053.66,

--- a/build/office_election/10/index.json
+++ b/build/office_election/10/index.json
@@ -37,7 +37,7 @@
         }
       },
       "opposing_money": {
-        "opposing_expenditures": 16800.0
+        "opposing_expenditures": 23375.65
       },
       "contributions_received": 28085.0,
       "total_contributions": 28085.0,

--- a/build/office_election/4/index.json
+++ b/build/office_election/4/index.json
@@ -32,7 +32,7 @@
           "Self Funding": 300.0
         },
         "expenditures_by_type": {
-          "Not Stated": 35916.83,
+          "Not Stated": 43846.83,
           "Fundraising Events": 300.8,
           "Campaign Consultants": 2500.0,
           "Campaign Paraphernalia/Misc.": 1095.75,
@@ -54,7 +54,7 @@
         "Self Funding": 300.0
       },
       "expenditures_by_type": {
-        "Not Stated": 35916.83,
+        "Not Stated": 43846.83,
         "Fundraising Events": 300.8,
         "Campaign Consultants": 2500.0,
         "Campaign Paraphernalia/Misc.": 1095.75,

--- a/build/office_election/7/index.json
+++ b/build/office_election/7/index.json
@@ -66,13 +66,13 @@
       "party_affiliation": null,
       "filer_id": 1386932,
       "supporting_money": {
-        "contributions_received": 11504.0,
-        "total_contributions": 11504.0,
+        "contributions_received": 13504.0,
+        "total_contributions": 13504.0,
         "total_expenditures": 2774.63,
         "total_loans_received": 0.0,
         "contributions_by_type": {
           "Committee": 1700.0,
-          "Individual": 8650.0,
+          "Individual": 10650.0,
           "Unitemized": 1154.0
         },
         "expenditures_by_type": {
@@ -82,13 +82,13 @@
       "opposing_money": {
         "opposing_expenditures": null
       },
-      "contributions_received": 11504.0,
-      "total_contributions": 11504.0,
+      "contributions_received": 13504.0,
+      "total_contributions": 13504.0,
       "total_expenditures": 2774.63,
       "total_loans_received": 0.0,
       "contributions_by_type": {
         "Committee": 1700.0,
-        "Individual": 8650.0,
+        "Individual": 10650.0,
         "Unitemized": 1154.0
       },
       "expenditures_by_type": {

--- a/build/office_election/8/index.json
+++ b/build/office_election/8/index.json
@@ -181,7 +181,7 @@
           "Other (includes Businesses)": 1500.0
         },
         "expenditures_by_type": {
-          "Not Stated": 26256.98,
+          "Not Stated": 33276.98,
           "Fundraising Events": 126.9,
           "Voter Registration": 1600.0,
           "Campaign Paraphernalia/Misc.": 856.05,
@@ -204,7 +204,7 @@
         "Other (includes Businesses)": 1500.0
       },
       "expenditures_by_type": {
-        "Not Stated": 26256.98,
+        "Not Stated": 33276.98,
         "Fundraising Events": 126.9,
         "Voter Registration": 1600.0,
         "Campaign Paraphernalia/Misc.": 856.05,

--- a/build/referendum/1/supporting/index.json
+++ b/build/referendum/1/supporting/index.json
@@ -13,10 +13,10 @@
       "amount": 2049149.3
     }
   ],
-  "total_contributions": 3055763.0,
+  "total_contributions": 3557309.51,
   "contributions_by_region": [
     {
-      "amount": 2955823.0,
+      "amount": 3457369.51,
       "locale": "Out of State"
     },
     {

--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -10,7 +10,7 @@
       "id": "1385949",
       "name": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "payee": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
-      "amount": 146105.24
+      "amount": 150025.72
     },
     {
       "id": "1364564",
@@ -19,10 +19,10 @@
       "amount": 181644.61
     }
   ],
-  "total_contributions": 299698.92000000004,
+  "total_contributions": 299698.92,
   "contributions_by_region": [
     {
-      "amount": 9000.0,
+      "amount": 14000.0,
       "locale": "Out of State"
     },
     {
@@ -30,11 +30,11 @@
       "locale": "Within California"
     },
     {
-      "amount": 221899.79,
+      "amount": 231485.44,
       "locale": "Within Oakland"
     },
     {
-      "amount": 14799.129999999976,
+      "amount": 213.47999999998137,
       "locale": "Unknown"
     }
   ]

--- a/build/referendum/4/supporting/index.json
+++ b/build/referendum/4/supporting/index.json
@@ -13,18 +13,18 @@
       "amount": 93678.0
     }
   ],
-  "total_contributions": 241915.78,
+  "total_contributions": 289990.78,
   "contributions_by_region": [
     {
       "amount": 15000.0,
       "locale": "Out of State"
     },
     {
-      "amount": 75600.0,
+      "amount": 77600.0,
       "locale": "Within California"
     },
     {
-      "amount": 151315.78,
+      "amount": 197390.78,
       "locale": "Within Oakland"
     }
   ]

--- a/build/referendum/5/supporting/index.json
+++ b/build/referendum/5/supporting/index.json
@@ -13,7 +13,7 @@
       "amount": 7855.0
     }
   ],
-  "total_contributions": 14891.5,
+  "total_contributions": 15891.5,
   "contributions_by_region": [
     {
       "amount": 125.0,
@@ -24,7 +24,7 @@
       "locale": "Within California"
     },
     {
-      "amount": 7866.5,
+      "amount": 8866.5,
       "locale": "Within Oakland"
     }
   ]

--- a/build/referendum/6/supporting/index.json
+++ b/build/referendum/6/supporting/index.json
@@ -11,20 +11,22 @@
       "name": "Families and Educators for Public Education, Sponsored by Go Public Schools Advocates",
       "payee": "Families and Educators for Public Education, Sponsored by Go Public Schools Advocates",
       "amount": 14827.630000000001
-    }
-  ],
-  "total_contributions": 147246.01,
-  "contributions_by_region": [
-    {
-      "amount": 641.63,
-      "locale": "Out of State"
     },
     {
-      "amount": 72376.87,
+      "id": "960997",
+      "name": "Friends of Oakland Public Schools Yes on G1 2016",
+      "payee": "Friends of Oakland Public Schools Yes on G1 2016",
+      "amount": 32926.02
+    }
+  ],
+  "total_contributions": 60000.0,
+  "contributions_by_region": [
+    {
+      "amount": 6000.0,
       "locale": "Within California"
     },
     {
-      "amount": 74227.51,
+      "amount": 54000.0,
       "locale": "Within Oakland"
     }
   ]

--- a/build/stats/index.json
+++ b/build/stats/index.json
@@ -1,3 +1,3 @@
 {
-  "date_processed": "2016-10-11"
+  "date_processed": "2016-10-13"
 }

--- a/calculators/referendum_expenditures_by_origin.rb
+++ b/calculators/referendum_expenditures_by_origin.rb
@@ -16,14 +16,11 @@ class ReferendumExpendituresByOrigin
 
     contributions = ActiveRecord::Base.connection.execute(<<-SQL)
       SELECT
-        expenditures."Measure_Number",
-        expenditures."Sup_Opp_Cd",
+        "Ballot_Measure" AS "Measure_Number",
+        "Support_Or_Oppose" AS "Sup_Opp_Cd",
         contributions_by_locale.locale,
         SUM(contributions_by_locale.total) as total
-      FROM (
-        SELECT DISTINCT "Filer_ID", "Measure_Number", "Sup_Opp_Cd"
-        FROM "Measure_Expenditures"
-      ) expenditures,
+      FROM "oakland_committees" committees,
       (
         SELECT "Filer_ID",
         CASE
@@ -49,9 +46,9 @@ class ReferendumExpendituresByOrigin
         ) contributions
         GROUP BY "Filer_ID", locale
       ) contributions_by_locale
-      WHERE expenditures."Filer_ID" = contributions_by_locale."Filer_ID"
-      GROUP BY expenditures."Measure_Number", expenditures."Sup_Opp_Cd", contributions_by_locale.locale
-      ORDER BY expenditures."Measure_Number", expenditures."Sup_Opp_Cd", contributions_by_locale.locale;
+      WHERE committees."Filer_ID" = contributions_by_locale."Filer_ID"
+      GROUP BY "Ballot_Measure", "Support_Or_Oppose", contributions_by_locale.locale
+      ORDER BY "Ballot_Measure", "Support_Or_Oppose", contributions_by_locale.locale;
     SQL
 
     support_total = {}

--- a/make_view.sh
+++ b/make_view.sh
@@ -12,7 +12,6 @@ SELECT "Filer_ID"::varchar, "Filer_NamL",
 FROM
   "efile_COAK_2016_E-Expenditure", oakland_name_to_number
 WHERE LOWER("Bal_Name") = LOWER("Measure_Name")
-AND "Sup_Opp_Cd" IS NOT NULL
 -- Get IE 
 UNION ALL
 SELECT "Filer_ID"::varchar, "Filer_NamL",
@@ -30,7 +29,7 @@ SELECT expend."Filer_ID"::varchar, expend."Filer_NamL",
 FROM
   "efile_COAK_2016_E-Expenditure" expend,
   oakland_committees committee
-WHERE "Sup_Opp_Cd" IS NULL
+WHERE "Bal_Name" IS NULL
   AND expend."Filer_ID" = committee."Filer_ID"
   AND "Ballot_Measure" IS NOT NULL
 UNION ALL


### PR DESCRIPTION
The Measure_Expenditures view was looking for Sup_Opp_Cd to be null to use information from the oakland_committees table to discern measure support.  The "Friends" committed was filling that field in but not the Bal_Name which is really what would exclude it from the other part of the union.

We were using spending on a measure to determine if a contribution to a committee should count as a contribution to the measure.  We should just use the information in the oakalnd_committees table to determine which committees support a measure.