### PR TITLE
Separate out IEC for candidates + TYPE fixes

### DIFF
--- a/build/ballot/1/index.json
+++ b/build/ballot/1/index.json
@@ -36,16 +36,20 @@
               "Other (includes Businesses)": 4450.0
             },
             "expenditures_by_type": {
-              "": 31671.74,
+              "Not Stated": 31671.74,
               "Civic Donations": 18683.77,
               "Office Expenses": 1498.61,
               "Campaign Literature and Mailings": 7535.18,
               "Postage, Delivery and Messenger Services": 12149.88,
               "Professional Services (Legal, Accounting)": 5380.73
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 42542.0,
           "total_contributions": 42542.0,
@@ -58,7 +62,7 @@
             "Other (includes Businesses)": 4450.0
           },
           "expenditures_by_type": {
-            "": 31671.74,
+            "Not Stated": 31671.74,
             "Civic Donations": 18683.77,
             "Office Expenses": 1498.61,
             "Campaign Literature and Mailings": 7535.18,
@@ -97,8 +101,8 @@
               "Other (includes Businesses)": 11357.0
             },
             "expenditures_by_type": {
-              "": 1388.85,
               "Print Ads": 300.0,
+              "Not Stated": 1388.85,
               "Civic Donations": 1000.0,
               "Fundraising Events": 12500.23,
               "Campaign Consultants": 37769.07,
@@ -110,10 +114,17 @@
               "Information Technology Costs (Internet, E-mail)": 4226.01,
               "Independent Expenditure Supporting/Opposing Others": 300.0,
               "Transfer Between Committees of the Same Candidate/sponsor": 600.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 12416.96
+            "opposing_expenditures": 12416.96,
+            "opposing_by_type": {
+              "Design of mailer in opposition of Dan Kalb.": 1650.0,
+              "Printing of mailer in opposition to Dan Kalb": 2916.63,
+              "Mailing and Postage in opposition to Dan Kalb": 7850.33
+            }
           },
           "contributions_received": 109521.66,
           "total_contributions": 109521.66,
@@ -127,8 +138,8 @@
             "Other (includes Businesses)": 11357.0
           },
           "expenditures_by_type": {
-            "": 1388.85,
             "Print Ads": 300.0,
+            "Not Stated": 1388.85,
             "Civic Donations": 1000.0,
             "Fundraising Events": 12500.23,
             "Campaign Consultants": 37769.07,
@@ -179,8 +190,8 @@
               "Other (includes Businesses)": 11200.0
             },
             "expenditures_by_type": {
-              "": 17406.96,
               "Print Ads": 1000.0,
+              "Not Stated": 17406.96,
               "Contribution": 750.0,
               "Civic Donations": 4600.0,
               "Office Expenses": 7051.9,
@@ -193,10 +204,14 @@
               "Candidate Travel, Lodging, and Meals": 91.39,
               "Professional Services (Legal, Accounting)": 12410.7,
               "Information Technology Costs (Internet, E-mail)": 3343.09
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 58231.08,
           "total_contributions": 58231.08,
@@ -209,8 +224,8 @@
             "Other (includes Businesses)": 11200.0
           },
           "expenditures_by_type": {
-            "": 17406.96,
             "Print Ads": 1000.0,
+            "Not Stated": 17406.96,
             "Contribution": 750.0,
             "Civic Donations": 4600.0,
             "Office Expenses": 7051.9,
@@ -262,10 +277,14 @@
               "Candidate Filing/Ballot Fees": 300.0,
               "Campaign Literature and Mailings": 3399.31,
               "Information Technology Costs (Internet, E-mail)": 387.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 10634.0,
           "total_contributions": 10634.0,
@@ -325,8 +344,8 @@
               "Other (includes Businesses)": 11950.0
             },
             "expenditures_by_type": {
-              "": 16605.58,
               "Print Ads": 1298.18,
+              "Not Stated": 16605.58,
               "Office Expenses": 15728.02,
               "Fundraising Events": 750.0,
               "Campaign Consultants": 41405.69,
@@ -338,10 +357,14 @@
               "Professional Services (Legal, Accounting)": 3583.75,
               "T.V. or Cable Airtime and Production Costs": 8000.0,
               "Information Technology Costs (Internet, E-mail)": 400.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 134374.0,
           "total_contributions": 134374.0,
@@ -355,8 +378,8 @@
             "Other (includes Businesses)": 11950.0
           },
           "expenditures_by_type": {
-            "": 16605.58,
             "Print Ads": 1298.18,
+            "Not Stated": 16605.58,
             "Office Expenses": 15728.02,
             "Fundraising Events": 750.0,
             "Campaign Consultants": 41405.69,
@@ -408,10 +431,14 @@
               "Campaign Literature and Mailings": 1056.73,
               "Professional Services (Legal, Accounting)": 5575.0,
               "Information Technology Costs (Internet, E-mail)": 1997.97
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 75623.14,
           "total_contributions": 75623.14,
@@ -464,10 +491,14 @@
               "Office Expenses": 145.97,
               "Campaign Paraphernalia/Misc.": 310.03,
               "Candidate Filing/Ballot Fees": 190.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 396.0,
           "total_contributions": 396.0,
@@ -508,10 +539,14 @@
             "contributions_by_type": {
             },
             "expenditures_by_type": {
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -564,10 +599,14 @@
               "Professional Services (Legal, Accounting)": 14215.1,
               "T.V. or Cable Airtime and Production Costs": 79500.0,
               "Information Technology Costs (Internet, E-mail)": 6488.21
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 198167.0,
           "total_contributions": 198167.0,
@@ -632,7 +671,6 @@
             },
             "expenditures_by_type": {
               "Print Ads": 13871.57,
-              "Not Stated": 114796.33,
               "Phone Banks": 79.0,
               "Office Expenses": 125.0,
               "Fundraising Events": 300.8,
@@ -640,10 +678,23 @@
               "Campaign Paraphernalia/Misc.": 2443.7,
               "Candidate Filing/Ballot Fees": 250.0,
               "Professional Services (Legal, Accounting)": 4542.81
+            },
+            "supporting_by_type": {
+              "Print Ads": 2048.0,
+              "CANVASSING": 5000.0,
+              "Phone Banks": 597.7,
+              "ESTIMATE OF LIT": 7915.0,
+              "ESTIMATE OF STAFF TIME": 31088.83,
+              "Campaign Paraphernalia/Misc.": 2702.11,
+              "Campaign Literature and Mailings": 44502.69,
+              "Information Technology Costs (Internet, E-mail)": 8350.0,
+              "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 12592.0
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 27586.0,
           "total_contributions": 27586.0,
@@ -657,7 +708,6 @@
           },
           "expenditures_by_type": {
             "Print Ads": 13871.57,
-            "Not Stated": 114796.33,
             "Phone Banks": 79.0,
             "Office Expenses": 125.0,
             "Fundraising Events": 300.8,
@@ -696,16 +746,21 @@
               "Unitemized": 2762.0
             },
             "expenditures_by_type": {
-              "": 2033.0,
+              "Not Stated": 2033.0,
               "Office Expenses": 1900.34,
               "Campaign Consultants": 3950.0,
               "Campaign Paraphernalia/Misc.": 1167.25,
               "Campaign Literature and Mailings": 1054.74,
               "Professional Services (Legal, Accounting)": 2206.32
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 6987.5
+            "opposing_expenditures": 6987.5,
+            "opposing_by_type": {
+              "Campaign Literature and Mailings": 6987.5
+            }
           },
           "contributions_received": 13562.0,
           "total_contributions": 13562.0,
@@ -717,7 +772,7 @@
             "Unitemized": 2762.0
           },
           "expenditures_by_type": {
-            "": 2033.0,
+            "Not Stated": 2033.0,
             "Office Expenses": 1900.34,
             "Campaign Consultants": 3950.0,
             "Campaign Paraphernalia/Misc.": 1167.25,
@@ -761,7 +816,7 @@
               "Other (includes Businesses)": 1750.0
             },
             "expenditures_by_type": {
-              "": 809.02,
+              "Not Stated": 809.02,
               "Office Expenses": 1710.94,
               "Fundraising Events": 147.81,
               "Voter Registration": 156.15,
@@ -773,10 +828,14 @@
               "Staff/Spouse Travel, Lodging, and Meals": 320.14,
               "Professional Services (Legal, Accounting)": 372.42,
               "Information Technology Costs (Internet, E-mail)": 100.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 5144.0,
           "total_contributions": 5144.0,
@@ -788,7 +847,7 @@
             "Other (includes Businesses)": 1750.0
           },
           "expenditures_by_type": {
-            "": 809.02,
+            "Not Stated": 809.02,
             "Office Expenses": 1710.94,
             "Fundraising Events": 147.81,
             "Voter Registration": 156.15,
@@ -832,7 +891,6 @@
               "Other (includes Businesses)": 2600.0
             },
             "expenditures_by_type": {
-              "Not Stated": 3894.33,
               "Office Expenses": 248.2,
               "Fundraising Events": 2338.58,
               "Campaign Consultants": 1000.0,
@@ -840,10 +898,17 @@
               "Campaign Paraphernalia/Misc.": 3755.99,
               "Candidate Filing/Ballot Fees": 300.0,
               "Campaign Literature and Mailings": 15150.0
+            },
+            "supporting_by_type": {
+              "ESTIMATE OF STAFF TIME": 1941.33,
+              "Campaign Literature and Mailings": 48.0,
+              "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 1905.0
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 22344.0,
           "total_contributions": 22344.0,
@@ -856,7 +921,6 @@
             "Other (includes Businesses)": 2600.0
           },
           "expenditures_by_type": {
-            "Not Stated": 3894.33,
             "Office Expenses": 248.2,
             "Fundraising Events": 2338.58,
             "Campaign Consultants": 1000.0,
@@ -902,7 +966,6 @@
               "Unitemized": 0.0
             },
             "expenditures_by_type": {
-              "Not Stated": 78327.14,
               "Phone Banks": 834.94,
               "Fundraising Events": 203.53,
               "Campaign Consultants": 1340.0,
@@ -910,10 +973,22 @@
               "Campaign Literature and Mailings": 5458.08,
               "Professional Services (Legal, Accounting)": 200.0,
               "Information Technology Costs (Internet, E-mail)": 597.0
+            },
+            "supporting_by_type": {
+              "Print Ads": 2048.0,
+              "Phone Banks": 276.33,
+              "ESTIMATE OF LIT": 1800.0,
+              "ESTIMATE OF STAFF TIME": 19599.4,
+              "Campaign Paraphernalia/Misc.": 2702.11,
+              "Campaign Literature and Mailings": 45044.3,
+              "Information Technology Costs (Internet, E-mail)": 675.0,
+              "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 6182.0
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 17888.0,
           "total_contributions": 17888.0,
@@ -925,7 +1000,6 @@
             "Unitemized": 0.0
           },
           "expenditures_by_type": {
-            "Not Stated": 78327.14,
             "Phone Banks": 834.94,
             "Fundraising Events": 203.53,
             "Campaign Consultants": 1340.0,
@@ -961,10 +1035,14 @@
             "contributions_by_type": {
             },
             "expenditures_by_type": {
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -994,43 +1072,49 @@
           "party_affiliation": null,
           "filer_id": 1386929,
           "supporting_money": {
-            "contributions_received": 3980.0,
-            "total_contributions": 3980.0,
-            "total_expenditures": 2382.67,
+            "contributions_received": 5798.0,
+            "total_contributions": 5798.0,
+            "total_expenditures": 3052.34,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Individual": 1800.0,
-              "Unitemized": 515.0,
-              "Other (includes Businesses)": 1665.0
+              "Individual": 2590.0,
+              "Unitemized": 1093.0,
+              "Other (includes Businesses)": 2115.0
             },
             "expenditures_by_type": {
+              "Not Stated": 60.0,
               "Fundraising Events": 128.05,
               "Meetings and Appearances": 114.67,
-              "Campaign Paraphernalia/Misc.": 724.48,
-              "Candidate Filing/Ballot Fees": 300.0,
-              "Campaign Literature and Mailings": 839.01,
-              "Information Technology Costs (Internet, E-mail)": 148.0
+              "Campaign Paraphernalia/Misc.": 870.17,
+              "Candidate Filing/Ballot Fees": 310.0,
+              "Campaign Literature and Mailings": 1187.01,
+              "Information Technology Costs (Internet, E-mail)": 177.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
-          "contributions_received": 3980.0,
-          "total_contributions": 3980.0,
-          "total_expenditures": 2382.67,
+          "contributions_received": 5798.0,
+          "total_contributions": 5798.0,
+          "total_expenditures": 3052.34,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Individual": 1800.0,
-            "Unitemized": 515.0,
-            "Other (includes Businesses)": 1665.0
+            "Individual": 2590.0,
+            "Unitemized": 1093.0,
+            "Other (includes Businesses)": 2115.0
           },
           "expenditures_by_type": {
+            "Not Stated": 60.0,
             "Fundraising Events": 128.05,
             "Meetings and Appearances": 114.67,
-            "Campaign Paraphernalia/Misc.": 724.48,
-            "Candidate Filing/Ballot Fees": 300.0,
-            "Campaign Literature and Mailings": 839.01,
-            "Information Technology Costs (Internet, E-mail)": 148.0
+            "Campaign Paraphernalia/Misc.": 870.17,
+            "Candidate Filing/Ballot Fees": 310.0,
+            "Campaign Literature and Mailings": 1187.01,
+            "Information Technology Costs (Internet, E-mail)": 177.0
           }
         },
         {
@@ -1059,10 +1143,14 @@
             "contributions_by_type": {
             },
             "expenditures_by_type": {
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -1107,13 +1195,17 @@
               "Unitemized": 382.0
             },
             "expenditures_by_type": {
-              "": 435.74,
+              "Not Stated": 435.74,
               "Campaign Paraphernalia/Misc.": 13557.03,
               "Professional Services (Legal, Accounting)": 850.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 20239.0,
           "total_contributions": 20239.0,
@@ -1123,7 +1215,7 @@
             "Unitemized": 382.0
           },
           "expenditures_by_type": {
-            "": 435.74,
+            "Not Stated": 435.74,
             "Campaign Paraphernalia/Misc.": 13557.03,
             "Professional Services (Legal, Accounting)": 850.0
           }
@@ -1157,7 +1249,7 @@
               "Unitemized": 3066.0
             },
             "expenditures_by_type": {
-              "": 700.0,
+              "Not Stated": 700.0,
               "Phone Banks": 1659.63,
               "Office Expenses": 2307.9,
               "Campaign Consultants": 3000.0,
@@ -1165,10 +1257,14 @@
               "Campaign Literature and Mailings": 7287.36,
               "Postage, Delivery and Messenger Services": 3818.95,
               "Professional Services (Legal, Accounting)": 3147.37
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 26966.0,
           "total_contributions": 26966.0,
@@ -1180,7 +1276,7 @@
             "Unitemized": 3066.0
           },
           "expenditures_by_type": {
-            "": 700.0,
+            "Not Stated": 700.0,
             "Phone Banks": 1659.63,
             "Office Expenses": 2307.9,
             "Campaign Consultants": 3000.0,
@@ -1220,8 +1316,8 @@
               "Other (includes Businesses)": 15550.0
             },
             "expenditures_by_type": {
-              "": 4698.42,
               "Print Ads": 1000.0,
+              "Not Stated": 4698.42,
               "Office Expenses": 649.6,
               "Fundraising Events": 315.92,
               "Campaign Consultants": 15000.0,
@@ -1231,10 +1327,14 @@
               "Staff/Spouse Travel, Lodging, and Meals": 202.76,
               "Professional Services (Legal, Accounting)": 10248.12,
               "Information Technology Costs (Internet, E-mail)": 2236.58
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 72976.0,
           "total_contributions": 72976.0,
@@ -1247,8 +1347,8 @@
             "Other (includes Businesses)": 15550.0
           },
           "expenditures_by_type": {
-            "": 4698.42,
             "Print Ads": 1000.0,
+            "Not Stated": 4698.42,
             "Office Expenses": 649.6,
             "Fundraising Events": 315.92,
             "Campaign Consultants": 15000.0,
@@ -1299,10 +1399,14 @@
               "Office Expenses": 506.71,
               "Campaign Consultants": 2500.0,
               "Information Technology Costs (Internet, E-mail)": 265.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 8486.0,
           "total_contributions": 8486.0,
@@ -1345,10 +1449,14 @@
             "contributions_by_type": {
             },
             "expenditures_by_type": {
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -1370,7 +1478,7 @@
           "last_name": "Torres",
           "ballot_item": 8,
           "office_election": 8,
-          "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home\"",
+          "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home",
           "committee_name": "Roseann Torres for Oakland School Board 2016",
           "is_accepted_expenditure_ceiling": null,
           "is_incumbent": true,
@@ -1389,7 +1497,7 @@
               "Other (includes Businesses)": 1000.0
             },
             "expenditures_by_type": {
-              "": 3317.0,
+              "Not Stated": 3317.0,
               "Contribution": 300.0,
               "Office Expenses": 1736.74,
               "Fundraising Events": 1243.86,
@@ -1398,10 +1506,15 @@
               "Campaign Literature and Mailings": 3183.32,
               "Professional Services (Legal, Accounting)": 7081.33,
               "Information Technology Costs (Internet, E-mail)": 400.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 6987.5
+            "opposing_expenditures": 6987.5,
+            "opposing_by_type": {
+              "Campaign Literature and Mailings": 6987.5
+            }
           },
           "contributions_received": 21893.01,
           "total_contributions": 21893.01,
@@ -1414,7 +1527,7 @@
             "Other (includes Businesses)": 1000.0
           },
           "expenditures_by_type": {
-            "": 3317.0,
+            "Not Stated": 3317.0,
             "Contribution": 300.0,
             "Office Expenses": 1736.74,
             "Fundraising Events": 1243.86,
@@ -1455,7 +1568,6 @@
               "Other (includes Businesses)": 3000.0
             },
             "expenditures_by_type": {
-              "Not Stated": 88339.72,
               "Office Expenses": 123.83,
               "Fundraising Events": 126.9,
               "Voter Registration": 1600.0,
@@ -1465,10 +1577,23 @@
               "Campaign Literature and Mailings": 10825.06,
               "Professional Services (Legal, Accounting)": 2500.0,
               "Information Technology Costs (Internet, E-mail)": 833.57
+            },
+            "supporting_by_type": {
+              "Print Ads": 48.0,
+              "CANVASSING": 5000.0,
+              "Phone Banks": 342.45,
+              "ESTIMATE OF LIT": 8981.0,
+              "ESTIMATE OF STAFF TIME": 20623.98,
+              "Campaign Paraphernalia/Misc.": 2702.11,
+              "Campaign Literature and Mailings": 35454.18,
+              "Information Technology Costs (Internet, E-mail)": 5675.0,
+              "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 9513.0
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 21685.48,
           "total_contributions": 21685.48,
@@ -1481,7 +1606,6 @@
             "Other (includes Businesses)": 3000.0
           },
           "expenditures_by_type": {
-            "Not Stated": 88339.72,
             "Office Expenses": 123.83,
             "Fundraising Events": 126.9,
             "Voter Registration": 1600.0,
@@ -1533,10 +1657,14 @@
               "Campaign Paraphernalia/Misc.": 820.44,
               "Candidate Filing/Ballot Fees": 1477.0,
               "Campaign Literature and Mailings": 1559.56
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 67909.0,
           "total_contributions": 67909.0,
@@ -1591,8 +1719,8 @@
               "Other (includes Businesses)": 37631.69
             },
             "expenditures_by_type": {
-              "": 10826.1,
               "Print Ads": 500.0,
+              "Not Stated": 10826.1,
               "Contribution": 550.0,
               "Civic Donations": 700.0,
               "Office Expenses": 3595.76,
@@ -1602,10 +1730,23 @@
               "Candidate Filing/Ballot Fees": 300.0,
               "Campaign Literature and Mailings": 36593.49,
               "Professional Services (Legal, Accounting)": 21788.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 40013.84
+            "opposing_expenditures": 40013.84,
+            "opposing_by_type": {
+              "Postage": 4714.25,
+              "Mailer Design": 1650.0,
+              "Mailer Printing": 2438.13,
+              "Mailhouse \u0026 Postage": 3699.26,
+              "Digital Ad in opposition to Noel Gallo": 9250.0,
+              "Design of mailer in opposition to Noel Gallo": 3300.0,
+              "Design of mailer in opposition of Noel Gallo.": 1650.0,
+              "Printing of mailer in opposition to Noel Gallo": 5913.68,
+              "Mailing and Postage in opposition to Noel Gallo": 7398.52
+            }
           },
           "contributions_received": 80100.69,
           "total_contributions": 80100.69,
@@ -1618,8 +1759,8 @@
             "Other (includes Businesses)": 37631.69
           },
           "expenditures_by_type": {
-            "": 10826.1,
             "Print Ads": 500.0,
+            "Not Stated": 10826.1,
             "Contribution": 550.0,
             "Civic Donations": 700.0,
             "Office Expenses": 3595.76,
@@ -1662,16 +1803,20 @@
               "Other (includes Businesses)": 3300.0
             },
             "expenditures_by_type": {
-              "": 455.45,
+              "Not Stated": 455.45,
               "Campaign Consultants": 18667.55,
               "Meetings and Appearances": 529.0,
               "Campaign Paraphernalia/Misc.": 3884.37,
               "Campaign Literature and Mailings": 33656.76,
               "Information Technology Costs (Internet, E-mail)": 3150.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 84742.41,
           "total_contributions": 84742.41,
@@ -1685,7 +1830,7 @@
             "Other (includes Businesses)": 3300.0
           },
           "expenditures_by_type": {
-            "": 455.45,
+            "Not Stated": 455.45,
             "Campaign Consultants": 18667.55,
             "Meetings and Appearances": 529.0,
             "Campaign Paraphernalia/Misc.": 3884.37,

--- a/build/candidate/1/index.json
+++ b/build/candidate/1/index.json
@@ -31,10 +31,14 @@
       "Campaign Paraphernalia/Misc.": 820.44,
       "Candidate Filing/Ballot Fees": 1477.0,
       "Campaign Literature and Mailings": 1559.56
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 67909.0,
   "total_contributions": 67909.0,

--- a/build/candidate/1/opposing/index.json
+++ b/build/candidate/1/opposing/index.json
@@ -31,10 +31,14 @@
       "Campaign Paraphernalia/Misc.": 820.44,
       "Candidate Filing/Ballot Fees": 1477.0,
       "Campaign Literature and Mailings": 1559.56
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 67909.0,
   "total_contributions": 67909.0,

--- a/build/candidate/1/supporting/index.json
+++ b/build/candidate/1/supporting/index.json
@@ -31,10 +31,14 @@
       "Campaign Paraphernalia/Misc.": 820.44,
       "Candidate Filing/Ballot Fees": 1477.0,
       "Campaign Literature and Mailings": 1559.56
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 67909.0,
   "total_contributions": 67909.0,

--- a/build/candidate/10/index.json
+++ b/build/candidate/10/index.json
@@ -35,10 +35,14 @@
       "Candidate Filing/Ballot Fees": 300.0,
       "Campaign Literature and Mailings": 3399.31,
       "Information Technology Costs (Internet, E-mail)": 387.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 10634.0,
   "total_contributions": 10634.0,

--- a/build/candidate/10/opposing/index.json
+++ b/build/candidate/10/opposing/index.json
@@ -35,10 +35,14 @@
       "Candidate Filing/Ballot Fees": 300.0,
       "Campaign Literature and Mailings": 3399.31,
       "Information Technology Costs (Internet, E-mail)": 387.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 10634.0,
   "total_contributions": 10634.0,

--- a/build/candidate/10/supporting/index.json
+++ b/build/candidate/10/supporting/index.json
@@ -35,10 +35,14 @@
       "Candidate Filing/Ballot Fees": 300.0,
       "Campaign Literature and Mailings": 3399.31,
       "Information Technology Costs (Internet, E-mail)": 387.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 10634.0,
   "total_contributions": 10634.0,

--- a/build/candidate/11/index.json
+++ b/build/candidate/11/index.json
@@ -28,8 +28,8 @@
       "Other (includes Businesses)": 37631.69
     },
     "expenditures_by_type": {
-      "": 10826.1,
       "Print Ads": 500.0,
+      "Not Stated": 10826.1,
       "Contribution": 550.0,
       "Civic Donations": 700.0,
       "Office Expenses": 3595.76,
@@ -39,10 +39,23 @@
       "Candidate Filing/Ballot Fees": 300.0,
       "Campaign Literature and Mailings": 36593.49,
       "Professional Services (Legal, Accounting)": 21788.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 40013.84
+    "opposing_expenditures": 40013.84,
+    "opposing_by_type": {
+      "Postage": 4714.25,
+      "Mailer Design": 1650.0,
+      "Mailer Printing": 2438.13,
+      "Mailhouse \u0026 Postage": 3699.26,
+      "Digital Ad in opposition to Noel Gallo": 9250.0,
+      "Design of mailer in opposition to Noel Gallo": 3300.0,
+      "Design of mailer in opposition of Noel Gallo.": 1650.0,
+      "Printing of mailer in opposition to Noel Gallo": 5913.68,
+      "Mailing and Postage in opposition to Noel Gallo": 7398.52
+    }
   },
   "contributions_received": 80100.69,
   "total_contributions": 80100.69,
@@ -55,8 +68,8 @@
     "Other (includes Businesses)": 37631.69
   },
   "expenditures_by_type": {
-    "": 10826.1,
     "Print Ads": 500.0,
+    "Not Stated": 10826.1,
     "Contribution": 550.0,
     "Civic Donations": 700.0,
     "Office Expenses": 3595.76,

--- a/build/candidate/11/opposing/index.json
+++ b/build/candidate/11/opposing/index.json
@@ -28,8 +28,8 @@
       "Other (includes Businesses)": 37631.69
     },
     "expenditures_by_type": {
-      "": 10826.1,
       "Print Ads": 500.0,
+      "Not Stated": 10826.1,
       "Contribution": 550.0,
       "Civic Donations": 700.0,
       "Office Expenses": 3595.76,
@@ -39,10 +39,23 @@
       "Candidate Filing/Ballot Fees": 300.0,
       "Campaign Literature and Mailings": 36593.49,
       "Professional Services (Legal, Accounting)": 21788.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 40013.84
+    "opposing_expenditures": 40013.84,
+    "opposing_by_type": {
+      "Postage": 4714.25,
+      "Mailer Design": 1650.0,
+      "Mailer Printing": 2438.13,
+      "Mailhouse \u0026 Postage": 3699.26,
+      "Digital Ad in opposition to Noel Gallo": 9250.0,
+      "Design of mailer in opposition to Noel Gallo": 3300.0,
+      "Design of mailer in opposition of Noel Gallo.": 1650.0,
+      "Printing of mailer in opposition to Noel Gallo": 5913.68,
+      "Mailing and Postage in opposition to Noel Gallo": 7398.52
+    }
   },
   "contributions_received": 80100.69,
   "total_contributions": 80100.69,
@@ -55,8 +68,8 @@
     "Other (includes Businesses)": 37631.69
   },
   "expenditures_by_type": {
-    "": 10826.1,
     "Print Ads": 500.0,
+    "Not Stated": 10826.1,
     "Contribution": 550.0,
     "Civic Donations": 700.0,
     "Office Expenses": 3595.76,

--- a/build/candidate/11/supporting/index.json
+++ b/build/candidate/11/supporting/index.json
@@ -28,8 +28,8 @@
       "Other (includes Businesses)": 37631.69
     },
     "expenditures_by_type": {
-      "": 10826.1,
       "Print Ads": 500.0,
+      "Not Stated": 10826.1,
       "Contribution": 550.0,
       "Civic Donations": 700.0,
       "Office Expenses": 3595.76,
@@ -39,10 +39,23 @@
       "Candidate Filing/Ballot Fees": 300.0,
       "Campaign Literature and Mailings": 36593.49,
       "Professional Services (Legal, Accounting)": 21788.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 40013.84
+    "opposing_expenditures": 40013.84,
+    "opposing_by_type": {
+      "Postage": 4714.25,
+      "Mailer Design": 1650.0,
+      "Mailer Printing": 2438.13,
+      "Mailhouse \u0026 Postage": 3699.26,
+      "Digital Ad in opposition to Noel Gallo": 9250.0,
+      "Design of mailer in opposition to Noel Gallo": 3300.0,
+      "Design of mailer in opposition of Noel Gallo.": 1650.0,
+      "Printing of mailer in opposition to Noel Gallo": 5913.68,
+      "Mailing and Postage in opposition to Noel Gallo": 7398.52
+    }
   },
   "contributions_received": 80100.69,
   "total_contributions": 80100.69,
@@ -55,8 +68,8 @@
     "Other (includes Businesses)": 37631.69
   },
   "expenditures_by_type": {
-    "": 10826.1,
     "Print Ads": 500.0,
+    "Not Stated": 10826.1,
     "Contribution": 550.0,
     "Civic Donations": 700.0,
     "Office Expenses": 3595.76,

--- a/build/candidate/12/index.json
+++ b/build/candidate/12/index.json
@@ -29,16 +29,20 @@
       "Other (includes Businesses)": 3300.0
     },
     "expenditures_by_type": {
-      "": 455.45,
+      "Not Stated": 455.45,
       "Campaign Consultants": 18667.55,
       "Meetings and Appearances": 529.0,
       "Campaign Paraphernalia/Misc.": 3884.37,
       "Campaign Literature and Mailings": 33656.76,
       "Information Technology Costs (Internet, E-mail)": 3150.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 84742.41,
   "total_contributions": 84742.41,
@@ -52,7 +56,7 @@
     "Other (includes Businesses)": 3300.0
   },
   "expenditures_by_type": {
-    "": 455.45,
+    "Not Stated": 455.45,
     "Campaign Consultants": 18667.55,
     "Meetings and Appearances": 529.0,
     "Campaign Paraphernalia/Misc.": 3884.37,

--- a/build/candidate/12/opposing/index.json
+++ b/build/candidate/12/opposing/index.json
@@ -29,16 +29,20 @@
       "Other (includes Businesses)": 3300.0
     },
     "expenditures_by_type": {
-      "": 455.45,
+      "Not Stated": 455.45,
       "Campaign Consultants": 18667.55,
       "Meetings and Appearances": 529.0,
       "Campaign Paraphernalia/Misc.": 3884.37,
       "Campaign Literature and Mailings": 33656.76,
       "Information Technology Costs (Internet, E-mail)": 3150.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 84742.41,
   "total_contributions": 84742.41,
@@ -52,7 +56,7 @@
     "Other (includes Businesses)": 3300.0
   },
   "expenditures_by_type": {
-    "": 455.45,
+    "Not Stated": 455.45,
     "Campaign Consultants": 18667.55,
     "Meetings and Appearances": 529.0,
     "Campaign Paraphernalia/Misc.": 3884.37,

--- a/build/candidate/12/supporting/index.json
+++ b/build/candidate/12/supporting/index.json
@@ -29,16 +29,20 @@
       "Other (includes Businesses)": 3300.0
     },
     "expenditures_by_type": {
-      "": 455.45,
+      "Not Stated": 455.45,
       "Campaign Consultants": 18667.55,
       "Meetings and Appearances": 529.0,
       "Campaign Paraphernalia/Misc.": 3884.37,
       "Campaign Literature and Mailings": 33656.76,
       "Information Technology Costs (Internet, E-mail)": 3150.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 84742.41,
   "total_contributions": 84742.41,
@@ -52,7 +56,7 @@
     "Other (includes Businesses)": 3300.0
   },
   "expenditures_by_type": {
-    "": 455.45,
+    "Not Stated": 455.45,
     "Campaign Consultants": 18667.55,
     "Meetings and Appearances": 529.0,
     "Campaign Paraphernalia/Misc.": 3884.37,

--- a/build/candidate/13/index.json
+++ b/build/candidate/13/index.json
@@ -25,13 +25,17 @@
       "Unitemized": 382.0
     },
     "expenditures_by_type": {
-      "": 435.74,
+      "Not Stated": 435.74,
       "Campaign Paraphernalia/Misc.": 13557.03,
       "Professional Services (Legal, Accounting)": 850.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 20239.0,
   "total_contributions": 20239.0,
@@ -41,7 +45,7 @@
     "Unitemized": 382.0
   },
   "expenditures_by_type": {
-    "": 435.74,
+    "Not Stated": 435.74,
     "Campaign Paraphernalia/Misc.": 13557.03,
     "Professional Services (Legal, Accounting)": 850.0
   }

--- a/build/candidate/13/opposing/index.json
+++ b/build/candidate/13/opposing/index.json
@@ -25,13 +25,17 @@
       "Unitemized": 382.0
     },
     "expenditures_by_type": {
-      "": 435.74,
+      "Not Stated": 435.74,
       "Campaign Paraphernalia/Misc.": 13557.03,
       "Professional Services (Legal, Accounting)": 850.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 20239.0,
   "total_contributions": 20239.0,
@@ -41,7 +45,7 @@
     "Unitemized": 382.0
   },
   "expenditures_by_type": {
-    "": 435.74,
+    "Not Stated": 435.74,
     "Campaign Paraphernalia/Misc.": 13557.03,
     "Professional Services (Legal, Accounting)": 850.0
   }

--- a/build/candidate/13/supporting/index.json
+++ b/build/candidate/13/supporting/index.json
@@ -25,13 +25,17 @@
       "Unitemized": 382.0
     },
     "expenditures_by_type": {
-      "": 435.74,
+      "Not Stated": 435.74,
       "Campaign Paraphernalia/Misc.": 13557.03,
       "Professional Services (Legal, Accounting)": 850.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 20239.0,
   "total_contributions": 20239.0,
@@ -41,7 +45,7 @@
     "Unitemized": 382.0
   },
   "expenditures_by_type": {
-    "": 435.74,
+    "Not Stated": 435.74,
     "Campaign Paraphernalia/Misc.": 13557.03,
     "Professional Services (Legal, Accounting)": 850.0
   }

--- a/build/candidate/14/index.json
+++ b/build/candidate/14/index.json
@@ -27,7 +27,7 @@
       "Unitemized": 3066.0
     },
     "expenditures_by_type": {
-      "": 700.0,
+      "Not Stated": 700.0,
       "Phone Banks": 1659.63,
       "Office Expenses": 2307.9,
       "Campaign Consultants": 3000.0,
@@ -35,10 +35,14 @@
       "Campaign Literature and Mailings": 7287.36,
       "Postage, Delivery and Messenger Services": 3818.95,
       "Professional Services (Legal, Accounting)": 3147.37
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 26966.0,
   "total_contributions": 26966.0,
@@ -50,7 +54,7 @@
     "Unitemized": 3066.0
   },
   "expenditures_by_type": {
-    "": 700.0,
+    "Not Stated": 700.0,
     "Phone Banks": 1659.63,
     "Office Expenses": 2307.9,
     "Campaign Consultants": 3000.0,

--- a/build/candidate/14/opposing/index.json
+++ b/build/candidate/14/opposing/index.json
@@ -27,7 +27,7 @@
       "Unitemized": 3066.0
     },
     "expenditures_by_type": {
-      "": 700.0,
+      "Not Stated": 700.0,
       "Phone Banks": 1659.63,
       "Office Expenses": 2307.9,
       "Campaign Consultants": 3000.0,
@@ -35,10 +35,14 @@
       "Campaign Literature and Mailings": 7287.36,
       "Postage, Delivery and Messenger Services": 3818.95,
       "Professional Services (Legal, Accounting)": 3147.37
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 26966.0,
   "total_contributions": 26966.0,
@@ -50,7 +54,7 @@
     "Unitemized": 3066.0
   },
   "expenditures_by_type": {
-    "": 700.0,
+    "Not Stated": 700.0,
     "Phone Banks": 1659.63,
     "Office Expenses": 2307.9,
     "Campaign Consultants": 3000.0,

--- a/build/candidate/14/supporting/index.json
+++ b/build/candidate/14/supporting/index.json
@@ -27,7 +27,7 @@
       "Unitemized": 3066.0
     },
     "expenditures_by_type": {
-      "": 700.0,
+      "Not Stated": 700.0,
       "Phone Banks": 1659.63,
       "Office Expenses": 2307.9,
       "Campaign Consultants": 3000.0,
@@ -35,10 +35,14 @@
       "Campaign Literature and Mailings": 7287.36,
       "Postage, Delivery and Messenger Services": 3818.95,
       "Professional Services (Legal, Accounting)": 3147.37
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 26966.0,
   "total_contributions": 26966.0,
@@ -50,7 +54,7 @@
     "Unitemized": 3066.0
   },
   "expenditures_by_type": {
-    "": 700.0,
+    "Not Stated": 700.0,
     "Phone Banks": 1659.63,
     "Office Expenses": 2307.9,
     "Campaign Consultants": 3000.0,

--- a/build/candidate/15/index.json
+++ b/build/candidate/15/index.json
@@ -28,8 +28,8 @@
       "Other (includes Businesses)": 15550.0
     },
     "expenditures_by_type": {
-      "": 4698.42,
       "Print Ads": 1000.0,
+      "Not Stated": 4698.42,
       "Office Expenses": 649.6,
       "Fundraising Events": 315.92,
       "Campaign Consultants": 15000.0,
@@ -39,10 +39,14 @@
       "Staff/Spouse Travel, Lodging, and Meals": 202.76,
       "Professional Services (Legal, Accounting)": 10248.12,
       "Information Technology Costs (Internet, E-mail)": 2236.58
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 72976.0,
   "total_contributions": 72976.0,
@@ -55,8 +59,8 @@
     "Other (includes Businesses)": 15550.0
   },
   "expenditures_by_type": {
-    "": 4698.42,
     "Print Ads": 1000.0,
+    "Not Stated": 4698.42,
     "Office Expenses": 649.6,
     "Fundraising Events": 315.92,
     "Campaign Consultants": 15000.0,

--- a/build/candidate/15/opposing/index.json
+++ b/build/candidate/15/opposing/index.json
@@ -28,8 +28,8 @@
       "Other (includes Businesses)": 15550.0
     },
     "expenditures_by_type": {
-      "": 4698.42,
       "Print Ads": 1000.0,
+      "Not Stated": 4698.42,
       "Office Expenses": 649.6,
       "Fundraising Events": 315.92,
       "Campaign Consultants": 15000.0,
@@ -39,10 +39,14 @@
       "Staff/Spouse Travel, Lodging, and Meals": 202.76,
       "Professional Services (Legal, Accounting)": 10248.12,
       "Information Technology Costs (Internet, E-mail)": 2236.58
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 72976.0,
   "total_contributions": 72976.0,
@@ -55,8 +59,8 @@
     "Other (includes Businesses)": 15550.0
   },
   "expenditures_by_type": {
-    "": 4698.42,
     "Print Ads": 1000.0,
+    "Not Stated": 4698.42,
     "Office Expenses": 649.6,
     "Fundraising Events": 315.92,
     "Campaign Consultants": 15000.0,

--- a/build/candidate/15/supporting/index.json
+++ b/build/candidate/15/supporting/index.json
@@ -28,8 +28,8 @@
       "Other (includes Businesses)": 15550.0
     },
     "expenditures_by_type": {
-      "": 4698.42,
       "Print Ads": 1000.0,
+      "Not Stated": 4698.42,
       "Office Expenses": 649.6,
       "Fundraising Events": 315.92,
       "Campaign Consultants": 15000.0,
@@ -39,10 +39,14 @@
       "Staff/Spouse Travel, Lodging, and Meals": 202.76,
       "Professional Services (Legal, Accounting)": 10248.12,
       "Information Technology Costs (Internet, E-mail)": 2236.58
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 72976.0,
   "total_contributions": 72976.0,
@@ -55,8 +59,8 @@
     "Other (includes Businesses)": 15550.0
   },
   "expenditures_by_type": {
-    "": 4698.42,
     "Print Ads": 1000.0,
+    "Not Stated": 4698.42,
     "Office Expenses": 649.6,
     "Fundraising Events": 315.92,
     "Campaign Consultants": 15000.0,

--- a/build/candidate/16/index.json
+++ b/build/candidate/16/index.json
@@ -27,7 +27,7 @@
       "Other (includes Businesses)": 1750.0
     },
     "expenditures_by_type": {
-      "": 809.02,
+      "Not Stated": 809.02,
       "Office Expenses": 1710.94,
       "Fundraising Events": 147.81,
       "Voter Registration": 156.15,
@@ -39,10 +39,14 @@
       "Staff/Spouse Travel, Lodging, and Meals": 320.14,
       "Professional Services (Legal, Accounting)": 372.42,
       "Information Technology Costs (Internet, E-mail)": 100.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 5144.0,
   "total_contributions": 5144.0,
@@ -54,7 +58,7 @@
     "Other (includes Businesses)": 1750.0
   },
   "expenditures_by_type": {
-    "": 809.02,
+    "Not Stated": 809.02,
     "Office Expenses": 1710.94,
     "Fundraising Events": 147.81,
     "Voter Registration": 156.15,

--- a/build/candidate/16/opposing/index.json
+++ b/build/candidate/16/opposing/index.json
@@ -27,7 +27,7 @@
       "Other (includes Businesses)": 1750.0
     },
     "expenditures_by_type": {
-      "": 809.02,
+      "Not Stated": 809.02,
       "Office Expenses": 1710.94,
       "Fundraising Events": 147.81,
       "Voter Registration": 156.15,
@@ -39,10 +39,14 @@
       "Staff/Spouse Travel, Lodging, and Meals": 320.14,
       "Professional Services (Legal, Accounting)": 372.42,
       "Information Technology Costs (Internet, E-mail)": 100.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 5144.0,
   "total_contributions": 5144.0,
@@ -54,7 +58,7 @@
     "Other (includes Businesses)": 1750.0
   },
   "expenditures_by_type": {
-    "": 809.02,
+    "Not Stated": 809.02,
     "Office Expenses": 1710.94,
     "Fundraising Events": 147.81,
     "Voter Registration": 156.15,

--- a/build/candidate/16/supporting/index.json
+++ b/build/candidate/16/supporting/index.json
@@ -27,7 +27,7 @@
       "Other (includes Businesses)": 1750.0
     },
     "expenditures_by_type": {
-      "": 809.02,
+      "Not Stated": 809.02,
       "Office Expenses": 1710.94,
       "Fundraising Events": 147.81,
       "Voter Registration": 156.15,
@@ -39,10 +39,14 @@
       "Staff/Spouse Travel, Lodging, and Meals": 320.14,
       "Professional Services (Legal, Accounting)": 372.42,
       "Information Technology Costs (Internet, E-mail)": 100.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 5144.0,
   "total_contributions": 5144.0,
@@ -54,7 +58,7 @@
     "Other (includes Businesses)": 1750.0
   },
   "expenditures_by_type": {
-    "": 809.02,
+    "Not Stated": 809.02,
     "Office Expenses": 1710.94,
     "Fundraising Events": 147.81,
     "Voter Registration": 156.15,

--- a/build/candidate/17/index.json
+++ b/build/candidate/17/index.json
@@ -28,7 +28,6 @@
       "Other (includes Businesses)": 2600.0
     },
     "expenditures_by_type": {
-      "Not Stated": 3894.33,
       "Office Expenses": 248.2,
       "Fundraising Events": 2338.58,
       "Campaign Consultants": 1000.0,
@@ -36,10 +35,17 @@
       "Campaign Paraphernalia/Misc.": 3755.99,
       "Candidate Filing/Ballot Fees": 300.0,
       "Campaign Literature and Mailings": 15150.0
+    },
+    "supporting_by_type": {
+      "ESTIMATE OF STAFF TIME": 1941.33,
+      "Campaign Literature and Mailings": 48.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 1905.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 22344.0,
   "total_contributions": 22344.0,
@@ -52,7 +58,6 @@
     "Other (includes Businesses)": 2600.0
   },
   "expenditures_by_type": {
-    "Not Stated": 3894.33,
     "Office Expenses": 248.2,
     "Fundraising Events": 2338.58,
     "Campaign Consultants": 1000.0,

--- a/build/candidate/17/opposing/index.json
+++ b/build/candidate/17/opposing/index.json
@@ -28,7 +28,6 @@
       "Other (includes Businesses)": 2600.0
     },
     "expenditures_by_type": {
-      "Not Stated": 3894.33,
       "Office Expenses": 248.2,
       "Fundraising Events": 2338.58,
       "Campaign Consultants": 1000.0,
@@ -36,10 +35,17 @@
       "Campaign Paraphernalia/Misc.": 3755.99,
       "Candidate Filing/Ballot Fees": 300.0,
       "Campaign Literature and Mailings": 15150.0
+    },
+    "supporting_by_type": {
+      "ESTIMATE OF STAFF TIME": 1941.33,
+      "Campaign Literature and Mailings": 48.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 1905.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 22344.0,
   "total_contributions": 22344.0,
@@ -52,7 +58,6 @@
     "Other (includes Businesses)": 2600.0
   },
   "expenditures_by_type": {
-    "Not Stated": 3894.33,
     "Office Expenses": 248.2,
     "Fundraising Events": 2338.58,
     "Campaign Consultants": 1000.0,

--- a/build/candidate/17/supporting/index.json
+++ b/build/candidate/17/supporting/index.json
@@ -28,7 +28,6 @@
       "Other (includes Businesses)": 2600.0
     },
     "expenditures_by_type": {
-      "Not Stated": 3894.33,
       "Office Expenses": 248.2,
       "Fundraising Events": 2338.58,
       "Campaign Consultants": 1000.0,
@@ -36,10 +35,17 @@
       "Campaign Paraphernalia/Misc.": 3755.99,
       "Candidate Filing/Ballot Fees": 300.0,
       "Campaign Literature and Mailings": 15150.0
+    },
+    "supporting_by_type": {
+      "ESTIMATE OF STAFF TIME": 1941.33,
+      "Campaign Literature and Mailings": 48.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 1905.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 22344.0,
   "total_contributions": 22344.0,
@@ -52,7 +58,6 @@
     "Other (includes Businesses)": 2600.0
   },
   "expenditures_by_type": {
-    "Not Stated": 3894.33,
     "Office Expenses": 248.2,
     "Fundraising Events": 2338.58,
     "Campaign Consultants": 1000.0,

--- a/build/candidate/18/index.json
+++ b/build/candidate/18/index.json
@@ -27,7 +27,6 @@
       "Unitemized": 0.0
     },
     "expenditures_by_type": {
-      "Not Stated": 78327.14,
       "Phone Banks": 834.94,
       "Fundraising Events": 203.53,
       "Campaign Consultants": 1340.0,
@@ -35,10 +34,22 @@
       "Campaign Literature and Mailings": 5458.08,
       "Professional Services (Legal, Accounting)": 200.0,
       "Information Technology Costs (Internet, E-mail)": 597.0
+    },
+    "supporting_by_type": {
+      "Print Ads": 2048.0,
+      "Phone Banks": 276.33,
+      "ESTIMATE OF LIT": 1800.0,
+      "ESTIMATE OF STAFF TIME": 19599.4,
+      "Campaign Paraphernalia/Misc.": 2702.11,
+      "Campaign Literature and Mailings": 45044.3,
+      "Information Technology Costs (Internet, E-mail)": 675.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 6182.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 17888.0,
   "total_contributions": 17888.0,
@@ -50,7 +61,6 @@
     "Unitemized": 0.0
   },
   "expenditures_by_type": {
-    "Not Stated": 78327.14,
     "Phone Banks": 834.94,
     "Fundraising Events": 203.53,
     "Campaign Consultants": 1340.0,

--- a/build/candidate/18/opposing/index.json
+++ b/build/candidate/18/opposing/index.json
@@ -27,7 +27,6 @@
       "Unitemized": 0.0
     },
     "expenditures_by_type": {
-      "Not Stated": 78327.14,
       "Phone Banks": 834.94,
       "Fundraising Events": 203.53,
       "Campaign Consultants": 1340.0,
@@ -35,10 +34,22 @@
       "Campaign Literature and Mailings": 5458.08,
       "Professional Services (Legal, Accounting)": 200.0,
       "Information Technology Costs (Internet, E-mail)": 597.0
+    },
+    "supporting_by_type": {
+      "Print Ads": 2048.0,
+      "Phone Banks": 276.33,
+      "ESTIMATE OF LIT": 1800.0,
+      "ESTIMATE OF STAFF TIME": 19599.4,
+      "Campaign Paraphernalia/Misc.": 2702.11,
+      "Campaign Literature and Mailings": 45044.3,
+      "Information Technology Costs (Internet, E-mail)": 675.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 6182.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 17888.0,
   "total_contributions": 17888.0,
@@ -50,7 +61,6 @@
     "Unitemized": 0.0
   },
   "expenditures_by_type": {
-    "Not Stated": 78327.14,
     "Phone Banks": 834.94,
     "Fundraising Events": 203.53,
     "Campaign Consultants": 1340.0,

--- a/build/candidate/18/supporting/index.json
+++ b/build/candidate/18/supporting/index.json
@@ -27,7 +27,6 @@
       "Unitemized": 0.0
     },
     "expenditures_by_type": {
-      "Not Stated": 78327.14,
       "Phone Banks": 834.94,
       "Fundraising Events": 203.53,
       "Campaign Consultants": 1340.0,
@@ -35,10 +34,22 @@
       "Campaign Literature and Mailings": 5458.08,
       "Professional Services (Legal, Accounting)": 200.0,
       "Information Technology Costs (Internet, E-mail)": 597.0
+    },
+    "supporting_by_type": {
+      "Print Ads": 2048.0,
+      "Phone Banks": 276.33,
+      "ESTIMATE OF LIT": 1800.0,
+      "ESTIMATE OF STAFF TIME": 19599.4,
+      "Campaign Paraphernalia/Misc.": 2702.11,
+      "Campaign Literature and Mailings": 45044.3,
+      "Information Technology Costs (Internet, E-mail)": 675.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 6182.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 17888.0,
   "total_contributions": 17888.0,
@@ -50,7 +61,6 @@
     "Unitemized": 0.0
   },
   "expenditures_by_type": {
-    "Not Stated": 78327.14,
     "Phone Banks": 834.94,
     "Fundraising Events": 203.53,
     "Campaign Consultants": 1340.0,

--- a/build/candidate/19/index.json
+++ b/build/candidate/19/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/19/opposing/index.json
+++ b/build/candidate/19/opposing/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/19/supporting/index.json
+++ b/build/candidate/19/supporting/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/2/index.json
+++ b/build/candidate/2/index.json
@@ -29,8 +29,8 @@
       "Other (includes Businesses)": 11950.0
     },
     "expenditures_by_type": {
-      "": 16605.58,
       "Print Ads": 1298.18,
+      "Not Stated": 16605.58,
       "Office Expenses": 15728.02,
       "Fundraising Events": 750.0,
       "Campaign Consultants": 41405.69,
@@ -42,10 +42,14 @@
       "Professional Services (Legal, Accounting)": 3583.75,
       "T.V. or Cable Airtime and Production Costs": 8000.0,
       "Information Technology Costs (Internet, E-mail)": 400.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 134374.0,
   "total_contributions": 134374.0,
@@ -59,8 +63,8 @@
     "Other (includes Businesses)": 11950.0
   },
   "expenditures_by_type": {
-    "": 16605.58,
     "Print Ads": 1298.18,
+    "Not Stated": 16605.58,
     "Office Expenses": 15728.02,
     "Fundraising Events": 750.0,
     "Campaign Consultants": 41405.69,

--- a/build/candidate/2/opposing/index.json
+++ b/build/candidate/2/opposing/index.json
@@ -29,8 +29,8 @@
       "Other (includes Businesses)": 11950.0
     },
     "expenditures_by_type": {
-      "": 16605.58,
       "Print Ads": 1298.18,
+      "Not Stated": 16605.58,
       "Office Expenses": 15728.02,
       "Fundraising Events": 750.0,
       "Campaign Consultants": 41405.69,
@@ -42,10 +42,14 @@
       "Professional Services (Legal, Accounting)": 3583.75,
       "T.V. or Cable Airtime and Production Costs": 8000.0,
       "Information Technology Costs (Internet, E-mail)": 400.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 134374.0,
   "total_contributions": 134374.0,
@@ -59,8 +63,8 @@
     "Other (includes Businesses)": 11950.0
   },
   "expenditures_by_type": {
-    "": 16605.58,
     "Print Ads": 1298.18,
+    "Not Stated": 16605.58,
     "Office Expenses": 15728.02,
     "Fundraising Events": 750.0,
     "Campaign Consultants": 41405.69,

--- a/build/candidate/2/supporting/index.json
+++ b/build/candidate/2/supporting/index.json
@@ -29,8 +29,8 @@
       "Other (includes Businesses)": 11950.0
     },
     "expenditures_by_type": {
-      "": 16605.58,
       "Print Ads": 1298.18,
+      "Not Stated": 16605.58,
       "Office Expenses": 15728.02,
       "Fundraising Events": 750.0,
       "Campaign Consultants": 41405.69,
@@ -42,10 +42,14 @@
       "Professional Services (Legal, Accounting)": 3583.75,
       "T.V. or Cable Airtime and Production Costs": 8000.0,
       "Information Technology Costs (Internet, E-mail)": 400.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 134374.0,
   "total_contributions": 134374.0,
@@ -59,8 +63,8 @@
     "Other (includes Businesses)": 11950.0
   },
   "expenditures_by_type": {
-    "": 16605.58,
     "Print Ads": 1298.18,
+    "Not Stated": 16605.58,
     "Office Expenses": 15728.02,
     "Fundraising Events": 750.0,
     "Campaign Consultants": 41405.69,

--- a/build/candidate/20/index.json
+++ b/build/candidate/20/index.json
@@ -17,42 +17,48 @@
   "party_affiliation": null,
   "filer_id": 1386929,
   "supporting_money": {
-    "contributions_received": 3980.0,
-    "total_contributions": 3980.0,
-    "total_expenditures": 2382.67,
+    "contributions_received": 5798.0,
+    "total_contributions": 5798.0,
+    "total_expenditures": 3052.34,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Individual": 1800.0,
-      "Unitemized": 515.0,
-      "Other (includes Businesses)": 1665.0
+      "Individual": 2590.0,
+      "Unitemized": 1093.0,
+      "Other (includes Businesses)": 2115.0
     },
     "expenditures_by_type": {
+      "Not Stated": 60.0,
       "Fundraising Events": 128.05,
       "Meetings and Appearances": 114.67,
-      "Campaign Paraphernalia/Misc.": 724.48,
-      "Candidate Filing/Ballot Fees": 300.0,
-      "Campaign Literature and Mailings": 839.01,
-      "Information Technology Costs (Internet, E-mail)": 148.0
+      "Campaign Paraphernalia/Misc.": 870.17,
+      "Candidate Filing/Ballot Fees": 310.0,
+      "Campaign Literature and Mailings": 1187.01,
+      "Information Technology Costs (Internet, E-mail)": 177.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
-  "contributions_received": 3980.0,
-  "total_contributions": 3980.0,
-  "total_expenditures": 2382.67,
+  "contributions_received": 5798.0,
+  "total_contributions": 5798.0,
+  "total_expenditures": 3052.34,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Individual": 1800.0,
-    "Unitemized": 515.0,
-    "Other (includes Businesses)": 1665.0
+    "Individual": 2590.0,
+    "Unitemized": 1093.0,
+    "Other (includes Businesses)": 2115.0
   },
   "expenditures_by_type": {
+    "Not Stated": 60.0,
     "Fundraising Events": 128.05,
     "Meetings and Appearances": 114.67,
-    "Campaign Paraphernalia/Misc.": 724.48,
-    "Candidate Filing/Ballot Fees": 300.0,
-    "Campaign Literature and Mailings": 839.01,
-    "Information Technology Costs (Internet, E-mail)": 148.0
+    "Campaign Paraphernalia/Misc.": 870.17,
+    "Candidate Filing/Ballot Fees": 310.0,
+    "Campaign Literature and Mailings": 1187.01,
+    "Information Technology Costs (Internet, E-mail)": 177.0
   }
 }

--- a/build/candidate/20/opposing/index.json
+++ b/build/candidate/20/opposing/index.json
@@ -17,42 +17,48 @@
   "party_affiliation": null,
   "filer_id": 1386929,
   "supporting_money": {
-    "contributions_received": 3980.0,
-    "total_contributions": 3980.0,
-    "total_expenditures": 2382.67,
+    "contributions_received": 5798.0,
+    "total_contributions": 5798.0,
+    "total_expenditures": 3052.34,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Individual": 1800.0,
-      "Unitemized": 515.0,
-      "Other (includes Businesses)": 1665.0
+      "Individual": 2590.0,
+      "Unitemized": 1093.0,
+      "Other (includes Businesses)": 2115.0
     },
     "expenditures_by_type": {
+      "Not Stated": 60.0,
       "Fundraising Events": 128.05,
       "Meetings and Appearances": 114.67,
-      "Campaign Paraphernalia/Misc.": 724.48,
-      "Candidate Filing/Ballot Fees": 300.0,
-      "Campaign Literature and Mailings": 839.01,
-      "Information Technology Costs (Internet, E-mail)": 148.0
+      "Campaign Paraphernalia/Misc.": 870.17,
+      "Candidate Filing/Ballot Fees": 310.0,
+      "Campaign Literature and Mailings": 1187.01,
+      "Information Technology Costs (Internet, E-mail)": 177.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
-  "contributions_received": 3980.0,
-  "total_contributions": 3980.0,
-  "total_expenditures": 2382.67,
+  "contributions_received": 5798.0,
+  "total_contributions": 5798.0,
+  "total_expenditures": 3052.34,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Individual": 1800.0,
-    "Unitemized": 515.0,
-    "Other (includes Businesses)": 1665.0
+    "Individual": 2590.0,
+    "Unitemized": 1093.0,
+    "Other (includes Businesses)": 2115.0
   },
   "expenditures_by_type": {
+    "Not Stated": 60.0,
     "Fundraising Events": 128.05,
     "Meetings and Appearances": 114.67,
-    "Campaign Paraphernalia/Misc.": 724.48,
-    "Candidate Filing/Ballot Fees": 300.0,
-    "Campaign Literature and Mailings": 839.01,
-    "Information Technology Costs (Internet, E-mail)": 148.0
+    "Campaign Paraphernalia/Misc.": 870.17,
+    "Candidate Filing/Ballot Fees": 310.0,
+    "Campaign Literature and Mailings": 1187.01,
+    "Information Technology Costs (Internet, E-mail)": 177.0
   }
 }

--- a/build/candidate/20/supporting/index.json
+++ b/build/candidate/20/supporting/index.json
@@ -17,42 +17,48 @@
   "party_affiliation": null,
   "filer_id": 1386929,
   "supporting_money": {
-    "contributions_received": 3980.0,
-    "total_contributions": 3980.0,
-    "total_expenditures": 2382.67,
+    "contributions_received": 5798.0,
+    "total_contributions": 5798.0,
+    "total_expenditures": 3052.34,
     "total_loans_received": 0.0,
     "contributions_by_type": {
-      "Individual": 1800.0,
-      "Unitemized": 515.0,
-      "Other (includes Businesses)": 1665.0
+      "Individual": 2590.0,
+      "Unitemized": 1093.0,
+      "Other (includes Businesses)": 2115.0
     },
     "expenditures_by_type": {
+      "Not Stated": 60.0,
       "Fundraising Events": 128.05,
       "Meetings and Appearances": 114.67,
-      "Campaign Paraphernalia/Misc.": 724.48,
-      "Candidate Filing/Ballot Fees": 300.0,
-      "Campaign Literature and Mailings": 839.01,
-      "Information Technology Costs (Internet, E-mail)": 148.0
+      "Campaign Paraphernalia/Misc.": 870.17,
+      "Candidate Filing/Ballot Fees": 310.0,
+      "Campaign Literature and Mailings": 1187.01,
+      "Information Technology Costs (Internet, E-mail)": 177.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
-  "contributions_received": 3980.0,
-  "total_contributions": 3980.0,
-  "total_expenditures": 2382.67,
+  "contributions_received": 5798.0,
+  "total_contributions": 5798.0,
+  "total_expenditures": 3052.34,
   "total_loans_received": 0.0,
   "contributions_by_type": {
-    "Individual": 1800.0,
-    "Unitemized": 515.0,
-    "Other (includes Businesses)": 1665.0
+    "Individual": 2590.0,
+    "Unitemized": 1093.0,
+    "Other (includes Businesses)": 2115.0
   },
   "expenditures_by_type": {
+    "Not Stated": 60.0,
     "Fundraising Events": 128.05,
     "Meetings and Appearances": 114.67,
-    "Campaign Paraphernalia/Misc.": 724.48,
-    "Candidate Filing/Ballot Fees": 300.0,
-    "Campaign Literature and Mailings": 839.01,
-    "Information Technology Costs (Internet, E-mail)": 148.0
+    "Campaign Paraphernalia/Misc.": 870.17,
+    "Candidate Filing/Ballot Fees": 310.0,
+    "Campaign Literature and Mailings": 1187.01,
+    "Information Technology Costs (Internet, E-mail)": 177.0
   }
 }

--- a/build/candidate/21/index.json
+++ b/build/candidate/21/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/21/opposing/index.json
+++ b/build/candidate/21/opposing/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/21/supporting/index.json
+++ b/build/candidate/21/supporting/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/22/index.json
+++ b/build/candidate/22/index.json
@@ -30,10 +30,14 @@
       "Office Expenses": 506.71,
       "Campaign Consultants": 2500.0,
       "Information Technology Costs (Internet, E-mail)": 265.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 8486.0,
   "total_contributions": 8486.0,

--- a/build/candidate/22/opposing/index.json
+++ b/build/candidate/22/opposing/index.json
@@ -30,10 +30,14 @@
       "Office Expenses": 506.71,
       "Campaign Consultants": 2500.0,
       "Information Technology Costs (Internet, E-mail)": 265.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 8486.0,
   "total_contributions": 8486.0,

--- a/build/candidate/22/supporting/index.json
+++ b/build/candidate/22/supporting/index.json
@@ -30,10 +30,14 @@
       "Office Expenses": 506.71,
       "Campaign Consultants": 2500.0,
       "Information Technology Costs (Internet, E-mail)": 265.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 8486.0,
   "total_contributions": 8486.0,

--- a/build/candidate/23/index.json
+++ b/build/candidate/23/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/23/opposing/index.json
+++ b/build/candidate/23/opposing/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/23/supporting/index.json
+++ b/build/candidate/23/supporting/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/24/index.json
+++ b/build/candidate/24/index.json
@@ -9,7 +9,7 @@
   "last_name": "Torres",
   "ballot_item": 8,
   "office_election": 8,
-  "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home\"",
+  "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home",
   "committee_name": "Roseann Torres for Oakland School Board 2016",
   "is_accepted_expenditure_ceiling": null,
   "is_incumbent": true,
@@ -28,7 +28,7 @@
       "Other (includes Businesses)": 1000.0
     },
     "expenditures_by_type": {
-      "": 3317.0,
+      "Not Stated": 3317.0,
       "Contribution": 300.0,
       "Office Expenses": 1736.74,
       "Fundraising Events": 1243.86,
@@ -37,10 +37,15 @@
       "Campaign Literature and Mailings": 3183.32,
       "Professional Services (Legal, Accounting)": 7081.33,
       "Information Technology Costs (Internet, E-mail)": 400.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 6987.5
+    "opposing_expenditures": 6987.5,
+    "opposing_by_type": {
+      "Campaign Literature and Mailings": 6987.5
+    }
   },
   "contributions_received": 21893.01,
   "total_contributions": 21893.01,
@@ -53,7 +58,7 @@
     "Other (includes Businesses)": 1000.0
   },
   "expenditures_by_type": {
-    "": 3317.0,
+    "Not Stated": 3317.0,
     "Contribution": 300.0,
     "Office Expenses": 1736.74,
     "Fundraising Events": 1243.86,

--- a/build/candidate/24/opposing/index.json
+++ b/build/candidate/24/opposing/index.json
@@ -9,7 +9,7 @@
   "last_name": "Torres",
   "ballot_item": 8,
   "office_election": 8,
-  "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home\"",
+  "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home",
   "committee_name": "Roseann Torres for Oakland School Board 2016",
   "is_accepted_expenditure_ceiling": null,
   "is_incumbent": true,
@@ -28,7 +28,7 @@
       "Other (includes Businesses)": 1000.0
     },
     "expenditures_by_type": {
-      "": 3317.0,
+      "Not Stated": 3317.0,
       "Contribution": 300.0,
       "Office Expenses": 1736.74,
       "Fundraising Events": 1243.86,
@@ -37,10 +37,15 @@
       "Campaign Literature and Mailings": 3183.32,
       "Professional Services (Legal, Accounting)": 7081.33,
       "Information Technology Costs (Internet, E-mail)": 400.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 6987.5
+    "opposing_expenditures": 6987.5,
+    "opposing_by_type": {
+      "Campaign Literature and Mailings": 6987.5
+    }
   },
   "contributions_received": 21893.01,
   "total_contributions": 21893.01,
@@ -53,7 +58,7 @@
     "Other (includes Businesses)": 1000.0
   },
   "expenditures_by_type": {
-    "": 3317.0,
+    "Not Stated": 3317.0,
     "Contribution": 300.0,
     "Office Expenses": 1736.74,
     "Fundraising Events": 1243.86,

--- a/build/candidate/24/supporting/index.json
+++ b/build/candidate/24/supporting/index.json
@@ -9,7 +9,7 @@
   "last_name": "Torres",
   "ballot_item": 8,
   "office_election": 8,
-  "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home\"",
+  "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home",
   "committee_name": "Roseann Torres for Oakland School Board 2016",
   "is_accepted_expenditure_ceiling": null,
   "is_incumbent": true,
@@ -28,7 +28,7 @@
       "Other (includes Businesses)": 1000.0
     },
     "expenditures_by_type": {
-      "": 3317.0,
+      "Not Stated": 3317.0,
       "Contribution": 300.0,
       "Office Expenses": 1736.74,
       "Fundraising Events": 1243.86,
@@ -37,10 +37,15 @@
       "Campaign Literature and Mailings": 3183.32,
       "Professional Services (Legal, Accounting)": 7081.33,
       "Information Technology Costs (Internet, E-mail)": 400.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 6987.5
+    "opposing_expenditures": 6987.5,
+    "opposing_by_type": {
+      "Campaign Literature and Mailings": 6987.5
+    }
   },
   "contributions_received": 21893.01,
   "total_contributions": 21893.01,
@@ -53,7 +58,7 @@
     "Other (includes Businesses)": 1000.0
   },
   "expenditures_by_type": {
-    "": 3317.0,
+    "Not Stated": 3317.0,
     "Contribution": 300.0,
     "Office Expenses": 1736.74,
     "Fundraising Events": 1243.86,

--- a/build/candidate/25/index.json
+++ b/build/candidate/25/index.json
@@ -28,7 +28,6 @@
       "Other (includes Businesses)": 3000.0
     },
     "expenditures_by_type": {
-      "Not Stated": 88339.72,
       "Office Expenses": 123.83,
       "Fundraising Events": 126.9,
       "Voter Registration": 1600.0,
@@ -38,10 +37,23 @@
       "Campaign Literature and Mailings": 10825.06,
       "Professional Services (Legal, Accounting)": 2500.0,
       "Information Technology Costs (Internet, E-mail)": 833.57
+    },
+    "supporting_by_type": {
+      "Print Ads": 48.0,
+      "CANVASSING": 5000.0,
+      "Phone Banks": 342.45,
+      "ESTIMATE OF LIT": 8981.0,
+      "ESTIMATE OF STAFF TIME": 20623.98,
+      "Campaign Paraphernalia/Misc.": 2702.11,
+      "Campaign Literature and Mailings": 35454.18,
+      "Information Technology Costs (Internet, E-mail)": 5675.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 9513.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 21685.48,
   "total_contributions": 21685.48,
@@ -54,7 +66,6 @@
     "Other (includes Businesses)": 3000.0
   },
   "expenditures_by_type": {
-    "Not Stated": 88339.72,
     "Office Expenses": 123.83,
     "Fundraising Events": 126.9,
     "Voter Registration": 1600.0,

--- a/build/candidate/25/opposing/index.json
+++ b/build/candidate/25/opposing/index.json
@@ -28,7 +28,6 @@
       "Other (includes Businesses)": 3000.0
     },
     "expenditures_by_type": {
-      "Not Stated": 88339.72,
       "Office Expenses": 123.83,
       "Fundraising Events": 126.9,
       "Voter Registration": 1600.0,
@@ -38,10 +37,23 @@
       "Campaign Literature and Mailings": 10825.06,
       "Professional Services (Legal, Accounting)": 2500.0,
       "Information Technology Costs (Internet, E-mail)": 833.57
+    },
+    "supporting_by_type": {
+      "Print Ads": 48.0,
+      "CANVASSING": 5000.0,
+      "Phone Banks": 342.45,
+      "ESTIMATE OF LIT": 8981.0,
+      "ESTIMATE OF STAFF TIME": 20623.98,
+      "Campaign Paraphernalia/Misc.": 2702.11,
+      "Campaign Literature and Mailings": 35454.18,
+      "Information Technology Costs (Internet, E-mail)": 5675.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 9513.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 21685.48,
   "total_contributions": 21685.48,
@@ -54,7 +66,6 @@
     "Other (includes Businesses)": 3000.0
   },
   "expenditures_by_type": {
-    "Not Stated": 88339.72,
     "Office Expenses": 123.83,
     "Fundraising Events": 126.9,
     "Voter Registration": 1600.0,

--- a/build/candidate/25/supporting/index.json
+++ b/build/candidate/25/supporting/index.json
@@ -28,7 +28,6 @@
       "Other (includes Businesses)": 3000.0
     },
     "expenditures_by_type": {
-      "Not Stated": 88339.72,
       "Office Expenses": 123.83,
       "Fundraising Events": 126.9,
       "Voter Registration": 1600.0,
@@ -38,10 +37,23 @@
       "Campaign Literature and Mailings": 10825.06,
       "Professional Services (Legal, Accounting)": 2500.0,
       "Information Technology Costs (Internet, E-mail)": 833.57
+    },
+    "supporting_by_type": {
+      "Print Ads": 48.0,
+      "CANVASSING": 5000.0,
+      "Phone Banks": 342.45,
+      "ESTIMATE OF LIT": 8981.0,
+      "ESTIMATE OF STAFF TIME": 20623.98,
+      "Campaign Paraphernalia/Misc.": 2702.11,
+      "Campaign Literature and Mailings": 35454.18,
+      "Information Technology Costs (Internet, E-mail)": 5675.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 9513.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 21685.48,
   "total_contributions": 21685.48,
@@ -54,7 +66,6 @@
     "Other (includes Businesses)": 3000.0
   },
   "expenditures_by_type": {
-    "Not Stated": 88339.72,
     "Office Expenses": 123.83,
     "Fundraising Events": 126.9,
     "Voter Registration": 1600.0,

--- a/build/candidate/26/index.json
+++ b/build/candidate/26/index.json
@@ -29,7 +29,6 @@
     },
     "expenditures_by_type": {
       "Print Ads": 13871.57,
-      "Not Stated": 114796.33,
       "Phone Banks": 79.0,
       "Office Expenses": 125.0,
       "Fundraising Events": 300.8,
@@ -37,10 +36,23 @@
       "Campaign Paraphernalia/Misc.": 2443.7,
       "Candidate Filing/Ballot Fees": 250.0,
       "Professional Services (Legal, Accounting)": 4542.81
+    },
+    "supporting_by_type": {
+      "Print Ads": 2048.0,
+      "CANVASSING": 5000.0,
+      "Phone Banks": 597.7,
+      "ESTIMATE OF LIT": 7915.0,
+      "ESTIMATE OF STAFF TIME": 31088.83,
+      "Campaign Paraphernalia/Misc.": 2702.11,
+      "Campaign Literature and Mailings": 44502.69,
+      "Information Technology Costs (Internet, E-mail)": 8350.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 12592.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 27586.0,
   "total_contributions": 27586.0,
@@ -54,7 +66,6 @@
   },
   "expenditures_by_type": {
     "Print Ads": 13871.57,
-    "Not Stated": 114796.33,
     "Phone Banks": 79.0,
     "Office Expenses": 125.0,
     "Fundraising Events": 300.8,

--- a/build/candidate/26/opposing/index.json
+++ b/build/candidate/26/opposing/index.json
@@ -29,7 +29,6 @@
     },
     "expenditures_by_type": {
       "Print Ads": 13871.57,
-      "Not Stated": 114796.33,
       "Phone Banks": 79.0,
       "Office Expenses": 125.0,
       "Fundraising Events": 300.8,
@@ -37,10 +36,23 @@
       "Campaign Paraphernalia/Misc.": 2443.7,
       "Candidate Filing/Ballot Fees": 250.0,
       "Professional Services (Legal, Accounting)": 4542.81
+    },
+    "supporting_by_type": {
+      "Print Ads": 2048.0,
+      "CANVASSING": 5000.0,
+      "Phone Banks": 597.7,
+      "ESTIMATE OF LIT": 7915.0,
+      "ESTIMATE OF STAFF TIME": 31088.83,
+      "Campaign Paraphernalia/Misc.": 2702.11,
+      "Campaign Literature and Mailings": 44502.69,
+      "Information Technology Costs (Internet, E-mail)": 8350.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 12592.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 27586.0,
   "total_contributions": 27586.0,
@@ -54,7 +66,6 @@
   },
   "expenditures_by_type": {
     "Print Ads": 13871.57,
-    "Not Stated": 114796.33,
     "Phone Banks": 79.0,
     "Office Expenses": 125.0,
     "Fundraising Events": 300.8,

--- a/build/candidate/26/supporting/index.json
+++ b/build/candidate/26/supporting/index.json
@@ -29,7 +29,6 @@
     },
     "expenditures_by_type": {
       "Print Ads": 13871.57,
-      "Not Stated": 114796.33,
       "Phone Banks": 79.0,
       "Office Expenses": 125.0,
       "Fundraising Events": 300.8,
@@ -37,10 +36,23 @@
       "Campaign Paraphernalia/Misc.": 2443.7,
       "Candidate Filing/Ballot Fees": 250.0,
       "Professional Services (Legal, Accounting)": 4542.81
+    },
+    "supporting_by_type": {
+      "Print Ads": 2048.0,
+      "CANVASSING": 5000.0,
+      "Phone Banks": 597.7,
+      "ESTIMATE OF LIT": 7915.0,
+      "ESTIMATE OF STAFF TIME": 31088.83,
+      "Campaign Paraphernalia/Misc.": 2702.11,
+      "Campaign Literature and Mailings": 44502.69,
+      "Information Technology Costs (Internet, E-mail)": 8350.0,
+      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 12592.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 27586.0,
   "total_contributions": 27586.0,
@@ -54,7 +66,6 @@
   },
   "expenditures_by_type": {
     "Print Ads": 13871.57,
-    "Not Stated": 114796.33,
     "Phone Banks": 79.0,
     "Office Expenses": 125.0,
     "Fundraising Events": 300.8,

--- a/build/candidate/27/index.json
+++ b/build/candidate/27/index.json
@@ -27,16 +27,21 @@
       "Unitemized": 2762.0
     },
     "expenditures_by_type": {
-      "": 2033.0,
+      "Not Stated": 2033.0,
       "Office Expenses": 1900.34,
       "Campaign Consultants": 3950.0,
       "Campaign Paraphernalia/Misc.": 1167.25,
       "Campaign Literature and Mailings": 1054.74,
       "Professional Services (Legal, Accounting)": 2206.32
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 6987.5
+    "opposing_expenditures": 6987.5,
+    "opposing_by_type": {
+      "Campaign Literature and Mailings": 6987.5
+    }
   },
   "contributions_received": 13562.0,
   "total_contributions": 13562.0,
@@ -48,7 +53,7 @@
     "Unitemized": 2762.0
   },
   "expenditures_by_type": {
-    "": 2033.0,
+    "Not Stated": 2033.0,
     "Office Expenses": 1900.34,
     "Campaign Consultants": 3950.0,
     "Campaign Paraphernalia/Misc.": 1167.25,

--- a/build/candidate/27/opposing/index.json
+++ b/build/candidate/27/opposing/index.json
@@ -27,16 +27,21 @@
       "Unitemized": 2762.0
     },
     "expenditures_by_type": {
-      "": 2033.0,
+      "Not Stated": 2033.0,
       "Office Expenses": 1900.34,
       "Campaign Consultants": 3950.0,
       "Campaign Paraphernalia/Misc.": 1167.25,
       "Campaign Literature and Mailings": 1054.74,
       "Professional Services (Legal, Accounting)": 2206.32
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 6987.5
+    "opposing_expenditures": 6987.5,
+    "opposing_by_type": {
+      "Campaign Literature and Mailings": 6987.5
+    }
   },
   "contributions_received": 13562.0,
   "total_contributions": 13562.0,
@@ -48,7 +53,7 @@
     "Unitemized": 2762.0
   },
   "expenditures_by_type": {
-    "": 2033.0,
+    "Not Stated": 2033.0,
     "Office Expenses": 1900.34,
     "Campaign Consultants": 3950.0,
     "Campaign Paraphernalia/Misc.": 1167.25,

--- a/build/candidate/27/supporting/index.json
+++ b/build/candidate/27/supporting/index.json
@@ -27,16 +27,21 @@
       "Unitemized": 2762.0
     },
     "expenditures_by_type": {
-      "": 2033.0,
+      "Not Stated": 2033.0,
       "Office Expenses": 1900.34,
       "Campaign Consultants": 3950.0,
       "Campaign Paraphernalia/Misc.": 1167.25,
       "Campaign Literature and Mailings": 1054.74,
       "Professional Services (Legal, Accounting)": 2206.32
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 6987.5
+    "opposing_expenditures": 6987.5,
+    "opposing_by_type": {
+      "Campaign Literature and Mailings": 6987.5
+    }
   },
   "contributions_received": 13562.0,
   "total_contributions": 13562.0,
@@ -48,7 +53,7 @@
     "Unitemized": 2762.0
   },
   "expenditures_by_type": {
-    "": 2033.0,
+    "Not Stated": 2033.0,
     "Office Expenses": 1900.34,
     "Campaign Consultants": 3950.0,
     "Campaign Paraphernalia/Misc.": 1167.25,

--- a/build/candidate/3/index.json
+++ b/build/candidate/3/index.json
@@ -36,10 +36,14 @@
       "Campaign Literature and Mailings": 1056.73,
       "Professional Services (Legal, Accounting)": 5575.0,
       "Information Technology Costs (Internet, E-mail)": 1997.97
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 75623.14,
   "total_contributions": 75623.14,

--- a/build/candidate/3/opposing/index.json
+++ b/build/candidate/3/opposing/index.json
@@ -36,10 +36,14 @@
       "Campaign Literature and Mailings": 1056.73,
       "Professional Services (Legal, Accounting)": 5575.0,
       "Information Technology Costs (Internet, E-mail)": 1997.97
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 75623.14,
   "total_contributions": 75623.14,

--- a/build/candidate/3/supporting/index.json
+++ b/build/candidate/3/supporting/index.json
@@ -36,10 +36,14 @@
       "Campaign Literature and Mailings": 1056.73,
       "Professional Services (Legal, Accounting)": 5575.0,
       "Information Technology Costs (Internet, E-mail)": 1997.97
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 75623.14,
   "total_contributions": 75623.14,

--- a/build/candidate/4/index.json
+++ b/build/candidate/4/index.json
@@ -28,10 +28,14 @@
       "Office Expenses": 145.97,
       "Campaign Paraphernalia/Misc.": 310.03,
       "Candidate Filing/Ballot Fees": 190.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 396.0,
   "total_contributions": 396.0,

--- a/build/candidate/4/opposing/index.json
+++ b/build/candidate/4/opposing/index.json
@@ -28,10 +28,14 @@
       "Office Expenses": 145.97,
       "Campaign Paraphernalia/Misc.": 310.03,
       "Candidate Filing/Ballot Fees": 190.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 396.0,
   "total_contributions": 396.0,

--- a/build/candidate/4/supporting/index.json
+++ b/build/candidate/4/supporting/index.json
@@ -28,10 +28,14 @@
       "Office Expenses": 145.97,
       "Campaign Paraphernalia/Misc.": 310.03,
       "Candidate Filing/Ballot Fees": 190.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 396.0,
   "total_contributions": 396.0,

--- a/build/candidate/5/index.json
+++ b/build/candidate/5/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/5/opposing/index.json
+++ b/build/candidate/5/opposing/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/5/supporting/index.json
+++ b/build/candidate/5/supporting/index.json
@@ -24,10 +24,14 @@
     "contributions_by_type": {
     },
     "expenditures_by_type": {
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": null,
   "total_contributions": null,

--- a/build/candidate/6/index.json
+++ b/build/candidate/6/index.json
@@ -40,10 +40,14 @@
       "Professional Services (Legal, Accounting)": 14215.1,
       "T.V. or Cable Airtime and Production Costs": 79500.0,
       "Information Technology Costs (Internet, E-mail)": 6488.21
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 198167.0,
   "total_contributions": 198167.0,

--- a/build/candidate/6/opposing/index.json
+++ b/build/candidate/6/opposing/index.json
@@ -40,10 +40,14 @@
       "Professional Services (Legal, Accounting)": 14215.1,
       "T.V. or Cable Airtime and Production Costs": 79500.0,
       "Information Technology Costs (Internet, E-mail)": 6488.21
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 198167.0,
   "total_contributions": 198167.0,

--- a/build/candidate/6/supporting/index.json
+++ b/build/candidate/6/supporting/index.json
@@ -40,10 +40,14 @@
       "Professional Services (Legal, Accounting)": 14215.1,
       "T.V. or Cable Airtime and Production Costs": 79500.0,
       "Information Technology Costs (Internet, E-mail)": 6488.21
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 198167.0,
   "total_contributions": 198167.0,

--- a/build/candidate/7/index.json
+++ b/build/candidate/7/index.json
@@ -28,16 +28,20 @@
       "Other (includes Businesses)": 4450.0
     },
     "expenditures_by_type": {
-      "": 31671.74,
+      "Not Stated": 31671.74,
       "Civic Donations": 18683.77,
       "Office Expenses": 1498.61,
       "Campaign Literature and Mailings": 7535.18,
       "Postage, Delivery and Messenger Services": 12149.88,
       "Professional Services (Legal, Accounting)": 5380.73
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 42542.0,
   "total_contributions": 42542.0,
@@ -50,7 +54,7 @@
     "Other (includes Businesses)": 4450.0
   },
   "expenditures_by_type": {
-    "": 31671.74,
+    "Not Stated": 31671.74,
     "Civic Donations": 18683.77,
     "Office Expenses": 1498.61,
     "Campaign Literature and Mailings": 7535.18,

--- a/build/candidate/7/opposing/index.json
+++ b/build/candidate/7/opposing/index.json
@@ -28,16 +28,20 @@
       "Other (includes Businesses)": 4450.0
     },
     "expenditures_by_type": {
-      "": 31671.74,
+      "Not Stated": 31671.74,
       "Civic Donations": 18683.77,
       "Office Expenses": 1498.61,
       "Campaign Literature and Mailings": 7535.18,
       "Postage, Delivery and Messenger Services": 12149.88,
       "Professional Services (Legal, Accounting)": 5380.73
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 42542.0,
   "total_contributions": 42542.0,
@@ -50,7 +54,7 @@
     "Other (includes Businesses)": 4450.0
   },
   "expenditures_by_type": {
-    "": 31671.74,
+    "Not Stated": 31671.74,
     "Civic Donations": 18683.77,
     "Office Expenses": 1498.61,
     "Campaign Literature and Mailings": 7535.18,

--- a/build/candidate/7/supporting/index.json
+++ b/build/candidate/7/supporting/index.json
@@ -28,16 +28,20 @@
       "Other (includes Businesses)": 4450.0
     },
     "expenditures_by_type": {
-      "": 31671.74,
+      "Not Stated": 31671.74,
       "Civic Donations": 18683.77,
       "Office Expenses": 1498.61,
       "Campaign Literature and Mailings": 7535.18,
       "Postage, Delivery and Messenger Services": 12149.88,
       "Professional Services (Legal, Accounting)": 5380.73
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 42542.0,
   "total_contributions": 42542.0,
@@ -50,7 +54,7 @@
     "Other (includes Businesses)": 4450.0
   },
   "expenditures_by_type": {
-    "": 31671.74,
+    "Not Stated": 31671.74,
     "Civic Donations": 18683.77,
     "Office Expenses": 1498.61,
     "Campaign Literature and Mailings": 7535.18,

--- a/build/candidate/8/index.json
+++ b/build/candidate/8/index.json
@@ -29,8 +29,8 @@
       "Other (includes Businesses)": 11357.0
     },
     "expenditures_by_type": {
-      "": 1388.85,
       "Print Ads": 300.0,
+      "Not Stated": 1388.85,
       "Civic Donations": 1000.0,
       "Fundraising Events": 12500.23,
       "Campaign Consultants": 37769.07,
@@ -42,10 +42,17 @@
       "Information Technology Costs (Internet, E-mail)": 4226.01,
       "Independent Expenditure Supporting/Opposing Others": 300.0,
       "Transfer Between Committees of the Same Candidate/sponsor": 600.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 12416.96
+    "opposing_expenditures": 12416.96,
+    "opposing_by_type": {
+      "Design of mailer in opposition of Dan Kalb.": 1650.0,
+      "Printing of mailer in opposition to Dan Kalb": 2916.63,
+      "Mailing and Postage in opposition to Dan Kalb": 7850.33
+    }
   },
   "contributions_received": 109521.66,
   "total_contributions": 109521.66,
@@ -59,8 +66,8 @@
     "Other (includes Businesses)": 11357.0
   },
   "expenditures_by_type": {
-    "": 1388.85,
     "Print Ads": 300.0,
+    "Not Stated": 1388.85,
     "Civic Donations": 1000.0,
     "Fundraising Events": 12500.23,
     "Campaign Consultants": 37769.07,

--- a/build/candidate/8/opposing/index.json
+++ b/build/candidate/8/opposing/index.json
@@ -29,8 +29,8 @@
       "Other (includes Businesses)": 11357.0
     },
     "expenditures_by_type": {
-      "": 1388.85,
       "Print Ads": 300.0,
+      "Not Stated": 1388.85,
       "Civic Donations": 1000.0,
       "Fundraising Events": 12500.23,
       "Campaign Consultants": 37769.07,
@@ -42,10 +42,17 @@
       "Information Technology Costs (Internet, E-mail)": 4226.01,
       "Independent Expenditure Supporting/Opposing Others": 300.0,
       "Transfer Between Committees of the Same Candidate/sponsor": 600.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 12416.96
+    "opposing_expenditures": 12416.96,
+    "opposing_by_type": {
+      "Design of mailer in opposition of Dan Kalb.": 1650.0,
+      "Printing of mailer in opposition to Dan Kalb": 2916.63,
+      "Mailing and Postage in opposition to Dan Kalb": 7850.33
+    }
   },
   "contributions_received": 109521.66,
   "total_contributions": 109521.66,
@@ -59,8 +66,8 @@
     "Other (includes Businesses)": 11357.0
   },
   "expenditures_by_type": {
-    "": 1388.85,
     "Print Ads": 300.0,
+    "Not Stated": 1388.85,
     "Civic Donations": 1000.0,
     "Fundraising Events": 12500.23,
     "Campaign Consultants": 37769.07,

--- a/build/candidate/8/supporting/index.json
+++ b/build/candidate/8/supporting/index.json
@@ -29,8 +29,8 @@
       "Other (includes Businesses)": 11357.0
     },
     "expenditures_by_type": {
-      "": 1388.85,
       "Print Ads": 300.0,
+      "Not Stated": 1388.85,
       "Civic Donations": 1000.0,
       "Fundraising Events": 12500.23,
       "Campaign Consultants": 37769.07,
@@ -42,10 +42,17 @@
       "Information Technology Costs (Internet, E-mail)": 4226.01,
       "Independent Expenditure Supporting/Opposing Others": 300.0,
       "Transfer Between Committees of the Same Candidate/sponsor": 600.0
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 12416.96
+    "opposing_expenditures": 12416.96,
+    "opposing_by_type": {
+      "Design of mailer in opposition of Dan Kalb.": 1650.0,
+      "Printing of mailer in opposition to Dan Kalb": 2916.63,
+      "Mailing and Postage in opposition to Dan Kalb": 7850.33
+    }
   },
   "contributions_received": 109521.66,
   "total_contributions": 109521.66,
@@ -59,8 +66,8 @@
     "Other (includes Businesses)": 11357.0
   },
   "expenditures_by_type": {
-    "": 1388.85,
     "Print Ads": 300.0,
+    "Not Stated": 1388.85,
     "Civic Donations": 1000.0,
     "Fundraising Events": 12500.23,
     "Campaign Consultants": 37769.07,

--- a/build/candidate/9/index.json
+++ b/build/candidate/9/index.json
@@ -28,8 +28,8 @@
       "Other (includes Businesses)": 11200.0
     },
     "expenditures_by_type": {
-      "": 17406.96,
       "Print Ads": 1000.0,
+      "Not Stated": 17406.96,
       "Contribution": 750.0,
       "Civic Donations": 4600.0,
       "Office Expenses": 7051.9,
@@ -42,10 +42,14 @@
       "Candidate Travel, Lodging, and Meals": 91.39,
       "Professional Services (Legal, Accounting)": 12410.7,
       "Information Technology Costs (Internet, E-mail)": 3343.09
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 58231.08,
   "total_contributions": 58231.08,
@@ -58,8 +62,8 @@
     "Other (includes Businesses)": 11200.0
   },
   "expenditures_by_type": {
-    "": 17406.96,
     "Print Ads": 1000.0,
+    "Not Stated": 17406.96,
     "Contribution": 750.0,
     "Civic Donations": 4600.0,
     "Office Expenses": 7051.9,

--- a/build/candidate/9/opposing/index.json
+++ b/build/candidate/9/opposing/index.json
@@ -28,8 +28,8 @@
       "Other (includes Businesses)": 11200.0
     },
     "expenditures_by_type": {
-      "": 17406.96,
       "Print Ads": 1000.0,
+      "Not Stated": 17406.96,
       "Contribution": 750.0,
       "Civic Donations": 4600.0,
       "Office Expenses": 7051.9,
@@ -42,10 +42,14 @@
       "Candidate Travel, Lodging, and Meals": 91.39,
       "Professional Services (Legal, Accounting)": 12410.7,
       "Information Technology Costs (Internet, E-mail)": 3343.09
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 58231.08,
   "total_contributions": 58231.08,
@@ -58,8 +62,8 @@
     "Other (includes Businesses)": 11200.0
   },
   "expenditures_by_type": {
-    "": 17406.96,
     "Print Ads": 1000.0,
+    "Not Stated": 17406.96,
     "Contribution": 750.0,
     "Civic Donations": 4600.0,
     "Office Expenses": 7051.9,

--- a/build/candidate/9/supporting/index.json
+++ b/build/candidate/9/supporting/index.json
@@ -28,8 +28,8 @@
       "Other (includes Businesses)": 11200.0
     },
     "expenditures_by_type": {
-      "": 17406.96,
       "Print Ads": 1000.0,
+      "Not Stated": 17406.96,
       "Contribution": 750.0,
       "Civic Donations": 4600.0,
       "Office Expenses": 7051.9,
@@ -42,10 +42,14 @@
       "Candidate Travel, Lodging, and Meals": 91.39,
       "Professional Services (Legal, Accounting)": 12410.7,
       "Information Technology Costs (Internet, E-mail)": 3343.09
+    },
+    "supporting_by_type": {
     }
   },
   "opposing_money": {
-    "opposing_expenditures": null
+    "opposing_expenditures": null,
+    "opposing_by_type": {
+    }
   },
   "contributions_received": 58231.08,
   "total_contributions": 58231.08,
@@ -58,8 +62,8 @@
     "Other (includes Businesses)": 11200.0
   },
   "expenditures_by_type": {
-    "": 17406.96,
     "Print Ads": 1000.0,
+    "Not Stated": 17406.96,
     "Contribution": 750.0,
     "Civic Donations": 4600.0,
     "Office Expenses": 7051.9,

--- a/build/committee/1364564/contributions/index.json
+++ b/build/committee/1364564/contributions/index.json
@@ -1,15 +1,15 @@
 [
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-04-14",
+    "Tran_Amt1": 40000.0,
+    "Tran_Date": "2016-09-12",
     "Tran_NamF": null,
     "Tran_NamL": "ACCE Institute"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 40000.0,
-    "Tran_Date": "2016-09-12",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-04-14",
     "Tran_NamF": null,
     "Tran_NamL": "ACCE Institute"
   },
@@ -50,8 +50,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-04-15",
+    "Tran_Amt1": 3591.0,
+    "Tran_Date": "2016-10-13",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
@@ -65,7 +65,7 @@
   {
     "Filer_ID": "1364564",
     "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Date": "2016-04-15",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
@@ -78,8 +78,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 3591.0,
-    "Tran_Date": "2016-10-13",
+    "Tran_Amt1": 3000.0,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
@@ -162,22 +162,22 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 1144.95,
-    "Tran_Date": "2016-09-13",
+    "Tran_Amt1": 13315.74,
+    "Tran_Date": "2016-01-01",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 742.5,
-    "Tran_Date": "2016-11-07",
+    "Tran_Amt1": 983.91,
+    "Tran_Date": "2016-03-03",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 19700.0,
-    "Tran_Date": "2016-04-11",
+    "Tran_Amt1": 311.52,
+    "Tran_Date": "2016-04-02",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -190,8 +190,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 450.96,
-    "Tran_Date": "2016-11-07",
+    "Tran_Amt1": 19700.0,
+    "Tran_Date": "2016-04-11",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -211,50 +211,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 59000.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
     "Tran_Amt1": 355.95,
     "Tran_Date": "2016-07-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 13315.74,
-    "Tran_Date": "2016-01-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 53.18,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1020.82,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 311.52,
-    "Tran_Date": "2016-04-02",
-    "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-09-26",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -274,8 +232,29 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 1020.82,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 89.0,
     "Tran_Date": "2016-09-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 59000.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1144.95,
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -288,8 +267,8 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 983.91,
-    "Tran_Date": "2016-03-03",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-09-26",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -297,6 +276,62 @@
     "Filer_ID": "1364564",
     "Tran_Amt1": 4821.82,
     "Tran_Date": "2016-10-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 2771.39,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 53.18,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 450.96,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 742.5,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1990.75,
+    "Tran_Date": "2016-11-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 94.01,
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 178.0,
+    "Tran_Date": "2016-12-09",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -533,16 +568,16 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Mark",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Marc",
     "Tran_NamL": "Janowitz"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Marc",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Mark",
     "Tran_NamL": "Janowitz"
   },
   {
@@ -555,14 +590,14 @@
   {
     "Filer_ID": "1364564",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-19",
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "John George Democratic Club"
   },
   {
     "Filer_ID": "1364564",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Date": "2016-09-19",
     "Tran_NamF": null,
     "Tran_NamL": "John George Democratic Club"
   },
@@ -701,15 +736,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-26",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-04-22",
     "Tran_NamF": "Luke",
     "Tran_NamL": "Newton"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-22",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-26",
     "Tran_NamF": "Luke",
     "Tran_NamL": "Newton"
   },
@@ -729,13 +764,6 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 12296.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Rising Committee sponsored by Movement Strategy Action Center"
-  },
-  {
-    "Filer_ID": "1364564",
     "Tran_Amt1": 24966.0,
     "Tran_Date": "2016-10-01",
     "Tran_NamF": null,
@@ -743,29 +771,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 134.19,
-    "Tran_Date": "2016-11-04",
+    "Tran_Amt1": 12296.0,
+    "Tran_Date": "2016-10-23",
     "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 121.97,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 33.79,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+    "Tran_NamL": "Oakland Rising Committee sponsored by Movement Strategy Action Center"
   },
   {
     "Filer_ID": "1364564",
     "Tran_Amt1": 11845.16,
-    "Tran_Date": "2016-10-07",
+    "Tran_Date": "2016-10-28",
     "Tran_NamF": null,
     "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
   },
@@ -778,8 +792,22 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 53.4,
-    "Tran_Date": "2016-10-24",
+    "Tran_Amt1": 178.66,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 11845.16,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 134.19,
+    "Tran_Date": "2016-11-04",
     "Tran_NamF": null,
     "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
   },
@@ -792,8 +820,22 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 11845.16,
-    "Tran_Date": "2016-10-28",
+    "Tran_Amt1": 33.79,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 121.97,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 53.4,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": null,
     "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
   },
@@ -883,15 +925,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 7388.87,
-    "Tran_Date": "2016-11-05",
+    "Tran_Amt1": 471.78,
+    "Tran_Date": "2016-10-01",
     "Tran_NamF": null,
     "Tran_NamL": "SEIU Local 2015 Issues PAC"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 471.78,
-    "Tran_Date": "2016-10-13",
+    "Tran_Amt1": 7388.87,
+    "Tran_Date": "2016-11-05",
     "Tran_NamF": null,
     "Tran_NamL": "SEIU Local 2015 Issues PAC"
   },
@@ -939,14 +981,14 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 1450.24,
+    "Tran_Amt1": 2900.48,
     "Tran_Date": "2016-01-08",
     "Tran_NamF": null,
     "Tran_NamL": "Service Employees International Union Local 1021"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 2900.48,
+    "Tran_Amt1": 1450.24,
     "Tran_Date": "2016-01-08",
     "Tran_NamF": null,
     "Tran_NamL": "Service Employees International Union Local 1021"
@@ -1002,15 +1044,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-11",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-05",
     "Tran_NamF": "Alanya",
     "Tran_NamL": "Snyder"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-05",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-11",
     "Tran_NamF": "Alanya",
     "Tran_NamL": "Snyder"
   },

--- a/build/committee/1386929/contributions/index.json
+++ b/build/committee/1386929/contributions/index.json
@@ -2,6 +2,13 @@
   {
     "Filer_ID": "1386929",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Ismael",
+    "Tran_NamL": "Armendariz"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Janet",
     "Tran_NamL": "Arnold"
@@ -12,6 +19,13 @@
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "William",
     "Tran_NamL": "Chorneau"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Leigh",
+    "Tran_NamL": "Davenport"
   },
   {
     "Filer_ID": "1386929",
@@ -50,10 +64,45 @@
   },
   {
     "Filer_ID": "1386929",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Justice Coalition"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Justice Coalition"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 140.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Kameelah",
+    "Tran_NamL": "Rahmaan"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Alma",
+    "Tran_NamL": "Rahmaan"
+  },
+  {
+    "Filer_ID": "1386929",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-20",
     "Tran_NamF": "Sharrana",
     "Tran_NamL": "Richardson"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Sharon",
+    "Tran_NamL": "Rose"
   },
   {
     "Filer_ID": "1386929",
@@ -71,6 +120,13 @@
   },
   {
     "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-30",
+    "Tran_NamF": "Fredna",
+    "Tran_NamL": "Thomas"
+  },
+  {
+    "Filer_ID": "1386929",
     "Tran_Amt1": 1315.0,
     "Tran_Date": "2016-09-29",
     "Tran_NamF": null,
@@ -78,15 +134,15 @@
   },
   {
     "Filer_ID": "1386929",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-06",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-13",
     "Tran_NamF": null,
     "Tran_NamL": "Unitemized contributions"
   },
   {
     "Filer_ID": "1386929",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-13",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-06",
     "Tran_NamF": null,
     "Tran_NamL": "Unitemized contributions"
   }

--- a/build/committee/1388641/opposing/index.json
+++ b/build/committee/1388641/opposing/index.json
@@ -1,17 +1,5 @@
 [
   {
-    "total": 8400.0,
-    "Exp_Date": "2016-09-29",
-    "Filer_ID": 1388641,
-    "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
-  },
-  {
-    "total": 7787.39,
-    "Exp_Date": "2016-10-20",
-    "Filer_ID": 1388641,
-    "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
-  },
-  {
     "total": 7050.06,
     "Exp_Date": "2016-10-11",
     "Filer_ID": 1388641,
@@ -20,6 +8,18 @@
   {
     "total": 7526.39,
     "Exp_Date": "2016-10-06",
+    "Filer_ID": 1388641,
+    "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
+  },
+  {
+    "total": 8400.0,
+    "Exp_Date": "2016-09-29",
+    "Filer_ID": 1388641,
+    "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
+  },
+  {
+    "total": 7787.39,
+    "Exp_Date": "2016-10-20",
     "Filer_ID": 1388641,
     "Filer_NamL": "Oakland Police Officer's Association - Political Action Committee"
   },

--- a/build/locality/2/current_ballot/index.json
+++ b/build/locality/2/current_ballot/index.json
@@ -36,16 +36,20 @@
               "Other (includes Businesses)": 4450.0
             },
             "expenditures_by_type": {
-              "": 31671.74,
+              "Not Stated": 31671.74,
               "Civic Donations": 18683.77,
               "Office Expenses": 1498.61,
               "Campaign Literature and Mailings": 7535.18,
               "Postage, Delivery and Messenger Services": 12149.88,
               "Professional Services (Legal, Accounting)": 5380.73
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 42542.0,
           "total_contributions": 42542.0,
@@ -58,7 +62,7 @@
             "Other (includes Businesses)": 4450.0
           },
           "expenditures_by_type": {
-            "": 31671.74,
+            "Not Stated": 31671.74,
             "Civic Donations": 18683.77,
             "Office Expenses": 1498.61,
             "Campaign Literature and Mailings": 7535.18,
@@ -97,8 +101,8 @@
               "Other (includes Businesses)": 11357.0
             },
             "expenditures_by_type": {
-              "": 1388.85,
               "Print Ads": 300.0,
+              "Not Stated": 1388.85,
               "Civic Donations": 1000.0,
               "Fundraising Events": 12500.23,
               "Campaign Consultants": 37769.07,
@@ -110,10 +114,17 @@
               "Information Technology Costs (Internet, E-mail)": 4226.01,
               "Independent Expenditure Supporting/Opposing Others": 300.0,
               "Transfer Between Committees of the Same Candidate/sponsor": 600.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 12416.96
+            "opposing_expenditures": 12416.96,
+            "opposing_by_type": {
+              "Design of mailer in opposition of Dan Kalb.": 1650.0,
+              "Printing of mailer in opposition to Dan Kalb": 2916.63,
+              "Mailing and Postage in opposition to Dan Kalb": 7850.33
+            }
           },
           "contributions_received": 109521.66,
           "total_contributions": 109521.66,
@@ -127,8 +138,8 @@
             "Other (includes Businesses)": 11357.0
           },
           "expenditures_by_type": {
-            "": 1388.85,
             "Print Ads": 300.0,
+            "Not Stated": 1388.85,
             "Civic Donations": 1000.0,
             "Fundraising Events": 12500.23,
             "Campaign Consultants": 37769.07,
@@ -179,8 +190,8 @@
               "Other (includes Businesses)": 11200.0
             },
             "expenditures_by_type": {
-              "": 17406.96,
               "Print Ads": 1000.0,
+              "Not Stated": 17406.96,
               "Contribution": 750.0,
               "Civic Donations": 4600.0,
               "Office Expenses": 7051.9,
@@ -193,10 +204,14 @@
               "Candidate Travel, Lodging, and Meals": 91.39,
               "Professional Services (Legal, Accounting)": 12410.7,
               "Information Technology Costs (Internet, E-mail)": 3343.09
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 58231.08,
           "total_contributions": 58231.08,
@@ -209,8 +224,8 @@
             "Other (includes Businesses)": 11200.0
           },
           "expenditures_by_type": {
-            "": 17406.96,
             "Print Ads": 1000.0,
+            "Not Stated": 17406.96,
             "Contribution": 750.0,
             "Civic Donations": 4600.0,
             "Office Expenses": 7051.9,
@@ -262,10 +277,14 @@
               "Candidate Filing/Ballot Fees": 300.0,
               "Campaign Literature and Mailings": 3399.31,
               "Information Technology Costs (Internet, E-mail)": 387.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 10634.0,
           "total_contributions": 10634.0,
@@ -325,8 +344,8 @@
               "Other (includes Businesses)": 11950.0
             },
             "expenditures_by_type": {
-              "": 16605.58,
               "Print Ads": 1298.18,
+              "Not Stated": 16605.58,
               "Office Expenses": 15728.02,
               "Fundraising Events": 750.0,
               "Campaign Consultants": 41405.69,
@@ -338,10 +357,14 @@
               "Professional Services (Legal, Accounting)": 3583.75,
               "T.V. or Cable Airtime and Production Costs": 8000.0,
               "Information Technology Costs (Internet, E-mail)": 400.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 134374.0,
           "total_contributions": 134374.0,
@@ -355,8 +378,8 @@
             "Other (includes Businesses)": 11950.0
           },
           "expenditures_by_type": {
-            "": 16605.58,
             "Print Ads": 1298.18,
+            "Not Stated": 16605.58,
             "Office Expenses": 15728.02,
             "Fundraising Events": 750.0,
             "Campaign Consultants": 41405.69,
@@ -408,10 +431,14 @@
               "Campaign Literature and Mailings": 1056.73,
               "Professional Services (Legal, Accounting)": 5575.0,
               "Information Technology Costs (Internet, E-mail)": 1997.97
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 75623.14,
           "total_contributions": 75623.14,
@@ -464,10 +491,14 @@
               "Office Expenses": 145.97,
               "Campaign Paraphernalia/Misc.": 310.03,
               "Candidate Filing/Ballot Fees": 190.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 396.0,
           "total_contributions": 396.0,
@@ -508,10 +539,14 @@
             "contributions_by_type": {
             },
             "expenditures_by_type": {
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -564,10 +599,14 @@
               "Professional Services (Legal, Accounting)": 14215.1,
               "T.V. or Cable Airtime and Production Costs": 79500.0,
               "Information Technology Costs (Internet, E-mail)": 6488.21
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 198167.0,
           "total_contributions": 198167.0,
@@ -632,7 +671,6 @@
             },
             "expenditures_by_type": {
               "Print Ads": 13871.57,
-              "Not Stated": 114796.33,
               "Phone Banks": 79.0,
               "Office Expenses": 125.0,
               "Fundraising Events": 300.8,
@@ -640,10 +678,23 @@
               "Campaign Paraphernalia/Misc.": 2443.7,
               "Candidate Filing/Ballot Fees": 250.0,
               "Professional Services (Legal, Accounting)": 4542.81
+            },
+            "supporting_by_type": {
+              "Print Ads": 2048.0,
+              "CANVASSING": 5000.0,
+              "Phone Banks": 597.7,
+              "ESTIMATE OF LIT": 7915.0,
+              "ESTIMATE OF STAFF TIME": 31088.83,
+              "Campaign Paraphernalia/Misc.": 2702.11,
+              "Campaign Literature and Mailings": 44502.69,
+              "Information Technology Costs (Internet, E-mail)": 8350.0,
+              "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 12592.0
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 27586.0,
           "total_contributions": 27586.0,
@@ -657,7 +708,6 @@
           },
           "expenditures_by_type": {
             "Print Ads": 13871.57,
-            "Not Stated": 114796.33,
             "Phone Banks": 79.0,
             "Office Expenses": 125.0,
             "Fundraising Events": 300.8,
@@ -696,16 +746,21 @@
               "Unitemized": 2762.0
             },
             "expenditures_by_type": {
-              "": 2033.0,
+              "Not Stated": 2033.0,
               "Office Expenses": 1900.34,
               "Campaign Consultants": 3950.0,
               "Campaign Paraphernalia/Misc.": 1167.25,
               "Campaign Literature and Mailings": 1054.74,
               "Professional Services (Legal, Accounting)": 2206.32
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 6987.5
+            "opposing_expenditures": 6987.5,
+            "opposing_by_type": {
+              "Campaign Literature and Mailings": 6987.5
+            }
           },
           "contributions_received": 13562.0,
           "total_contributions": 13562.0,
@@ -717,7 +772,7 @@
             "Unitemized": 2762.0
           },
           "expenditures_by_type": {
-            "": 2033.0,
+            "Not Stated": 2033.0,
             "Office Expenses": 1900.34,
             "Campaign Consultants": 3950.0,
             "Campaign Paraphernalia/Misc.": 1167.25,
@@ -761,7 +816,7 @@
               "Other (includes Businesses)": 1750.0
             },
             "expenditures_by_type": {
-              "": 809.02,
+              "Not Stated": 809.02,
               "Office Expenses": 1710.94,
               "Fundraising Events": 147.81,
               "Voter Registration": 156.15,
@@ -773,10 +828,14 @@
               "Staff/Spouse Travel, Lodging, and Meals": 320.14,
               "Professional Services (Legal, Accounting)": 372.42,
               "Information Technology Costs (Internet, E-mail)": 100.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 5144.0,
           "total_contributions": 5144.0,
@@ -788,7 +847,7 @@
             "Other (includes Businesses)": 1750.0
           },
           "expenditures_by_type": {
-            "": 809.02,
+            "Not Stated": 809.02,
             "Office Expenses": 1710.94,
             "Fundraising Events": 147.81,
             "Voter Registration": 156.15,
@@ -832,7 +891,6 @@
               "Other (includes Businesses)": 2600.0
             },
             "expenditures_by_type": {
-              "Not Stated": 3894.33,
               "Office Expenses": 248.2,
               "Fundraising Events": 2338.58,
               "Campaign Consultants": 1000.0,
@@ -840,10 +898,17 @@
               "Campaign Paraphernalia/Misc.": 3755.99,
               "Candidate Filing/Ballot Fees": 300.0,
               "Campaign Literature and Mailings": 15150.0
+            },
+            "supporting_by_type": {
+              "ESTIMATE OF STAFF TIME": 1941.33,
+              "Campaign Literature and Mailings": 48.0,
+              "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 1905.0
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 22344.0,
           "total_contributions": 22344.0,
@@ -856,7 +921,6 @@
             "Other (includes Businesses)": 2600.0
           },
           "expenditures_by_type": {
-            "Not Stated": 3894.33,
             "Office Expenses": 248.2,
             "Fundraising Events": 2338.58,
             "Campaign Consultants": 1000.0,
@@ -902,7 +966,6 @@
               "Unitemized": 0.0
             },
             "expenditures_by_type": {
-              "Not Stated": 78327.14,
               "Phone Banks": 834.94,
               "Fundraising Events": 203.53,
               "Campaign Consultants": 1340.0,
@@ -910,10 +973,22 @@
               "Campaign Literature and Mailings": 5458.08,
               "Professional Services (Legal, Accounting)": 200.0,
               "Information Technology Costs (Internet, E-mail)": 597.0
+            },
+            "supporting_by_type": {
+              "Print Ads": 2048.0,
+              "Phone Banks": 276.33,
+              "ESTIMATE OF LIT": 1800.0,
+              "ESTIMATE OF STAFF TIME": 19599.4,
+              "Campaign Paraphernalia/Misc.": 2702.11,
+              "Campaign Literature and Mailings": 45044.3,
+              "Information Technology Costs (Internet, E-mail)": 675.0,
+              "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 6182.0
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 17888.0,
           "total_contributions": 17888.0,
@@ -925,7 +1000,6 @@
             "Unitemized": 0.0
           },
           "expenditures_by_type": {
-            "Not Stated": 78327.14,
             "Phone Banks": 834.94,
             "Fundraising Events": 203.53,
             "Campaign Consultants": 1340.0,
@@ -961,10 +1035,14 @@
             "contributions_by_type": {
             },
             "expenditures_by_type": {
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -994,43 +1072,49 @@
           "party_affiliation": null,
           "filer_id": 1386929,
           "supporting_money": {
-            "contributions_received": 3980.0,
-            "total_contributions": 3980.0,
-            "total_expenditures": 2382.67,
+            "contributions_received": 5798.0,
+            "total_contributions": 5798.0,
+            "total_expenditures": 3052.34,
             "total_loans_received": 0.0,
             "contributions_by_type": {
-              "Individual": 1800.0,
-              "Unitemized": 515.0,
-              "Other (includes Businesses)": 1665.0
+              "Individual": 2590.0,
+              "Unitemized": 1093.0,
+              "Other (includes Businesses)": 2115.0
             },
             "expenditures_by_type": {
+              "Not Stated": 60.0,
               "Fundraising Events": 128.05,
               "Meetings and Appearances": 114.67,
-              "Campaign Paraphernalia/Misc.": 724.48,
-              "Candidate Filing/Ballot Fees": 300.0,
-              "Campaign Literature and Mailings": 839.01,
-              "Information Technology Costs (Internet, E-mail)": 148.0
+              "Campaign Paraphernalia/Misc.": 870.17,
+              "Candidate Filing/Ballot Fees": 310.0,
+              "Campaign Literature and Mailings": 1187.01,
+              "Information Technology Costs (Internet, E-mail)": 177.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
-          "contributions_received": 3980.0,
-          "total_contributions": 3980.0,
-          "total_expenditures": 2382.67,
+          "contributions_received": 5798.0,
+          "total_contributions": 5798.0,
+          "total_expenditures": 3052.34,
           "total_loans_received": 0.0,
           "contributions_by_type": {
-            "Individual": 1800.0,
-            "Unitemized": 515.0,
-            "Other (includes Businesses)": 1665.0
+            "Individual": 2590.0,
+            "Unitemized": 1093.0,
+            "Other (includes Businesses)": 2115.0
           },
           "expenditures_by_type": {
+            "Not Stated": 60.0,
             "Fundraising Events": 128.05,
             "Meetings and Appearances": 114.67,
-            "Campaign Paraphernalia/Misc.": 724.48,
-            "Candidate Filing/Ballot Fees": 300.0,
-            "Campaign Literature and Mailings": 839.01,
-            "Information Technology Costs (Internet, E-mail)": 148.0
+            "Campaign Paraphernalia/Misc.": 870.17,
+            "Candidate Filing/Ballot Fees": 310.0,
+            "Campaign Literature and Mailings": 1187.01,
+            "Information Technology Costs (Internet, E-mail)": 177.0
           }
         },
         {
@@ -1059,10 +1143,14 @@
             "contributions_by_type": {
             },
             "expenditures_by_type": {
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -1107,13 +1195,17 @@
               "Unitemized": 382.0
             },
             "expenditures_by_type": {
-              "": 435.74,
+              "Not Stated": 435.74,
               "Campaign Paraphernalia/Misc.": 13557.03,
               "Professional Services (Legal, Accounting)": 850.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 20239.0,
           "total_contributions": 20239.0,
@@ -1123,7 +1215,7 @@
             "Unitemized": 382.0
           },
           "expenditures_by_type": {
-            "": 435.74,
+            "Not Stated": 435.74,
             "Campaign Paraphernalia/Misc.": 13557.03,
             "Professional Services (Legal, Accounting)": 850.0
           }
@@ -1157,7 +1249,7 @@
               "Unitemized": 3066.0
             },
             "expenditures_by_type": {
-              "": 700.0,
+              "Not Stated": 700.0,
               "Phone Banks": 1659.63,
               "Office Expenses": 2307.9,
               "Campaign Consultants": 3000.0,
@@ -1165,10 +1257,14 @@
               "Campaign Literature and Mailings": 7287.36,
               "Postage, Delivery and Messenger Services": 3818.95,
               "Professional Services (Legal, Accounting)": 3147.37
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 26966.0,
           "total_contributions": 26966.0,
@@ -1180,7 +1276,7 @@
             "Unitemized": 3066.0
           },
           "expenditures_by_type": {
-            "": 700.0,
+            "Not Stated": 700.0,
             "Phone Banks": 1659.63,
             "Office Expenses": 2307.9,
             "Campaign Consultants": 3000.0,
@@ -1220,8 +1316,8 @@
               "Other (includes Businesses)": 15550.0
             },
             "expenditures_by_type": {
-              "": 4698.42,
               "Print Ads": 1000.0,
+              "Not Stated": 4698.42,
               "Office Expenses": 649.6,
               "Fundraising Events": 315.92,
               "Campaign Consultants": 15000.0,
@@ -1231,10 +1327,14 @@
               "Staff/Spouse Travel, Lodging, and Meals": 202.76,
               "Professional Services (Legal, Accounting)": 10248.12,
               "Information Technology Costs (Internet, E-mail)": 2236.58
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 72976.0,
           "total_contributions": 72976.0,
@@ -1247,8 +1347,8 @@
             "Other (includes Businesses)": 15550.0
           },
           "expenditures_by_type": {
-            "": 4698.42,
             "Print Ads": 1000.0,
+            "Not Stated": 4698.42,
             "Office Expenses": 649.6,
             "Fundraising Events": 315.92,
             "Campaign Consultants": 15000.0,
@@ -1299,10 +1399,14 @@
               "Office Expenses": 506.71,
               "Campaign Consultants": 2500.0,
               "Information Technology Costs (Internet, E-mail)": 265.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 8486.0,
           "total_contributions": 8486.0,
@@ -1345,10 +1449,14 @@
             "contributions_by_type": {
             },
             "expenditures_by_type": {
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": null,
           "total_contributions": null,
@@ -1370,7 +1478,7 @@
           "last_name": "Torres",
           "ballot_item": 8,
           "office_election": 8,
-          "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home\"",
+          "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home",
           "committee_name": "Roseann Torres for Oakland School Board 2016",
           "is_accepted_expenditure_ceiling": null,
           "is_incumbent": true,
@@ -1389,7 +1497,7 @@
               "Other (includes Businesses)": 1000.0
             },
             "expenditures_by_type": {
-              "": 3317.0,
+              "Not Stated": 3317.0,
               "Contribution": 300.0,
               "Office Expenses": 1736.74,
               "Fundraising Events": 1243.86,
@@ -1398,10 +1506,15 @@
               "Campaign Literature and Mailings": 3183.32,
               "Professional Services (Legal, Accounting)": 7081.33,
               "Information Technology Costs (Internet, E-mail)": 400.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 6987.5
+            "opposing_expenditures": 6987.5,
+            "opposing_by_type": {
+              "Campaign Literature and Mailings": 6987.5
+            }
           },
           "contributions_received": 21893.01,
           "total_contributions": 21893.01,
@@ -1414,7 +1527,7 @@
             "Other (includes Businesses)": 1000.0
           },
           "expenditures_by_type": {
-            "": 3317.0,
+            "Not Stated": 3317.0,
             "Contribution": 300.0,
             "Office Expenses": 1736.74,
             "Fundraising Events": 1243.86,
@@ -1455,7 +1568,6 @@
               "Other (includes Businesses)": 3000.0
             },
             "expenditures_by_type": {
-              "Not Stated": 88339.72,
               "Office Expenses": 123.83,
               "Fundraising Events": 126.9,
               "Voter Registration": 1600.0,
@@ -1465,10 +1577,23 @@
               "Campaign Literature and Mailings": 10825.06,
               "Professional Services (Legal, Accounting)": 2500.0,
               "Information Technology Costs (Internet, E-mail)": 833.57
+            },
+            "supporting_by_type": {
+              "Print Ads": 48.0,
+              "CANVASSING": 5000.0,
+              "Phone Banks": 342.45,
+              "ESTIMATE OF LIT": 8981.0,
+              "ESTIMATE OF STAFF TIME": 20623.98,
+              "Campaign Paraphernalia/Misc.": 2702.11,
+              "Campaign Literature and Mailings": 35454.18,
+              "Information Technology Costs (Internet, E-mail)": 5675.0,
+              "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 9513.0
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 21685.48,
           "total_contributions": 21685.48,
@@ -1481,7 +1606,6 @@
             "Other (includes Businesses)": 3000.0
           },
           "expenditures_by_type": {
-            "Not Stated": 88339.72,
             "Office Expenses": 123.83,
             "Fundraising Events": 126.9,
             "Voter Registration": 1600.0,
@@ -1533,10 +1657,14 @@
               "Campaign Paraphernalia/Misc.": 820.44,
               "Candidate Filing/Ballot Fees": 1477.0,
               "Campaign Literature and Mailings": 1559.56
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 67909.0,
           "total_contributions": 67909.0,
@@ -1591,8 +1719,8 @@
               "Other (includes Businesses)": 37631.69
             },
             "expenditures_by_type": {
-              "": 10826.1,
               "Print Ads": 500.0,
+              "Not Stated": 10826.1,
               "Contribution": 550.0,
               "Civic Donations": 700.0,
               "Office Expenses": 3595.76,
@@ -1602,10 +1730,23 @@
               "Candidate Filing/Ballot Fees": 300.0,
               "Campaign Literature and Mailings": 36593.49,
               "Professional Services (Legal, Accounting)": 21788.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": 40013.84
+            "opposing_expenditures": 40013.84,
+            "opposing_by_type": {
+              "Postage": 4714.25,
+              "Mailer Design": 1650.0,
+              "Mailer Printing": 2438.13,
+              "Mailhouse \u0026 Postage": 3699.26,
+              "Digital Ad in opposition to Noel Gallo": 9250.0,
+              "Design of mailer in opposition to Noel Gallo": 3300.0,
+              "Design of mailer in opposition of Noel Gallo.": 1650.0,
+              "Printing of mailer in opposition to Noel Gallo": 5913.68,
+              "Mailing and Postage in opposition to Noel Gallo": 7398.52
+            }
           },
           "contributions_received": 80100.69,
           "total_contributions": 80100.69,
@@ -1618,8 +1759,8 @@
             "Other (includes Businesses)": 37631.69
           },
           "expenditures_by_type": {
-            "": 10826.1,
             "Print Ads": 500.0,
+            "Not Stated": 10826.1,
             "Contribution": 550.0,
             "Civic Donations": 700.0,
             "Office Expenses": 3595.76,
@@ -1662,16 +1803,20 @@
               "Other (includes Businesses)": 3300.0
             },
             "expenditures_by_type": {
-              "": 455.45,
+              "Not Stated": 455.45,
               "Campaign Consultants": 18667.55,
               "Meetings and Appearances": 529.0,
               "Campaign Paraphernalia/Misc.": 3884.37,
               "Campaign Literature and Mailings": 33656.76,
               "Information Technology Costs (Internet, E-mail)": 3150.0
+            },
+            "supporting_by_type": {
             }
           },
           "opposing_money": {
-            "opposing_expenditures": null
+            "opposing_expenditures": null,
+            "opposing_by_type": {
+            }
           },
           "contributions_received": 84742.41,
           "total_contributions": 84742.41,
@@ -1685,7 +1830,7 @@
             "Other (includes Businesses)": 3300.0
           },
           "expenditures_by_type": {
-            "": 455.45,
+            "Not Stated": 455.45,
             "Campaign Consultants": 18667.55,
             "Meetings and Appearances": 529.0,
             "Campaign Paraphernalia/Misc.": 3884.37,

--- a/build/office_election/1/index.json
+++ b/build/office_election/1/index.json
@@ -33,16 +33,20 @@
           "Other (includes Businesses)": 4450.0
         },
         "expenditures_by_type": {
-          "": 31671.74,
+          "Not Stated": 31671.74,
           "Civic Donations": 18683.77,
           "Office Expenses": 1498.61,
           "Campaign Literature and Mailings": 7535.18,
           "Postage, Delivery and Messenger Services": 12149.88,
           "Professional Services (Legal, Accounting)": 5380.73
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 42542.0,
       "total_contributions": 42542.0,
@@ -55,7 +59,7 @@
         "Other (includes Businesses)": 4450.0
       },
       "expenditures_by_type": {
-        "": 31671.74,
+        "Not Stated": 31671.74,
         "Civic Donations": 18683.77,
         "Office Expenses": 1498.61,
         "Campaign Literature and Mailings": 7535.18,
@@ -94,8 +98,8 @@
           "Other (includes Businesses)": 11357.0
         },
         "expenditures_by_type": {
-          "": 1388.85,
           "Print Ads": 300.0,
+          "Not Stated": 1388.85,
           "Civic Donations": 1000.0,
           "Fundraising Events": 12500.23,
           "Campaign Consultants": 37769.07,
@@ -107,10 +111,17 @@
           "Information Technology Costs (Internet, E-mail)": 4226.01,
           "Independent Expenditure Supporting/Opposing Others": 300.0,
           "Transfer Between Committees of the Same Candidate/sponsor": 600.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": 12416.96
+        "opposing_expenditures": 12416.96,
+        "opposing_by_type": {
+          "Design of mailer in opposition of Dan Kalb.": 1650.0,
+          "Printing of mailer in opposition to Dan Kalb": 2916.63,
+          "Mailing and Postage in opposition to Dan Kalb": 7850.33
+        }
       },
       "contributions_received": 109521.66,
       "total_contributions": 109521.66,
@@ -124,8 +135,8 @@
         "Other (includes Businesses)": 11357.0
       },
       "expenditures_by_type": {
-        "": 1388.85,
         "Print Ads": 300.0,
+        "Not Stated": 1388.85,
         "Civic Donations": 1000.0,
         "Fundraising Events": 12500.23,
         "Campaign Consultants": 37769.07,

--- a/build/office_election/10/index.json
+++ b/build/office_election/10/index.json
@@ -33,8 +33,8 @@
           "Other (includes Businesses)": 37631.69
         },
         "expenditures_by_type": {
-          "": 10826.1,
           "Print Ads": 500.0,
+          "Not Stated": 10826.1,
           "Contribution": 550.0,
           "Civic Donations": 700.0,
           "Office Expenses": 3595.76,
@@ -44,10 +44,23 @@
           "Candidate Filing/Ballot Fees": 300.0,
           "Campaign Literature and Mailings": 36593.49,
           "Professional Services (Legal, Accounting)": 21788.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": 40013.84
+        "opposing_expenditures": 40013.84,
+        "opposing_by_type": {
+          "Postage": 4714.25,
+          "Mailer Design": 1650.0,
+          "Mailer Printing": 2438.13,
+          "Mailhouse & Postage": 3699.26,
+          "Digital Ad in opposition to Noel Gallo": 9250.0,
+          "Design of mailer in opposition to Noel Gallo": 3300.0,
+          "Design of mailer in opposition of Noel Gallo.": 1650.0,
+          "Printing of mailer in opposition to Noel Gallo": 5913.68,
+          "Mailing and Postage in opposition to Noel Gallo": 7398.52
+        }
       },
       "contributions_received": 80100.69,
       "total_contributions": 80100.69,
@@ -60,8 +73,8 @@
         "Other (includes Businesses)": 37631.69
       },
       "expenditures_by_type": {
-        "": 10826.1,
         "Print Ads": 500.0,
+        "Not Stated": 10826.1,
         "Contribution": 550.0,
         "Civic Donations": 700.0,
         "Office Expenses": 3595.76,
@@ -104,16 +117,20 @@
           "Other (includes Businesses)": 3300.0
         },
         "expenditures_by_type": {
-          "": 455.45,
+          "Not Stated": 455.45,
           "Campaign Consultants": 18667.55,
           "Meetings and Appearances": 529.0,
           "Campaign Paraphernalia/Misc.": 3884.37,
           "Campaign Literature and Mailings": 33656.76,
           "Information Technology Costs (Internet, E-mail)": 3150.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 84742.41,
       "total_contributions": 84742.41,
@@ -127,7 +144,7 @@
         "Other (includes Businesses)": 3300.0
       },
       "expenditures_by_type": {
-        "": 455.45,
+        "Not Stated": 455.45,
         "Campaign Consultants": 18667.55,
         "Meetings and Appearances": 529.0,
         "Campaign Paraphernalia/Misc.": 3884.37,

--- a/build/office_election/2/index.json
+++ b/build/office_election/2/index.json
@@ -33,8 +33,8 @@
           "Other (includes Businesses)": 11200.0
         },
         "expenditures_by_type": {
-          "": 17406.96,
           "Print Ads": 1000.0,
+          "Not Stated": 17406.96,
           "Contribution": 750.0,
           "Civic Donations": 4600.0,
           "Office Expenses": 7051.9,
@@ -47,10 +47,14 @@
           "Candidate Travel, Lodging, and Meals": 91.39,
           "Professional Services (Legal, Accounting)": 12410.7,
           "Information Technology Costs (Internet, E-mail)": 3343.09
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 58231.08,
       "total_contributions": 58231.08,
@@ -63,8 +67,8 @@
         "Other (includes Businesses)": 11200.0
       },
       "expenditures_by_type": {
-        "": 17406.96,
         "Print Ads": 1000.0,
+        "Not Stated": 17406.96,
         "Contribution": 750.0,
         "Civic Donations": 4600.0,
         "Office Expenses": 7051.9,
@@ -116,10 +120,14 @@
           "Candidate Filing/Ballot Fees": 300.0,
           "Campaign Literature and Mailings": 3399.31,
           "Information Technology Costs (Internet, E-mail)": 387.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 10634.0,
       "total_contributions": 10634.0,

--- a/build/office_election/3/index.json
+++ b/build/office_election/3/index.json
@@ -34,8 +34,8 @@
           "Other (includes Businesses)": 11950.0
         },
         "expenditures_by_type": {
-          "": 16605.58,
           "Print Ads": 1298.18,
+          "Not Stated": 16605.58,
           "Office Expenses": 15728.02,
           "Fundraising Events": 750.0,
           "Campaign Consultants": 41405.69,
@@ -47,10 +47,14 @@
           "Professional Services (Legal, Accounting)": 3583.75,
           "T.V. or Cable Airtime and Production Costs": 8000.0,
           "Information Technology Costs (Internet, E-mail)": 400.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 134374.0,
       "total_contributions": 134374.0,
@@ -64,8 +68,8 @@
         "Other (includes Businesses)": 11950.0
       },
       "expenditures_by_type": {
-        "": 16605.58,
         "Print Ads": 1298.18,
+        "Not Stated": 16605.58,
         "Office Expenses": 15728.02,
         "Fundraising Events": 750.0,
         "Campaign Consultants": 41405.69,
@@ -117,10 +121,14 @@
           "Campaign Literature and Mailings": 1056.73,
           "Professional Services (Legal, Accounting)": 5575.0,
           "Information Technology Costs (Internet, E-mail)": 1997.97
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 75623.14,
       "total_contributions": 75623.14,
@@ -173,10 +181,14 @@
           "Office Expenses": 145.97,
           "Campaign Paraphernalia/Misc.": 310.03,
           "Candidate Filing/Ballot Fees": 190.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 396.0,
       "total_contributions": 396.0,
@@ -217,10 +229,14 @@
         "contributions_by_type": {
         },
         "expenditures_by_type": {
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -273,10 +289,14 @@
           "Professional Services (Legal, Accounting)": 14215.1,
           "T.V. or Cable Airtime and Production Costs": 79500.0,
           "Information Technology Costs (Internet, E-mail)": 6488.21
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 198167.0,
       "total_contributions": 198167.0,

--- a/build/office_election/4/index.json
+++ b/build/office_election/4/index.json
@@ -34,7 +34,6 @@
         },
         "expenditures_by_type": {
           "Print Ads": 13871.57,
-          "Not Stated": 114796.33,
           "Phone Banks": 79.0,
           "Office Expenses": 125.0,
           "Fundraising Events": 300.8,
@@ -42,10 +41,23 @@
           "Campaign Paraphernalia/Misc.": 2443.7,
           "Candidate Filing/Ballot Fees": 250.0,
           "Professional Services (Legal, Accounting)": 4542.81
+        },
+        "supporting_by_type": {
+          "Print Ads": 2048.0,
+          "CANVASSING": 5000.0,
+          "Phone Banks": 597.7,
+          "ESTIMATE OF LIT": 7915.0,
+          "ESTIMATE OF STAFF TIME": 31088.83,
+          "Campaign Paraphernalia/Misc.": 2702.11,
+          "Campaign Literature and Mailings": 44502.69,
+          "Information Technology Costs (Internet, E-mail)": 8350.0,
+          "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 12592.0
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 27586.0,
       "total_contributions": 27586.0,
@@ -59,7 +71,6 @@
       },
       "expenditures_by_type": {
         "Print Ads": 13871.57,
-        "Not Stated": 114796.33,
         "Phone Banks": 79.0,
         "Office Expenses": 125.0,
         "Fundraising Events": 300.8,
@@ -98,16 +109,21 @@
           "Unitemized": 2762.0
         },
         "expenditures_by_type": {
-          "": 2033.0,
+          "Not Stated": 2033.0,
           "Office Expenses": 1900.34,
           "Campaign Consultants": 3950.0,
           "Campaign Paraphernalia/Misc.": 1167.25,
           "Campaign Literature and Mailings": 1054.74,
           "Professional Services (Legal, Accounting)": 2206.32
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": 6987.5
+        "opposing_expenditures": 6987.5,
+        "opposing_by_type": {
+          "Campaign Literature and Mailings": 6987.5
+        }
       },
       "contributions_received": 13562.0,
       "total_contributions": 13562.0,
@@ -119,7 +135,7 @@
         "Unitemized": 2762.0
       },
       "expenditures_by_type": {
-        "": 2033.0,
+        "Not Stated": 2033.0,
         "Office Expenses": 1900.34,
         "Campaign Consultants": 3950.0,
         "Campaign Paraphernalia/Misc.": 1167.25,

--- a/build/office_election/5/index.json
+++ b/build/office_election/5/index.json
@@ -32,7 +32,7 @@
           "Other (includes Businesses)": 1750.0
         },
         "expenditures_by_type": {
-          "": 809.02,
+          "Not Stated": 809.02,
           "Office Expenses": 1710.94,
           "Fundraising Events": 147.81,
           "Voter Registration": 156.15,
@@ -44,10 +44,14 @@
           "Staff/Spouse Travel, Lodging, and Meals": 320.14,
           "Professional Services (Legal, Accounting)": 372.42,
           "Information Technology Costs (Internet, E-mail)": 100.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 5144.0,
       "total_contributions": 5144.0,
@@ -59,7 +63,7 @@
         "Other (includes Businesses)": 1750.0
       },
       "expenditures_by_type": {
-        "": 809.02,
+        "Not Stated": 809.02,
         "Office Expenses": 1710.94,
         "Fundraising Events": 147.81,
         "Voter Registration": 156.15,
@@ -103,7 +107,6 @@
           "Other (includes Businesses)": 2600.0
         },
         "expenditures_by_type": {
-          "Not Stated": 3894.33,
           "Office Expenses": 248.2,
           "Fundraising Events": 2338.58,
           "Campaign Consultants": 1000.0,
@@ -111,10 +114,17 @@
           "Campaign Paraphernalia/Misc.": 3755.99,
           "Candidate Filing/Ballot Fees": 300.0,
           "Campaign Literature and Mailings": 15150.0
+        },
+        "supporting_by_type": {
+          "ESTIMATE OF STAFF TIME": 1941.33,
+          "Campaign Literature and Mailings": 48.0,
+          "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 1905.0
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 22344.0,
       "total_contributions": 22344.0,
@@ -127,7 +137,6 @@
         "Other (includes Businesses)": 2600.0
       },
       "expenditures_by_type": {
-        "Not Stated": 3894.33,
         "Office Expenses": 248.2,
         "Fundraising Events": 2338.58,
         "Campaign Consultants": 1000.0,

--- a/build/office_election/6/index.json
+++ b/build/office_election/6/index.json
@@ -32,7 +32,6 @@
           "Unitemized": 0.0
         },
         "expenditures_by_type": {
-          "Not Stated": 78327.14,
           "Phone Banks": 834.94,
           "Fundraising Events": 203.53,
           "Campaign Consultants": 1340.0,
@@ -40,10 +39,22 @@
           "Campaign Literature and Mailings": 5458.08,
           "Professional Services (Legal, Accounting)": 200.0,
           "Information Technology Costs (Internet, E-mail)": 597.0
+        },
+        "supporting_by_type": {
+          "Print Ads": 2048.0,
+          "Phone Banks": 276.33,
+          "ESTIMATE OF LIT": 1800.0,
+          "ESTIMATE OF STAFF TIME": 19599.4,
+          "Campaign Paraphernalia/Misc.": 2702.11,
+          "Campaign Literature and Mailings": 45044.3,
+          "Information Technology Costs (Internet, E-mail)": 675.0,
+          "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 6182.0
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 17888.0,
       "total_contributions": 17888.0,
@@ -55,7 +66,6 @@
         "Unitemized": 0.0
       },
       "expenditures_by_type": {
-        "Not Stated": 78327.14,
         "Phone Banks": 834.94,
         "Fundraising Events": 203.53,
         "Campaign Consultants": 1340.0,
@@ -91,10 +101,14 @@
         "contributions_by_type": {
         },
         "expenditures_by_type": {
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -124,43 +138,49 @@
       "party_affiliation": null,
       "filer_id": 1386929,
       "supporting_money": {
-        "contributions_received": 3980.0,
-        "total_contributions": 3980.0,
-        "total_expenditures": 2382.67,
+        "contributions_received": 5798.0,
+        "total_contributions": 5798.0,
+        "total_expenditures": 3052.34,
         "total_loans_received": 0.0,
         "contributions_by_type": {
-          "Individual": 1800.0,
-          "Unitemized": 515.0,
-          "Other (includes Businesses)": 1665.0
+          "Individual": 2590.0,
+          "Unitemized": 1093.0,
+          "Other (includes Businesses)": 2115.0
         },
         "expenditures_by_type": {
+          "Not Stated": 60.0,
           "Fundraising Events": 128.05,
           "Meetings and Appearances": 114.67,
-          "Campaign Paraphernalia/Misc.": 724.48,
-          "Candidate Filing/Ballot Fees": 300.0,
-          "Campaign Literature and Mailings": 839.01,
-          "Information Technology Costs (Internet, E-mail)": 148.0
+          "Campaign Paraphernalia/Misc.": 870.17,
+          "Candidate Filing/Ballot Fees": 310.0,
+          "Campaign Literature and Mailings": 1187.01,
+          "Information Technology Costs (Internet, E-mail)": 177.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
-      "contributions_received": 3980.0,
-      "total_contributions": 3980.0,
-      "total_expenditures": 2382.67,
+      "contributions_received": 5798.0,
+      "total_contributions": 5798.0,
+      "total_expenditures": 3052.34,
       "total_loans_received": 0.0,
       "contributions_by_type": {
-        "Individual": 1800.0,
-        "Unitemized": 515.0,
-        "Other (includes Businesses)": 1665.0
+        "Individual": 2590.0,
+        "Unitemized": 1093.0,
+        "Other (includes Businesses)": 2115.0
       },
       "expenditures_by_type": {
+        "Not Stated": 60.0,
         "Fundraising Events": 128.05,
         "Meetings and Appearances": 114.67,
-        "Campaign Paraphernalia/Misc.": 724.48,
-        "Candidate Filing/Ballot Fees": 300.0,
-        "Campaign Literature and Mailings": 839.01,
-        "Information Technology Costs (Internet, E-mail)": 148.0
+        "Campaign Paraphernalia/Misc.": 870.17,
+        "Candidate Filing/Ballot Fees": 310.0,
+        "Campaign Literature and Mailings": 1187.01,
+        "Information Technology Costs (Internet, E-mail)": 177.0
       }
     },
     {
@@ -189,10 +209,14 @@
         "contributions_by_type": {
         },
         "expenditures_by_type": {
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": null,
       "total_contributions": null,

--- a/build/office_election/7/index.json
+++ b/build/office_election/7/index.json
@@ -30,13 +30,17 @@
           "Unitemized": 382.0
         },
         "expenditures_by_type": {
-          "": 435.74,
+          "Not Stated": 435.74,
           "Campaign Paraphernalia/Misc.": 13557.03,
           "Professional Services (Legal, Accounting)": 850.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 20239.0,
       "total_contributions": 20239.0,
@@ -46,7 +50,7 @@
         "Unitemized": 382.0
       },
       "expenditures_by_type": {
-        "": 435.74,
+        "Not Stated": 435.74,
         "Campaign Paraphernalia/Misc.": 13557.03,
         "Professional Services (Legal, Accounting)": 850.0
       }
@@ -80,7 +84,7 @@
           "Unitemized": 3066.0
         },
         "expenditures_by_type": {
-          "": 700.0,
+          "Not Stated": 700.0,
           "Phone Banks": 1659.63,
           "Office Expenses": 2307.9,
           "Campaign Consultants": 3000.0,
@@ -88,10 +92,14 @@
           "Campaign Literature and Mailings": 7287.36,
           "Postage, Delivery and Messenger Services": 3818.95,
           "Professional Services (Legal, Accounting)": 3147.37
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 26966.0,
       "total_contributions": 26966.0,
@@ -103,7 +111,7 @@
         "Unitemized": 3066.0
       },
       "expenditures_by_type": {
-        "": 700.0,
+        "Not Stated": 700.0,
         "Phone Banks": 1659.63,
         "Office Expenses": 2307.9,
         "Campaign Consultants": 3000.0,
@@ -143,8 +151,8 @@
           "Other (includes Businesses)": 15550.0
         },
         "expenditures_by_type": {
-          "": 4698.42,
           "Print Ads": 1000.0,
+          "Not Stated": 4698.42,
           "Office Expenses": 649.6,
           "Fundraising Events": 315.92,
           "Campaign Consultants": 15000.0,
@@ -154,10 +162,14 @@
           "Staff/Spouse Travel, Lodging, and Meals": 202.76,
           "Professional Services (Legal, Accounting)": 10248.12,
           "Information Technology Costs (Internet, E-mail)": 2236.58
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 72976.0,
       "total_contributions": 72976.0,
@@ -170,8 +182,8 @@
         "Other (includes Businesses)": 15550.0
       },
       "expenditures_by_type": {
-        "": 4698.42,
         "Print Ads": 1000.0,
+        "Not Stated": 4698.42,
         "Office Expenses": 649.6,
         "Fundraising Events": 315.92,
         "Campaign Consultants": 15000.0,

--- a/build/office_election/8/index.json
+++ b/build/office_election/8/index.json
@@ -35,10 +35,14 @@
           "Office Expenses": 506.71,
           "Campaign Consultants": 2500.0,
           "Information Technology Costs (Internet, E-mail)": 265.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 8486.0,
       "total_contributions": 8486.0,
@@ -81,10 +85,14 @@
         "contributions_by_type": {
         },
         "expenditures_by_type": {
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": null,
       "total_contributions": null,
@@ -106,7 +114,7 @@
       "last_name": "Torres",
       "ballot_item": 8,
       "office_election": 8,
-      "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home\"",
+      "bio": "Rosie Torres is running for re-election to represent District 5 for Oakland School Board. Torres was elected to represent Oakland’s District 5 schools in 2012. Torres holds a Bachelor’s Degree in Marketing from San Francisco State University and a Juris Doctorate from Albany Law School in Albany, New York.  \n\nSource: https://www.facebook.com/torresforschoolboard/home",
       "committee_name": "Roseann Torres for Oakland School Board 2016",
       "is_accepted_expenditure_ceiling": null,
       "is_incumbent": true,
@@ -125,7 +133,7 @@
           "Other (includes Businesses)": 1000.0
         },
         "expenditures_by_type": {
-          "": 3317.0,
+          "Not Stated": 3317.0,
           "Contribution": 300.0,
           "Office Expenses": 1736.74,
           "Fundraising Events": 1243.86,
@@ -134,10 +142,15 @@
           "Campaign Literature and Mailings": 3183.32,
           "Professional Services (Legal, Accounting)": 7081.33,
           "Information Technology Costs (Internet, E-mail)": 400.0
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": 6987.5
+        "opposing_expenditures": 6987.5,
+        "opposing_by_type": {
+          "Campaign Literature and Mailings": 6987.5
+        }
       },
       "contributions_received": 21893.01,
       "total_contributions": 21893.01,
@@ -150,7 +163,7 @@
         "Other (includes Businesses)": 1000.0
       },
       "expenditures_by_type": {
-        "": 3317.0,
+        "Not Stated": 3317.0,
         "Contribution": 300.0,
         "Office Expenses": 1736.74,
         "Fundraising Events": 1243.86,
@@ -191,7 +204,6 @@
           "Other (includes Businesses)": 3000.0
         },
         "expenditures_by_type": {
-          "Not Stated": 88339.72,
           "Office Expenses": 123.83,
           "Fundraising Events": 126.9,
           "Voter Registration": 1600.0,
@@ -201,10 +213,23 @@
           "Campaign Literature and Mailings": 10825.06,
           "Professional Services (Legal, Accounting)": 2500.0,
           "Information Technology Costs (Internet, E-mail)": 833.57
+        },
+        "supporting_by_type": {
+          "Print Ads": 48.0,
+          "CANVASSING": 5000.0,
+          "Phone Banks": 342.45,
+          "ESTIMATE OF LIT": 8981.0,
+          "ESTIMATE OF STAFF TIME": 20623.98,
+          "Campaign Paraphernalia/Misc.": 2702.11,
+          "Campaign Literature and Mailings": 35454.18,
+          "Information Technology Costs (Internet, E-mail)": 5675.0,
+          "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 9513.0
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 21685.48,
       "total_contributions": 21685.48,
@@ -217,7 +242,6 @@
         "Other (includes Businesses)": 3000.0
       },
       "expenditures_by_type": {
-        "Not Stated": 88339.72,
         "Office Expenses": 123.83,
         "Fundraising Events": 126.9,
         "Voter Registration": 1600.0,

--- a/build/office_election/9/index.json
+++ b/build/office_election/9/index.json
@@ -36,10 +36,14 @@
           "Campaign Paraphernalia/Misc.": 820.44,
           "Candidate Filing/Ballot Fees": 1477.0,
           "Campaign Literature and Mailings": 1559.56
+        },
+        "supporting_by_type": {
         }
       },
       "opposing_money": {
-        "opposing_expenditures": null
+        "opposing_expenditures": null,
+        "opposing_by_type": {
+        }
       },
       "contributions_received": 67909.0,
       "total_contributions": 67909.0,

--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -7,19 +7,19 @@
   "number": "JJ",
   "supporting_organizations": [
     {
-      "id": "1364564",
-      "name": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
-      "payee": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
-      "amount": 370892.82999999996
-    },
-    {
       "id": "1385949",
       "name": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "payee": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "amount": 183890.79
+    },
+    {
+      "id": "1364564",
+      "name": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
+      "payee": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
+      "amount": 376155.64
     }
   ],
-  "total_contributions": 472457.0,
+  "total_contributions": 477719.80999999994,
   "contributions_by_region": [
     {
       "amount": 29200.0,
@@ -30,7 +30,7 @@
       "locale": "Within California"
     },
     {
-      "amount": 319496.35,
+      "amount": 324759.16,
       "locale": "Within Oakland"
     }
   ]

--- a/build/stats/index.json
+++ b/build/stats/index.json
@@ -1,3 +1,3 @@
 {
-  "date_processed": "2017-03-28"
+  "date_processed": "2017-05-20"
 }

--- a/models/oakland_candidate.rb
+++ b/models/oakland_candidate.rb
@@ -47,9 +47,11 @@ class OaklandCandidate < ActiveRecord::Base
         total_loans_received: calculation(:total_loans_received).try(:to_f),
         contributions_by_type: calculation(:contributions_by_type) || {},
         expenditures_by_type: calculation(:expenditures_by_type) || {},
+        supporting_by_type: calculation(:supporting_by_type) || {},
       },
       opposing_money: {
         opposing_expenditures: calculation(:total_opposing).try(:to_f),
+        opposing_by_type: calculation(:opposing_by_type) || {},
       },
 
       # for backwards compatibility, these should also be exposed at the


### PR DESCRIPTION
@tdooner Please take a look at this.  It almost does the right thing, but when there is IEC supporting expenditures it shows up as both supporting and opposing.  If there is opposing it shows up correctly.  Do you see my problem?
Also we seem to have lost outputting the opposing by type, which is why Kyle could never  find it.
Seems that Expn_Dscr can be used similar to Expn_Code for the 496 expenses.  Sometimes its the code sometimes its a (random) long description.
Noted that sometimes Expn_Code is NULL and mapped this to ''.