### PR TITLE
Make a couple processing steps more deterministic

### DIFF
--- a/build/committee/1294190/contributions/index.json
+++ b/build/committee/1294190/contributions/index.json
@@ -1,10 +1,10 @@
 [
   {
     "Filer_ID": "1294190",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-25",
+    "Tran_Amt1": 1250.0,
+    "Tran_Date": "2016-05-24",
     "Tran_NamF": null,
-    "Tran_NamL": "Community Bank of the Bay"
+    "Tran_NamL": "Faculty for Our University's Future Local Committee, sponsored by the California Faculty Association"
   },
   {
     "Filer_ID": "1294190",
@@ -15,17 +15,17 @@
   },
   {
     "Filer_ID": "1294190",
-    "Tran_Amt1": 1250.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Faculty for Our University's Future Local Committee, sponsored by the California Faculty Association"
-  },
-  {
-    "Filer_ID": "1294190",
     "Tran_Amt1": 1000.0,
     "Tran_Date": "2016-05-25",
     "Tran_NamF": "Abel",
     "Tran_NamL": "Guillen for Oakland City Council 2014 Officeholder Account"
+  },
+  {
+    "Filer_ID": "1294190",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-05-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021 Candidate PAC"
   },
   {
     "Filer_ID": "1294190",
@@ -43,6 +43,13 @@
   },
   {
     "Filer_ID": "1294190",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-07-05",
+    "Tran_NamF": "Tony",
+    "Tran_NamL": "Thurmond for Assembly 2016"
+  },
+  {
+    "Filer_ID": "1294190",
     "Tran_Amt1": 10000.0,
     "Tran_Date": "2016-09-01",
     "Tran_NamF": null,
@@ -50,17 +57,10 @@
   },
   {
     "Filer_ID": "1294190",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-05-30",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-25",
     "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021 Candidate PAC"
-  },
-  {
-    "Filer_ID": "1294190",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-07-05",
-    "Tran_NamF": "Tony",
-    "Tran_NamL": "Thurmond for Assembly 2016"
+    "Tran_NamL": "Community Bank of the Bay"
   },
   {
     "Filer_ID": "1294190",

--- a/build/committee/1294190/contributions/index.json
+++ b/build/committee/1294190/contributions/index.json
@@ -58,14 +58,14 @@
   {
     "Filer_ID": "1294190",
     "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-14",
+    "Tran_Date": "2016-07-05",
     "Tran_NamF": "Tony",
     "Tran_NamL": "Thurmond for Assembly 2016"
   },
   {
     "Filer_ID": "1294190",
     "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-07-05",
+    "Tran_Date": "2016-10-14",
     "Tran_NamF": "Tony",
     "Tran_NamL": "Thurmond for Assembly 2016"
   }

--- a/build/committee/1303019/contributions/index.json
+++ b/build/committee/1303019/contributions/index.json
@@ -1,143 +1,10 @@
 [
   {
     "Filer_ID": "1303019",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Bob",
-    "Tran_NamL": "Arnold"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "Becky",
-    "Tran_NamL": "Austin"
-  },
-  {
-    "Filer_ID": "1303019",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Kathy",
-    "Tran_NamL": "Baldanza"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Berg"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "Caroline",
-    "Tran_NamL": "Bettendorf"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-19",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bliss"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Bradley",
-    "Tran_NamL": "Brownlow"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Cohen"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 360.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "Hilary",
-    "Tran_NamL": "Crosby"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "Kelly",
-    "Tran_NamL": "Cushner"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Kelly",
-    "Tran_NamL": "Cushner"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-27",
-    "Tran_NamF": "Virginia",
-    "Tran_NamL": "Davis"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-14",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Diamond"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Dobbins"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Dowling"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Kai",
-    "Tran_NamL": "Drekmeier"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Ellie",
-    "Tran_NamL": "Ehrenhaft"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Epstein"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Jenny",
-    "Tran_NamL": "Ettinger"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "Paul",
-    "Tran_NamL": "Fassinger"
+    "Tran_Date": "2016-02-25",
+    "Tran_NamF": "Elogeanne",
+    "Tran_NamL": "Matson Grossmna"
   },
   {
     "Filer_ID": "1303019",
@@ -149,198 +16,9 @@
   {
     "Filer_ID": "1303019",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Shelly",
-    "Tran_NamL": "Fierston"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Flattery"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Lori",
-    "Tran_NamL": "Fogarty"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Gessel"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Nori",
-    "Tran_NamL": "Grossman"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Gurowitz"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Jill",
-    "Tran_NamL": "Habig"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Haladay"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Halperin"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "Beverly",
-    "Tran_NamL": "Hansen"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Justin",
-    "Tran_NamL": "Horner"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Hunt"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Jeff and Dutch",
-    "Tran_NamL": "Key"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-24",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Kidd"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-17",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Klein"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-24",
-    "Tran_NamF": "Jodi",
-    "Tran_NamL": "Korb"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "Joan",
-    "Tran_NamL": "Korin"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Kuiper"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Lake"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-19",
-    "Tran_NamF": "Evelyn",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Chan",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-13",
-    "Tran_NamF": "Marty",
-    "Tran_NamL": "Liberman"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Maxi",
-    "Tran_NamL": "Lilley"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-16",
-    "Tran_NamF": "Arnie",
-    "Tran_NamL": "London"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Arnie",
-    "Tran_NamL": "London"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "Jane",
-    "Tran_NamL": "Mason"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-02-25",
-    "Tran_NamF": "Elogeanne",
-    "Tran_NamL": "Matson Grossmna"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-20",
-    "Tran_NamF": "Demetra",
-    "Tran_NamL": "McBride"
+    "Tran_Date": "2016-03-01",
+    "Tran_NamF": "Peter",
+    "Tran_NamL": "Wright"
   },
   {
     "Filer_ID": "1303019",
@@ -352,58 +30,9 @@
   {
     "Filer_ID": "1303019",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Erin",
-    "Tran_NamL": "McDevitt"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "McKoy"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Jackie",
-    "Tran_NamL": "Minor"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "Irene",
-    "Tran_NamL": "Moosen"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Jim",
-    "Tran_NamL": "Morehead"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-27",
-    "Tran_NamF": "Gregg",
-    "Tran_NamL": "Morris"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Neuts"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-04-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Northern California Carpenters Regional Council"
+    "Tran_Date": "2016-03-02",
+    "Tran_NamF": "Simone & Marvin",
+    "Tran_NamL": "Savlov"
   },
   {
     "Filer_ID": "1303019",
@@ -414,45 +43,24 @@
   },
   {
     "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Ellen",
-    "Tran_NamL": "Polansky"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-10",
+    "Tran_NamF": "Gene",
+    "Tran_NamL": "Zahas"
   },
   {
     "Filer_ID": "1303019",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Poncelet"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "Jean",
-    "Tran_NamL": "Port"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-19",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
   },
   {
     "Filer_ID": "1303019",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Kathy",
-    "Tran_NamL": "Riani"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-11",
-    "Tran_NamF": "Pamela",
-    "Tran_NamL": "Rich"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Kersti",
-    "Tran_NamL": "Rose"
+    "Tran_Date": "2016-03-19",
+    "Tran_NamF": "Evelyn",
+    "Tran_NamL": "Lee"
   },
   {
     "Filer_ID": "1303019",
@@ -460,139 +68,6 @@
     "Tran_Date": "2016-03-19",
     "Tran_NamF": "Leslie",
     "Tran_NamL": "Sanders"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-02",
-    "Tran_NamF": "Simone & Marvin",
-    "Tran_NamL": "Savlov"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "Libby",
-    "Tran_NamL": "Schaaf"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-10",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Schiller"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Schumacher"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "Jeff",
-    "Tran_NamL": "Segall"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sheet Metal Workers' Local Union No. 104"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-11",
-    "Tran_NamF": "Pat",
-    "Tran_NamL": "Shoptaugh"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Silver"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Skinner for Senate 2016"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-24",
-    "Tran_NamF": "Cindy",
-    "Tran_NamL": "Sloan"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-17",
-    "Tran_NamF": "Cory",
-    "Tran_NamL": "Smegal"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Spencer"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sprinkler Fitters and Apprentices Local 483"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "Stacey Luce Graphic Design"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Stein"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-04-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "Teamsters Joint Council No 7"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Truelove"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Ubell"
-  },
-  {
-    "Filer_ID": "1303019",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Zachary",
-    "Tran_NamL": "Unger"
   },
   {
     "Filer_ID": "1303019",
@@ -604,9 +79,198 @@
   {
     "Filer_ID": "1303019",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-20",
+    "Tran_NamF": "Demetra",
+    "Tran_NamL": "McBride"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-04-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California Carpenters Regional Council"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Zachary",
+    "Tran_NamL": "Unger"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-04-16",
+    "Tran_NamF": "Arnie",
+    "Tran_NamL": "London"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-04-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "Teamsters Joint Council No 7"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "Beverly",
+    "Tran_NamL": "Hansen"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "Stacey Luce Graphic Design"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Spencer"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-13",
+    "Tran_NamF": "Marty",
+    "Tran_NamL": "Liberman"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Schumacher"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-11",
+    "Tran_NamF": "Pat",
+    "Tran_NamL": "Shoptaugh"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-14",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Diamond"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-07-14",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Walsh"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Poncelet"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-17",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Klein"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-17",
+    "Tran_NamF": "Cory",
+    "Tran_NamL": "Smegal"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Hunt"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Korin"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "Jean",
+    "Tran_NamL": "Port"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "Libby",
+    "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Truelove"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-24",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-24",
+    "Tran_NamF": "Jodi",
+    "Tran_NamL": "Korb"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-24",
+    "Tran_NamF": "Cindy",
+    "Tran_NamL": "Sloan"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-27",
+    "Tran_NamF": "Virginia",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-27",
+    "Tran_NamF": "Gregg",
+    "Tran_NamL": "Morris"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "Kelly",
+    "Tran_NamL": "Cushner"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Ubell"
   },
   {
     "Filer_ID": "1303019",
@@ -618,9 +282,170 @@
   {
     "Filer_ID": "1303019",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-01",
-    "Tran_NamF": "Peter",
-    "Tran_NamL": "Wright"
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Jenny",
+    "Tran_NamL": "Ettinger"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Stein"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Dowling"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Dobbins"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Lake"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Andy",
+    "Tran_NamL": "Young"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "Irene",
+    "Tran_NamL": "Moosen"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "Jeff",
+    "Tran_NamL": "Segall"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Flattery"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Kathy",
+    "Tran_NamL": "Baldanza"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Haladay"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Jackie",
+    "Tran_NamL": "Minor"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Kersti",
+    "Tran_NamL": "Rose"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Kelly",
+    "Tran_NamL": "Cushner"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Chan",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Kathy",
+    "Tran_NamL": "Riani"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Cohen"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Justin",
+    "Tran_NamL": "Horner"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Jim",
+    "Tran_NamL": "Morehead"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Becky",
+    "Tran_NamL": "Austin"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Paul",
+    "Tran_NamL": "Fassinger"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Gessel"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Bob",
+    "Tran_NamL": "Arnold"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 360.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "Hilary",
+    "Tran_NamL": "Crosby"
   },
   {
     "Filer_ID": "1303019",
@@ -632,15 +457,190 @@
   {
     "Filer_ID": "1303019",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Andy",
-    "Tran_NamL": "Young"
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Erin",
+    "Tran_NamL": "McDevitt"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Gurowitz"
   },
   {
     "Filer_ID": "1303019",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-10",
-    "Tran_NamF": "Gene",
-    "Tran_NamL": "Zahas"
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "Caroline",
+    "Tran_NamL": "Bettendorf"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Berg"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Kuiper"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Maxi",
+    "Tran_NamL": "Lilley"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Neuts"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Schiller"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-11",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Rich"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Nori",
+    "Tran_NamL": "Grossman"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Epstein"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Ellen",
+    "Tran_NamL": "Polansky"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Jeff and Dutch",
+    "Tran_NamL": "Key"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sprinkler Fitters and Apprentices Local 483"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Ellie",
+    "Tran_NamL": "Ehrenhaft"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "Jane",
+    "Tran_NamL": "Mason"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Drekmeier"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Halperin"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sheet Metal Workers' Local Union No. 104"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Lori",
+    "Tran_NamL": "Fogarty"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Jill",
+    "Tran_NamL": "Habig"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Arnie",
+    "Tran_NamL": "London"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Shelly",
+    "Tran_NamL": "Fierston"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "McKoy"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Skinner for Senate 2016"
+  },
+  {
+    "Filer_ID": "1303019",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Brownlow"
   }
 ]

--- a/build/committee/1303019/contributions/index.json
+++ b/build/committee/1303019/contributions/index.json
@@ -65,14 +65,14 @@
   {
     "Filer_ID": "1303019",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-17",
+    "Tran_Date": "2016-07-28",
     "Tran_NamF": "Kelly",
     "Tran_NamL": "Cushner"
   },
   {
     "Filer_ID": "1303019",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-28",
+    "Tran_Date": "2016-08-17",
     "Tran_NamF": "Kelly",
     "Tran_NamL": "Cushner"
   },

--- a/build/committee/1307016/contributions/index.json
+++ b/build/committee/1307016/contributions/index.json
@@ -1,10 +1,10 @@
 [
   {
     "Filer_ID": "1307016",
-    "Tran_Amt1": 20000.0,
-    "Tran_Date": "2016-07-11",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-01-07",
     "Tran_NamF": null,
-    "Tran_NamL": "22 Terra Vista Apartments, c/o J&R Associates"
+    "Tran_NamL": "AT&T California Employees PAC"
   },
   {
     "Filer_ID": "1307016",
@@ -15,10 +15,52 @@
   },
   {
     "Filer_ID": "1307016",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-01-07",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-16",
     "Tran_NamF": null,
-    "Tran_NamL": "AT&T California Employees PAC"
+    "Tran_NamL": "Ford Street TIC"
+  },
+  {
+    "Filer_ID": "1307016",
+    "Tran_Amt1": 15000.0,
+    "Tran_Date": "2016-05-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Flynn Investments"
+  },
+  {
+    "Filer_ID": "1307016",
+    "Tran_Amt1": 3250.0,
+    "Tran_Date": "2016-05-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Pacific Gas & Electric"
+  },
+  {
+    "Filer_ID": "1307016",
+    "Tran_Amt1": 20000.0,
+    "Tran_Date": "2016-07-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "22 Terra Vista Apartments, c/o J&R Associates"
+  },
+  {
+    "Filer_ID": "1307016",
+    "Tran_Amt1": 20000.0,
+    "Tran_Date": "2016-07-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "J & R Land & Cattle Company, LP (1551 Madison Street)"
+  },
+  {
+    "Filer_ID": "1307016",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-07-19",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Del Beccaro"
+  },
+  {
+    "Filer_ID": "1307016",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lennar Multifamily Communities LLC-West"
   },
   {
     "Filer_ID": "1307016",
@@ -36,27 +78,6 @@
   },
   {
     "Filer_ID": "1307016",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-07-19",
-    "Tran_NamF": "Edward",
-    "Tran_NamL": "Del Beccaro"
-  },
-  {
-    "Filer_ID": "1307016",
-    "Tran_Amt1": 15000.0,
-    "Tran_Date": "2016-05-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Flynn Investments"
-  },
-  {
-    "Filer_ID": "1307016",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "Ford Street TIC"
-  },
-  {
-    "Filer_ID": "1307016",
     "Tran_Amt1": 10000.0,
     "Tran_Date": "2016-09-21",
     "Tran_NamF": null,
@@ -64,30 +85,9 @@
   },
   {
     "Filer_ID": "1307016",
-    "Tran_Amt1": 20000.0,
-    "Tran_Date": "2016-07-11",
-    "Tran_NamF": null,
-    "Tran_NamL": "J & R Land & Cattle Company, LP (1551 Madison Street)"
-  },
-  {
-    "Filer_ID": "1307016",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lennar Multifamily Communities LLC-West"
-  },
-  {
-    "Filer_ID": "1307016",
     "Tran_Amt1": 3500.0,
     "Tran_Date": "2016-10-26",
     "Tran_NamF": null,
     "Tran_NamL": "PG&E Corporation"
-  },
-  {
-    "Filer_ID": "1307016",
-    "Tran_Amt1": 3250.0,
-    "Tran_Date": "2016-05-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Pacific Gas & Electric"
   }
 ]

--- a/build/committee/1331137/contributions/index.json
+++ b/build/committee/1331137/contributions/index.json
@@ -3452,14 +3452,14 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
+    "Tran_Amt1": 11.54,
     "Tran_Date": "2016-08-12",
     "Tran_NamF": "BEN",
     "Tran_NamL": "OCHSTEIN"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 11.54,
+    "Tran_Amt1": 75.0,
     "Tran_Date": "2016-08-12",
     "Tran_NamF": "BEN",
     "Tran_NamL": "OCHSTEIN"

--- a/build/committee/1331137/contributions/index.json
+++ b/build/committee/1331137/contributions/index.json
@@ -1,10 +1,164 @@
 [
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": "STEPHANIE",
+    "Tran_NamL": "NGUYEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 5.0,
     "Tran_Date": "2016-01-18",
     "Tran_NamF": "JASMINE",
     "Tran_NamL": "ABELE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "LAILA",
+    "Tran_NamL": "JENKINS-PEREZ"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "MARTEL",
+    "Tran_NamL": "PRICE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "SEDRICK",
+    "Tran_NamL": "TYDUS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-19",
+    "Tran_NamF": "BRUCE",
+    "Tran_NamL": "BUCKELEW"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-01-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-19",
+    "Tran_NamF": "LYNZI",
+    "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-20",
+    "Tran_NamF": "FRANCISCO",
+    "Tran_NamL": "NIETO"
   },
   {
     "Filer_ID": "1331137",
@@ -15,6 +169,244 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-21",
+    "Tran_NamF": "MARIA",
+    "Tran_NamL": "MASSELLA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-26",
+    "Tran_NamF": "IRIS",
+    "Tran_NamL": "WINOGROND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-02-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-02-05",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "LEWIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 130.0,
+    "Tran_Date": "2016-02-11",
+    "Tran_NamF": "THAI",
+    "Tran_NamL": "CHU"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "STEPHANIE",
+    "Tran_NamL": "NGUYEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "LAILA",
+    "Tran_NamL": "JENKINS-PEREZ"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "MARTEL",
+    "Tran_NamL": "PRICE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "SEDRICK",
+    "Tran_NamL": "TYDUS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-19",
+    "Tran_NamF": "BRUCE",
+    "Tran_NamL": "BUCKELEW"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-02-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-19",
+    "Tran_NamF": "LYNZI",
+    "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-20",
+    "Tran_NamF": "FRANCISCO",
+    "Tran_NamL": "NIETO"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
     "Tran_Date": "2016-02-21",
     "Tran_NamF": "LARISSA",
@@ -22,87 +414,213 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-03-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-21",
+    "Tran_NamF": "MARIA",
+    "Tran_NamL": "MASSELLA"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-04-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-05-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-26",
+    "Tran_NamF": "IRIS",
+    "Tran_NamL": "WINOGROND"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "SHERYL",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-11-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-03-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-12-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-08",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "ELEANOR",
-    "Tran_NamL": "ALDERMAN"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-03-09",
+    "Tran_NamF": "AUTUMN",
+    "Tran_NamL": "MCDONALD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-09",
+    "Tran_NamF": "AMY",
+    "Tran_NamL": "RODRIGUEZ BOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-10",
+    "Tran_NamF": "ABE",
+    "Tran_NamL": "FRIEDMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-10",
+    "Tran_NamF": "JENNIFER",
+    "Tran_NamL": "FRIEDMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "XAVIER",
+    "Tran_NamL": "BUSTER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "DIANA",
+    "Tran_NamL": "KAMPA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "CINDY",
+    "Tran_NamL": "LION"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "KYRA",
+    "Tran_NamL": "MUNGIA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 23.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "EDGAR",
+    "Tran_NamL": "RODRIGUEZ-RAMIREZ"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "STEPHANIE",
+    "Tran_NamL": "NGUYEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
   },
   {
     "Filer_ID": "1331137",
@@ -114,93 +632,9 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "RACHEL",
-    "Tran_NamL": "AMSTERDAM"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "JENNIFER",
-    "Tran_NamL": "ANDERSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "JUSTIN",
-    "Tran_NamL": "ANDERSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "ALICIA",
-    "Tran_NamL": "ARENAS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "ELIZABETH",
-    "Tran_NamL": "ARNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "LISSETTE",
-    "Tran_NamL": "AVERHOFF"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "LISSETTE",
-    "Tran_NamL": "AVERHOFF"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "LISSETTE",
-    "Tran_NamL": "AVERHOFF"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "NIDYA",
-    "Tran_NamL": "BAEZ"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "ROBIN",
     "Tran_NamL": "BAILER-GLOVER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-10",
-    "Tran_NamF": "JOHN",
-    "Tran_NamL": "BALDO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-26",
-    "Tran_NamF": "DANIEL",
-    "Tran_NamL": "BELLINO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "BENAVIDES"
   },
   {
     "Filer_ID": "1331137",
@@ -225,101 +659,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "TAIMA",
-    "Tran_NamL": "BEYAH"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "JOHN",
     "Tran_NamL": "BLISS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "JOHN",
-    "Tran_NamL": "BLISS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 300000.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "MONICA",
-    "Tran_NamL": "BOON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "NOAH",
-    "Tran_NamL": "BRADLEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "NOAH",
-    "Tran_NamL": "BRADLEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-19",
-    "Tran_NamF": "BRUCE",
-    "Tran_NamL": "BUCKELEW"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-19",
-    "Tran_NamF": "BRUCE",
-    "Tran_NamL": "BUCKELEW"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-19",
-    "Tran_NamF": "BRUCE",
-    "Tran_NamL": "BUCKELEW"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-19",
-    "Tran_NamF": "BRUCE",
-    "Tran_NamL": "BUCKELEW"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "BRUCE",
-    "Tran_NamL": "BUCKELEW"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "XAVIER",
-    "Tran_NamL": "BUSTER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "CARLOS",
-    "Tran_NamL": "CAMARGO"
   },
   {
     "Filer_ID": "1331137",
@@ -337,13 +680,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "YANIRA",
-    "Tran_NamL": "CANIZALES"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "WILLIAM",
@@ -351,38 +687,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-17",
-    "Tran_NamF": "WILLIAM",
-    "Tran_NamL": "CARDENAS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "KATHERINE",
-    "Tran_NamL": "CARTER"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "DAVID",
     "Tran_NamL": "CASTILLO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "CASTILLO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "CARRIE",
-    "Tran_NamL": "CHAN"
   },
   {
     "Filer_ID": "1331137",
@@ -393,31 +701,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "ANTHONY",
-    "Tran_NamL": "CHAVEZ"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "BEN",
     "Tran_NamL": "CHIDA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-07-19",
-    "Tran_NamF": "AMBER",
-    "Tran_NamL": "CHILDRESS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 130.0,
-    "Tran_Date": "2016-02-11",
-    "Tran_NamF": "THAI",
-    "Tran_NamL": "CHU"
   },
   {
     "Filer_ID": "1331137",
@@ -442,59 +729,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "CHARLES",
-    "Tran_NamL": "COLE III"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "CHARLES",
-    "Tran_NamL": "COLE, III"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "PETE",
-    "Tran_NamL": "CORDERO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "CHARLIE",
-    "Tran_NamL": "COURIC"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 11.54,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "RACHEL",
-    "Tran_NamL": "CRISCITIELLO"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "ASHLEY",
     "Tran_NamL": "CROMWELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "MAGGIE",
-    "Tran_NamL": "CROUSHORE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "MAGGIE",
-    "Tran_NamL": "CROUSHORE"
   },
   {
     "Filer_ID": "1331137",
@@ -520,13 +758,6 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "LAUREN",
-    "Tran_NamL": "DEWEES KEARSE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "REBECA",
     "Tran_NamL": "DIAZ"
@@ -540,52 +771,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "DIANE",
-    "Tran_NamL": "DODGE"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "COREY",
     "Tran_NamL": "DONAHUE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "MARIA",
-    "Tran_NamL": "DRAKE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "JEAN",
-    "Tran_NamL": "DRISCOLL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "JEAN",
-    "Tran_NamL": "DRISCOLL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "DRIVER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "KRISTIN",
-    "Tran_NamL": "ELIZALDE"
   },
   {
     "Filer_ID": "1331137",
@@ -603,62 +792,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "BETTINA",
@@ -666,178 +799,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-10",
-    "Tran_NamF": "ABE",
-    "Tran_NamL": "FRIEDMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-10",
-    "Tran_NamF": "JENNIFER",
-    "Tran_NamL": "FRIEDMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-25",
-    "Tran_NamF": "CATHERINE",
-    "Tran_NamL": "FRYSZCZYN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "LINDSEY",
-    "Tran_NamL": "FULLER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "FYLES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "KRISTIN",
-    "Tran_NamL": "GALLAGHER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "JULIA",
-    "Tran_NamL": "GELORMINO"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "EDWARD",
     "Tran_NamL": "GERBER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-10",
-    "Tran_NamF": "ED",
-    "Tran_NamL": "GERBER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "EDWARD",
-    "Tran_NamL": "GERBER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "ABBY",
-    "Tran_NamL": "GILLESPIE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "TRACEY",
-    "Tran_NamL": "GILLESPIE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "ABBY",
-    "Tran_NamL": "GILLESPIE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-02-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-03-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-03-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-07-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-11-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-12-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "ODIAKA",
-    "Tran_NamL": "GONZALEZ"
   },
   {
     "Filer_ID": "1331137",
@@ -848,136 +813,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "CHRISTINA",
-    "Tran_NamL": "GREENBERG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "ALLISON",
-    "Tran_NamL": "GUILFOIL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "JILL",
     "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "JORDAN",
-    "Tran_NamL": "HANDLER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "LEA",
-    "Tran_NamL": "HARTOG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "HASSID"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "SHELLEY",
-    "Tran_NamL": "HAWKINS-MCCRAY"
   },
   {
     "Filer_ID": "1331137",
@@ -996,20 +835,6 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "TAMARA",
-    "Tran_NamL": "HENRY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "MICHELLE",
-    "Tran_NamL": "HENSHAW"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "LAURA",
     "Tran_NamL": "HERNANDEZ"
@@ -1023,22 +848,8 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 53.74,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "HEUMANN"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
     "Tran_Date": "2016-03-16",
-    "Tran_NamF": "EMMA",
-    "Tran_NamL": "HIZA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-06-28",
     "Tran_NamF": "EMMA",
     "Tran_NamL": "HIZA"
   },
@@ -1048,62 +859,6 @@
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "VICTORIA",
     "Tran_NamL": "HOLDEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 1.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
   },
   {
     "Filer_ID": "1331137",
@@ -1129,13 +884,6 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-14",
-    "Tran_NamF": "KEVIN",
-    "Tran_NamL": "HUNTER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "CHRIS",
     "Tran_NamL": "HWANG"
@@ -1149,27 +897,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "LAILA",
-    "Tran_NamL": "JENKINS-PEREZ"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "LAILA",
-    "Tran_NamL": "JENKINS-PEREZ"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "LAILA",
-    "Tran_NamL": "JENKINS-PEREZ"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "LINDSEY",
@@ -1177,87 +904,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "JOHNSTONE SUPPLY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "JOHNSTONE SUPPLY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "BOBBY",
-    "Tran_NamL": "JORDAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "JORDAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "BOBBY",
-    "Tran_NamL": "JORDAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "PHILIPPA",
-    "Tran_NamL": "JUBELIRER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "DIANA",
-    "Tran_NamL": "KAMPA"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "DIANA",
     "Tran_NamL": "KAMPA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 32.64,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "KAUFMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "SAMANTHA",
-    "Tran_NamL": "KELLER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "PHIL",
-    "Tran_NamL": "KIM"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 35.0,
-    "Tran_Date": "2016-04-07",
-    "Tran_NamF": "KYLE",
-    "Tran_NamL": "KIMMERLE"
   },
   {
     "Filer_ID": "1331137",
@@ -1268,13 +918,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "NEERAV",
-    "Tran_NamL": "KINGSLAND"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "RENE",
@@ -1282,268 +925,9 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "JONATHAN",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-28",
-    "Tran_NamF": "R. JANE",
     "Tran_NamL": "KLEIN"
   },
   {
@@ -1555,206 +939,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "BILL",
-    "Tran_NamL": "KRAMER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "JOHN",
-    "Tran_NamL": "KRULL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-14",
-    "Tran_NamF": "NAYAA",
-    "Tran_NamL": "LACY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "AMIE",
-    "Tran_NamL": "LAMONTAGNE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "CRYSTAL",
-    "Tran_NamL": "LAND"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-07-19",
-    "Tran_NamF": "CAITLIN",
-    "Tran_NamL": "LANG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "PETER",
-    "Tran_NamL": "LAUB"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-14",
-    "Tran_NamF": "DIANA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-02-05",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "LEWIS"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "RONALD",
     "Tran_NamL": "LEWIS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "LEWIS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 49.0,
-    "Tran_Date": "2016-05-05",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "LEWIS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 68.0,
-    "Tran_Date": "2016-05-20",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "LEWIS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 148.0,
-    "Tran_Date": "2016-06-03",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "LEWIS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "LEWIS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "DEBBRA",
-    "Tran_NamL": "LINDO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "CINDY",
-    "Tran_NamL": "LION"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "CARA",
-    "Tran_NamL": "LIUZZI"
   },
   {
     "Filer_ID": "1331137",
@@ -1786,83 +974,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "ASHLEY",
-    "Tran_NamL": "MARTIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "ANNA",
-    "Tran_NamL": "MARTIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-21",
-    "Tran_NamF": "MARIA",
-    "Tran_NamL": "MASSELLA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-21",
-    "Tran_NamF": "MARIA",
-    "Tran_NamL": "MASSELLA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-21",
-    "Tran_NamF": "MARIA",
-    "Tran_NamL": "MASSELLA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "ALFREDO",
-    "Tran_NamL": "MATHEW"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "JANE",
-    "Tran_NamL": "MAYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "CHRISTINA",
-    "Tran_NamL": "MCCLAIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "SEAN",
-    "Tran_NamL": "MCCLUNG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-03-09",
-    "Tran_NamF": "AUTUMN",
-    "Tran_NamL": "MCDONALD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "AUTUMN",
-    "Tran_NamL": "MCDONALD"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "TERON",
@@ -1870,178 +981,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "SONYA",
     "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "ANNETTE",
-    "Tran_NamL": "MILLER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "ADAM",
-    "Tran_NamL": "MILLER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "ANNETTE",
-    "Tran_NamL": "MILLER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "ADAM",
-    "Tran_NamL": "MILLER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 115.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "EVAN",
-    "Tran_NamL": "MILLER"
   },
   {
     "Filer_ID": "1331137",
@@ -2052,87 +995,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "REEN",
-    "Tran_NamL": "MOHAMMED"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "RAY",
-    "Tran_NamL": "MONDRAGON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "L. KAREN",
-    "Tran_NamL": "MONROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "SABRINA",
-    "Tran_NamL": "MOORE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "KARINA",
-    "Tran_NamL": "MORENO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "KARINA",
-    "Tran_NamL": "MORENO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-03",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "MORGAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "DORAN",
-    "Tran_NamL": "MORGAN"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "SARAH",
     "Tran_NamL": "MORRILL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "SARAH",
-    "Tran_NamL": "MORRILL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "HUGH",
-    "Tran_NamL": "MORRISON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "KYRA",
-    "Tran_NamL": "MUNGIA"
   },
   {
     "Filer_ID": "1331137",
@@ -2147,153 +1013,6 @@
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "WILLIAM",
     "Tran_NamL": "NEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "WILLIAM",
-    "Tran_NamL": "NEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "WILLIAM",
-    "Tran_NamL": "NEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "WILLIAM",
-    "Tran_NamL": "NEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": "STEPHANIE",
-    "Tran_NamL": "NGUYEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "STEPHANIE",
-    "Tran_NamL": "NGUYEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "STEPHANIE",
-    "Tran_NamL": "NGUYEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "STEPHANIE",
-    "Tran_NamL": "NGUYEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 27.37,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "VYLINH",
-    "Tran_NamL": "NGUYEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
   },
   {
     "Filer_ID": "1331137",
@@ -2301,62 +1020,6 @@
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "KATE",
     "Tran_NamL": "NICOL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-20",
-    "Tran_NamF": "FRANCISCO",
-    "Tran_NamL": "NIETO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-20",
-    "Tran_NamF": "FRANCISCO",
-    "Tran_NamL": "NIETO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-20",
-    "Tran_NamF": "FRANCISCO",
-    "Tran_NamL": "NIETO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 270.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "FRANCISCO",
-    "Tran_NamL": "NIETO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "MARSHA",
-    "Tran_NamL": "NOVICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "SHERRY",
-    "Tran_NamL": "NOVICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "BEN",
-    "Tran_NamL": "NUSSBAUM"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "BEN",
-    "Tran_NamL": "NUSSBAUM"
   },
   {
     "Filer_ID": "1331137",
@@ -2374,188 +1037,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "IDA",
-    "Tran_NamL": "OBERMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "TERESA",
-    "Tran_NamL": "OBRIEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "BEN",
-    "Tran_NamL": "OCHSTEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 11.54,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "BEN",
-    "Tran_NamL": "OCHSTEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "JOY",
-    "Tran_NamL": "OSBORNE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "DAISY",
-    "Tran_NamL": "PADILLA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "DAISY",
-    "Tran_NamL": "PADILLA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 4100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "PARENT TEACHER ALLIANCE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 2600.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "PARENT TEACHER ALLIANCE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 2800.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "PARENT TEACHER ALLIANCE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 72250.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "PARENT TEACHER ALLIANCE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "MACY",
-    "Tran_NamL": "PARKER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 53.74,
-    "Tran_Date": "2016-07-27",
-    "Tran_NamF": "RICHARD",
-    "Tran_NamL": "PELAYO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "ERNEST",
-    "Tran_NamL": "PETERSON"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "SUSAN",
@@ -2563,148 +1044,8 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "MARGARET",
-    "Tran_NamL": "POWER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "MARTEL",
-    "Tran_NamL": "PRICE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "MARTEL",
-    "Tran_NamL": "PRICE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "MARTEL",
-    "Tran_NamL": "PRICE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "DONETHA",
-    "Tran_NamL": "PRINCE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "DAN",
-    "Tran_NamL": "QUIGLEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-07-20",
-    "Tran_NamF": "DAN",
-    "Tran_NamL": "QUIGLEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "SUSAN",
-    "Tran_NamL": "RASMUSSEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-25",
     "Tran_NamF": "NICK",
     "Tran_NamL": "RESNICK"
   },
@@ -2714,146 +1055,6 @@
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "CARMELITA",
     "Tran_NamL": "REYES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-07-20",
-    "Tran_NamF": "CARMELITA",
-    "Tran_NamL": "REYES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "MAYA",
-    "Tran_NamL": "ROBLES-WONG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 49900.0,
-    "Tran_Date": "2016-07-09",
-    "Tran_NamF": "ARTHUR",
-    "Tran_NamL": "ROCK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-09",
-    "Tran_NamF": "AMY",
-    "Tran_NamL": "RODRIGUEZ BOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "AMY",
-    "Tran_NamL": "RODRIGUEZ BOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "AMY",
-    "Tran_NamL": "RODRIGUEZ BOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 23.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "EDGAR",
-    "Tran_NamL": "RODRIGUEZ-RAMIREZ"
   },
   {
     "Filer_ID": "1331137",
@@ -2868,83 +1069,6 @@
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "DAVID",
     "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 750.0,
-    "Tran_Date": "2016-07-29",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-19",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-19",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 49900.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "T. GARY",
-    "Tran_NamL": "ROGERS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "EMMA",
-    "Tran_NamL": "ROOS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "HARVEY",
-    "Tran_NamL": "ROSEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "LYNNE",
-    "Tran_NamL": "ROSEN"
   },
   {
     "Filer_ID": "1331137",
@@ -2952,62 +1076,6 @@
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "ALANA",
     "Tran_NamL": "ROSS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-01-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-02-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-03-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-04-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-05-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-06-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-07-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
   },
   {
     "Filer_ID": "1331137",
@@ -3025,20 +1093,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-07-11",
-    "Tran_NamF": "MARIBEL",
-    "Tran_NamL": "SAINEZ"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 74.84,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "MARIBEL",
-    "Tran_NamL": "SAINEZ"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "ELISSA",
@@ -3047,86 +1101,9 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "EMILIANO",
-    "Tran_NamL": "SANCHEZ"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "AMY",
-    "Tran_NamL": "SAXTON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "AMY",
-    "Tran_NamL": "SAXTON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "AMY",
-    "Tran_NamL": "SAXTON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "AMY",
-    "Tran_NamL": "SAXTON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "AMY",
-    "Tran_NamL": "SAXTON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 264.74,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "LIBBY",
-    "Tran_NamL": "SCHAAF"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "YOLANDA",
     "Tran_NamL": "SCHONBRUN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "YOLANDA",
-    "Tran_NamL": "SCHONBRUN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "SCHOOLZILLA PBC"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "JONATHAN",
-    "Tran_NamL": "SCHORR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 53.74,
-    "Tran_Date": "2016-07-11",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "SEGALL"
   },
   {
     "Filer_ID": "1331137",
@@ -3134,13 +1111,6 @@
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "TRACY",
     "Tran_NamL": "SESSION"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "DON",
-    "Tran_NamL": "SHALVEY"
   },
   {
     "Filer_ID": "1331137",
@@ -3153,13 +1123,6 @@
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
-    "Tran_NamF": "CLAIRE",
-    "Tran_NamL": "SHORALL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-21",
     "Tran_NamF": "CLAIRE",
     "Tran_NamL": "SHORALL"
   },
@@ -3179,297 +1142,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "THOMAS",
-    "Tran_NamL": "SMITH"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "BRYAN",
     "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "ANNE",
-    "Tran_NamL": "SOTO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "LINDA",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
   },
   {
     "Filer_ID": "1331137",
@@ -3480,360 +1156,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "BRIAN",
-    "Tran_NamL": "STANLEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-08",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "JONATHAN",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 260.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "BRUCE",
     "Tran_NamL": "STOFFMACHER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
   },
   {
     "Filer_ID": "1331137",
@@ -3851,17 +1177,1193 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "MICHELE",
-    "Tran_NamL": "SUTTON"
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "MICHELLE",
+    "Tran_NamL": "TORGERSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "HUBER",
+    "Tran_NamL": "TRENADO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "ANNIE",
+    "Tran_NamL": "ULEVITCH"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "JEANNIE",
+    "Tran_NamL": "VALKEVICH"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "KAIA",
+    "Tran_NamL": "VILBERG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "NATALIE",
+    "Tran_NamL": "WALCHUK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "PATRICK",
+    "Tran_NamL": "WALSH"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "KATHERINE",
+    "Tran_NamL": "WELCH"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "PATRICIA",
+    "Tran_NamL": "WILLIAMS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "PHIL",
+    "Tran_NamL": "WILLIAMS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "JOHNSTONE SUPPLY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "LEWIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "ANNETTE",
+    "Tran_NamL": "MILLER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "WILLIAM",
+    "Tran_NamL": "NEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "LINDA",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "SEDRICK",
+    "Tran_NamL": "TYDUS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-19",
+    "Tran_NamF": "BRUCE",
+    "Tran_NamL": "BUCKELEW"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-03-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-19",
+    "Tran_NamF": "LYNZI",
+    "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-20",
+    "Tran_NamF": "FRANCISCO",
+    "Tran_NamL": "NIETO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-03-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-08-31",
+    "Tran_Date": "2016-03-21",
     "Tran_NamF": null,
-    "Tran_NamL": "SUTTON LAW FIRM"
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-21",
+    "Tran_NamF": "MARIA",
+    "Tran_NamL": "MASSELLA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-26",
+    "Tran_NamF": "IRIS",
+    "Tran_NamL": "WINOGROND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 35.0,
+    "Tran_Date": "2016-04-07",
+    "Tran_NamF": "KYLE",
+    "Tran_NamL": "KIMMERLE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-04-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "STEPHANIE",
+    "Tran_NamL": "NGUYEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "SEDRICK",
+    "Tran_NamL": "TYDUS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-19",
+    "Tran_NamF": "BRUCE",
+    "Tran_NamL": "BUCKELEW"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-04-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-04-19",
+    "Tran_NamF": "LYNZI",
+    "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-04-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-04-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-26",
+    "Tran_NamF": "IRIS",
+    "Tran_NamL": "WINOGROND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-05-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-03",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "MORGAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 49.0,
+    "Tran_Date": "2016-05-05",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "LEWIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "SCHOOLZILLA PBC"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "SEDRICK",
+    "Tran_NamL": "TYDUS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "LYNZI",
+    "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 68.0,
+    "Tran_Date": "2016-05-20",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "LEWIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-05-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "JONATHAN",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "IRIS",
+    "Tran_NamL": "WINOGROND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-05-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 148.0,
+    "Tran_Date": "2016-06-03",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "LEWIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-10",
+    "Tran_NamF": "JOHN",
+    "Tran_NamL": "BALDO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-10",
+    "Tran_NamF": "ED",
+    "Tran_NamL": "GERBER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 550.0,
+    "Tran_Date": "2016-06-16",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-16",
+    "Tran_NamF": "DIRK",
+    "Tran_NamL": "TILLOTSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "SEDRICK",
+    "Tran_NamL": "TYDUS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-06-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-19",
+    "Tran_NamF": "LYNZI",
+    "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "JENNIFER",
+    "Tran_NamL": "ANDERSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "LAUREN",
+    "Tran_NamL": "DEWEES KEARSE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "ADAM",
+    "Tran_NamL": "MILLER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "CLAIRE",
+    "Tran_NamL": "SHORALL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "THOMAS",
+    "Tran_NamL": "SMITH"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "SEAN",
+    "Tran_NamL": "MCCLUNG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "SARAH",
+    "Tran_NamL": "MORRILL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "ANNE",
+    "Tran_NamL": "SOTO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "FYLES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "TERESA",
+    "Tran_NamL": "OBRIEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "CARLOS",
+    "Tran_NamL": "CAMARGO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "NATALIE",
+    "Tran_NamL": "TRAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-25",
+    "Tran_NamF": "CATHERINE",
+    "Tran_NamL": "FRYSZCZYN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-26",
+    "Tran_NamF": "DANIEL",
+    "Tran_NamL": "BELLINO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-26",
+    "Tran_NamF": "IRIS",
+    "Tran_NamL": "WINOGROND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "NIDYA",
+    "Tran_NamL": "BAEZ"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 11.54,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "RACHEL",
+    "Tran_NamL": "CRISCITIELLO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "JULIA",
+    "Tran_NamL": "GELORMINO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 53.74,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "HEUMANN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "EMMA",
+    "Tran_NamL": "HIZA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "LAILA",
+    "Tran_NamL": "JENKINS-PEREZ"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 270.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "FRANCISCO",
+    "Tran_NamL": "NIETO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "MARSHA",
+    "Tran_NamL": "NOVICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "JOY",
+    "Tran_NamL": "OSBORNE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "HARVEY",
+    "Tran_NamL": "ROSEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "EMILIANO",
+    "Tran_NamL": "SANCHEZ"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "JONATHAN",
+    "Tran_NamL": "SCHORR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
   },
   {
     "Filer_ID": "1331137",
@@ -3872,10 +2374,283 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 16.82,
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "JENNY",
+    "Tran_NamL": "VENTURA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 32.64,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "MELISSA",
+    "Tran_NamL": "WURTH"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "DIANE",
+    "Tran_NamL": "DODGE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "MARIA",
+    "Tran_NamL": "DRAKE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "KRISTIN",
+    "Tran_NamL": "ELIZALDE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "ALLISON",
+    "Tran_NamL": "GUILFOIL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 32.64,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "KAUFMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "NEERAV",
+    "Tran_NamL": "KINGSLAND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "LEWIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "KARINA",
+    "Tran_NamL": "MORENO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "WILLIAM",
+    "Tran_NamL": "NEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "SHERRY",
+    "Tran_NamL": "NOVICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "IDA",
+    "Tran_NamL": "OBERMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "DAN",
+    "Tran_NamL": "QUIGLEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "JASON",
+    "Tran_NamL": "WILLIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-06-30",
-    "Tran_NamF": "STEVE",
-    "Tran_NamL": "TAFOLLA"
+    "Tran_NamF": "RACHEL",
+    "Tran_NamL": "AMSTERDAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "NOAH",
+    "Tran_NamL": "BRADLEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "BRUCE",
+    "Tran_NamL": "BUCKELEW"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "KATHERINE",
+    "Tran_NamL": "CARTER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "PETE",
+    "Tran_NamL": "CORDERO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "LINDSEY",
+    "Tran_NamL": "FULLER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "ABBY",
+    "Tran_NamL": "GILLESPIE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "LEA",
+    "Tran_NamL": "HARTOG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "TAMARA",
+    "Tran_NamL": "HENRY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "BOBBY",
+    "Tran_NamL": "JORDAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "PHIL",
+    "Tran_NamL": "KIM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "BILL",
+    "Tran_NamL": "KRAMER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "CARA",
+    "Tran_NamL": "LIUZZI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "ASHLEY",
+    "Tran_NamL": "MARTIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "ALFREDO",
+    "Tran_NamL": "MATHEW"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "CHRISTINA",
+    "Tran_NamL": "MCCLAIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "BEN",
+    "Tran_NamL": "NUSSBAUM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "MACY",
+    "Tran_NamL": "PARKER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 49900.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "T. GARY",
+    "Tran_NamL": "ROGERS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "LYNNE",
+    "Tran_NamL": "ROSEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 260.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
   },
   {
     "Filer_ID": "1331137",
@@ -3893,59 +2668,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 450.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 550.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
+    "Tran_Amt1": 16.82,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "STEVE",
+    "Tran_NamL": "TAFOLLA"
   },
   {
     "Filer_ID": "1331137",
@@ -3964,41 +2690,6 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "PATRICK",
     "Tran_NamL": "THOMAS"
@@ -4006,142 +2697,9 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": "DIRK",
-    "Tran_NamL": "TILLOTSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "DIRK",
     "Tran_NamL": "TILLOTSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "DIRK",
-    "Tran_NamL": "TILLOTSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "MICHELLE",
-    "Tran_NamL": "TORGERSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-07-27",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "TOWNS"
   },
   {
     "Filer_ID": "1331137",
@@ -4153,58 +2711,198 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "NATALIE",
-    "Tran_NamL": "TRAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "HUBER",
-    "Tran_NamL": "TRENADO"
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "KAIA",
+    "Tran_NamL": "VILBERG"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "SEDRICK",
-    "Tran_NamL": "TYDUS"
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "JANE",
+    "Tran_NamL": "WON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-07-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 49900.0,
+    "Tran_Date": "2016-07-09",
+    "Tran_NamF": "ARTHUR",
+    "Tran_NamL": "ROCK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-07-11",
+    "Tran_NamF": "MARIBEL",
+    "Tran_NamL": "SAINEZ"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 53.74,
+    "Tran_Date": "2016-07-11",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "SEGALL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "HASSID"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-14",
+    "Tran_NamF": "NAYAA",
+    "Tran_NamL": "LACY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-14",
+    "Tran_NamF": "DIANA",
+    "Tran_NamL": "LEE"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "SEDRICK",
-    "Tran_NamL": "TYDUS"
+    "Tran_Date": "2016-07-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "DAISY",
+    "Tran_NamL": "PADILLA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "SEDRICK",
-    "Tran_NamL": "TYDUS"
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-17",
+    "Tran_NamF": "WILLIAM",
+    "Tran_NamL": "CARDENAS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "SEDRICK",
-    "Tran_NamL": "TYDUS"
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "SEDRICK",
-    "Tran_NamL": "TYDUS"
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "SEDRICK",
-    "Tran_NamL": "TYDUS"
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
   },
   {
     "Filer_ID": "1331137",
@@ -4215,52 +2913,451 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-07-19",
+    "Tran_NamF": "AMBER",
+    "Tran_NamL": "CHILDRESS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-07-19",
+    "Tran_NamF": "CAITLIN",
+    "Tran_NamL": "LANG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-07-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "SEDRICK",
-    "Tran_NamL": "TYDUS"
+    "Tran_Date": "2016-07-19",
+    "Tran_NamF": "LYNZI",
+    "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-07-20",
+    "Tran_NamF": "DAN",
+    "Tran_NamL": "QUIGLEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-07-20",
+    "Tran_NamF": "CARMELITA",
+    "Tran_NamL": "REYES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "LISSETTE",
+    "Tran_NamL": "AVERHOFF"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "DAISY",
+    "Tran_NamL": "PADILLA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "IRIS",
+    "Tran_NamL": "WINOGROND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 53.74,
+    "Tran_Date": "2016-07-27",
+    "Tran_NamF": "RICHARD",
+    "Tran_NamL": "PELAYO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-07-27",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "TOWNS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "CRYSTAL",
+    "Tran_NamL": "LAND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "ANNIE",
-    "Tran_NamL": "ULEVITCH"
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 750.0,
+    "Tran_Date": "2016-07-29",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "SHERYL",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "SAMANTHA",
+    "Tran_NamL": "KELLER"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "JEANNIE",
-    "Tran_NamL": "VALKEVICH"
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 80.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "JANE",
+    "Tran_NamL": "MAYER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "ELIZABETH",
+    "Tran_NamL": "ARNEY"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "JENNY",
-    "Tran_NamL": "VENTURA"
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "PETER",
+    "Tran_NamL": "LAUB"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "KAIA",
-    "Tran_NamL": "VILBERG"
+    "Tran_Amt1": 264.74,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "LIBBY",
+    "Tran_NamL": "SCHAAF"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "KAIA",
-    "Tran_NamL": "VILBERG"
+    "Tran_Amt1": 27.37,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "VYLINH",
+    "Tran_NamL": "NGUYEN"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "NATALIE",
-    "Tran_NamL": "WALCHUK"
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "YOLANDA",
+    "Tran_NamL": "SCHONBRUN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "MICHELLE",
+    "Tran_NamL": "HENSHAW"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "JOHNSTONE SUPPLY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "ANNETTE",
+    "Tran_NamL": "MILLER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "RAY",
+    "Tran_NamL": "MONDRAGON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "L. KAREN",
+    "Tran_NamL": "MONROE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "MARGARET",
+    "Tran_NamL": "POWER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "EMMA",
+    "Tran_NamL": "ROOS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "MONICA",
+    "Tran_NamL": "BOON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "JEAN",
+    "Tran_NamL": "DRISCOLL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "TRACEY",
+    "Tran_NamL": "GILLESPIE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "ELEANOR",
+    "Tran_NamL": "ALDERMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "JUSTIN",
+    "Tran_NamL": "ANDERSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "LISSETTE",
+    "Tran_NamL": "AVERHOFF"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "ABBY",
+    "Tran_NamL": "GILLESPIE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "SHELLEY",
+    "Tran_NamL": "HAWKINS-MCCRAY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "AMIE",
+    "Tran_NamL": "LAMONTAGNE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "AUTUMN",
+    "Tran_NamL": "MCDONALD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "SABRINA",
+    "Tran_NamL": "MOORE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "DORAN",
+    "Tran_NamL": "MORGAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "PATRICIA",
+    "Tran_NamL": "WILLIAMS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "ALICIA",
+    "Tran_NamL": "ARENAS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "LISSETTE",
+    "Tran_NamL": "AVERHOFF"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "BENAVIDES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "CARRIE",
+    "Tran_NamL": "CHAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "MAGGIE",
+    "Tran_NamL": "CROUSHORE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "MAGGIE",
+    "Tran_NamL": "CROUSHORE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "JORDAN",
+    "Tran_NamL": "HANDLER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 1.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "ADAM",
+    "Tran_NamL": "MILLER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 115.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "EVAN",
+    "Tran_NamL": "MILLER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "WILLIAM",
+    "Tran_NamL": "NEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "ERNEST",
+    "Tran_NamL": "PETERSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 74.84,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "MARIBEL",
+    "Tran_NamL": "SAINEZ"
   },
   {
     "Filer_ID": "1331137",
@@ -4268,6 +3365,223 @@
     "Tran_Date": "2016-08-11",
     "Tran_NamF": "BRANDON",
     "Tran_NamL": "WALL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "BRI",
+    "Tran_NamL": "ZIKA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "JOHN",
+    "Tran_NamL": "BLISS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "CASTILLO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "CHARLES",
+    "Tran_NamL": "COLE, III"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "DRIVER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "KRISTIN",
+    "Tran_NamL": "GALLAGHER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "ODIAKA",
+    "Tran_NamL": "GONZALEZ"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "JORDAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "JOHN",
+    "Tran_NamL": "KRULL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "KARINA",
+    "Tran_NamL": "MORENO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "HUGH",
+    "Tran_NamL": "MORRISON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "BEN",
+    "Tran_NamL": "OCHSTEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 11.54,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "BEN",
+    "Tran_NamL": "OCHSTEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "MARTEL",
+    "Tran_NamL": "PRICE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "MICHELE",
+    "Tran_NamL": "SUTTON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "RENIA",
+    "Tran_NamL": "WEBB"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "LOUIS",
+    "Tran_NamL": "WILLACY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "TAIMA",
+    "Tran_NamL": "BEYAH"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "NOAH",
+    "Tran_NamL": "BRADLEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "YANIRA",
+    "Tran_NamL": "CANIZALES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "ANTHONY",
+    "Tran_NamL": "CHAVEZ"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "CHARLES",
+    "Tran_NamL": "COLE III"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "DEBBRA",
+    "Tran_NamL": "LINDO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "ANNA",
+    "Tran_NamL": "MARTIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "BEN",
+    "Tran_NamL": "NUSSBAUM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "DONETHA",
+    "Tran_NamL": "PRINCE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "MAYA",
+    "Tran_NamL": "ROBLES-WONG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "AMY",
+    "Tran_NamL": "RODRIGUEZ BOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "BRIAN",
+    "Tran_NamL": "STANLEY"
   },
   {
     "Filer_ID": "1331137",
@@ -4285,94 +3599,17 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "BRIANNE",
+    "Tran_NamL": "ZIKA"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-07-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-14",
+    "Tran_NamF": "KEVIN",
+    "Tran_NamL": "HUNTER"
   },
   {
     "Filer_ID": "1331137",
@@ -4383,6 +3620,48 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 4100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "PARENT TEACHER ALLIANCE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
     "Tran_Date": "2016-08-15",
     "Tran_NamF": "CRAIG",
@@ -4390,227 +3669,122 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-12-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "PATRICK",
-    "Tran_NamL": "WALSH"
+    "Tran_Date": "2016-08-16",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "RENIA",
-    "Tran_NamL": "WEBB"
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "EDWARD",
+    "Tran_NamL": "GERBER"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "KATHERINE",
-    "Tran_NamL": "WELCH"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "LOUIS",
-    "Tran_NamL": "WILLACY"
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "BOBBY",
+    "Tran_NamL": "JORDAN"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "PHIL",
-    "Tran_NamL": "WILLIAMS"
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "AMY",
+    "Tran_NamL": "SAXTON"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "PATRICIA",
-    "Tran_NamL": "WILLIAMS"
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "PATRICIA",
-    "Tran_NamL": "WILLIAMS"
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "JASON",
-    "Tran_NamL": "WILLIS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-26",
-    "Tran_NamF": "IRIS",
-    "Tran_NamL": "WINOGROND"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-26",
-    "Tran_NamF": "IRIS",
-    "Tran_NamL": "WINOGROND"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-26",
-    "Tran_NamF": "IRIS",
-    "Tran_NamL": "WINOGROND"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-26",
-    "Tran_NamF": "IRIS",
-    "Tran_NamL": "WINOGROND"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": "IRIS",
-    "Tran_NamL": "WINOGROND"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-26",
-    "Tran_NamF": "IRIS",
-    "Tran_NamL": "WINOGROND"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "IRIS",
-    "Tran_NamL": "WINOGROND"
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "JANE",
-    "Tran_NamL": "WON"
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "SEDRICK",
+    "Tran_NamL": "TYDUS"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 32.64,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "MELISSA",
-    "Tran_NamL": "WURTH"
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "AMY",
+    "Tran_NamL": "RODRIGUEZ BOLAR"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-19",
-    "Tran_NamF": "LYNZI",
-    "Tran_NamL": "ZIEGENHAGEN"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-19",
-    "Tran_NamF": "LYNZI",
-    "Tran_NamL": "ZIEGENHAGEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-19",
-    "Tran_NamF": "LYNZI",
-    "Tran_NamL": "ZIEGENHAGEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-19",
-    "Tran_NamF": "LYNZI",
-    "Tran_NamL": "ZIEGENHAGEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-19",
-    "Tran_NamF": "LYNZI",
-    "Tran_NamL": "ZIEGENHAGEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-19",
-    "Tran_NamF": "LYNZI",
-    "Tran_NamL": "ZIEGENHAGEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-07-19",
-    "Tran_NamF": "LYNZI",
-    "Tran_NamL": "ZIEGENHAGEN"
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
   },
   {
     "Filer_ID": "1331137",
@@ -4621,10 +3795,479 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "SUTTON LAW FIRM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 2600.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "PARENT TEACHER ALLIANCE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "REEN",
+    "Tran_NamL": "MOHAMMED"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "SUSAN",
+    "Tran_NamL": "RASMUSSEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "CHARLIE",
+    "Tran_NamL": "COURIC"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 2800.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "PARENT TEACHER ALLIANCE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "JEAN",
+    "Tran_NamL": "DRISCOLL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "AMY",
+    "Tran_NamL": "SAXTON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
     "Tran_Date": "2016-09-19",
     "Tran_NamF": "LYNZI",
     "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "DIRK",
+    "Tran_NamL": "TILLOTSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "CHRISTINA",
+    "Tran_NamL": "GREENBERG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "PHILIPPA",
+    "Tran_NamL": "JUBELIRER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 72250.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "PARENT TEACHER ALLIANCE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "DON",
+    "Tran_NamL": "SHALVEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "AMY",
+    "Tran_NamL": "SAXTON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 300000.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
   },
   {
     "Filer_ID": "1331137",
@@ -4635,10 +4278,353 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-11-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "AMY",
+    "Tran_NamL": "SAXTON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-19",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
     "Tran_Date": "2016-11-19",
     "Tran_NamF": "LYNZI",
     "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-11-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-12-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-12-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-12-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "AMY",
+    "Tran_NamL": "SAXTON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-19",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
   },
   {
     "Filer_ID": "1331137",
@@ -4649,16 +4635,30 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "BRI",
-    "Tran_NamL": "ZIKA"
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-12-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-12-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "BRIANNE",
-    "Tran_NamL": "ZIKA"
+    "Tran_Date": "2016-12-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
   }
 ]

--- a/build/committee/1331137/contributions/index.json
+++ b/build/committee/1331137/contributions/index.json
@@ -9,35 +9,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-01-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
     "Tran_Date": "2016-02-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "SHERYL",
-    "Tran_NamL": "ADAM"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-06-21",
     "Tran_NamF": "LARISSA",
     "Tran_NamL": "ADAM"
   },
@@ -51,13 +30,6 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-12-21",
-    "Tran_NamF": "LARISSA",
-    "Tran_NamL": "ADAM"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
     "Tran_Date": "2016-04-21",
     "Tran_NamF": "LARISSA",
     "Tran_NamL": "ADAM"
@@ -65,7 +37,35 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-01-21",
+    "Tran_Date": "2016-05-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "LARISSA",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "SHERYL",
+    "Tran_NamL": "ADAM"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-08-21",
     "Tran_NamF": "LARISSA",
     "Tran_NamL": "ADAM"
   },
@@ -79,7 +79,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-07-21",
+    "Tran_Date": "2016-10-21",
     "Tran_NamF": "LARISSA",
     "Tran_NamL": "ADAM"
   },
@@ -93,7 +93,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-05-21",
+    "Tran_Date": "2016-12-21",
     "Tran_NamF": "LARISSA",
     "Tran_NamL": "ADAM"
   },
@@ -120,16 +120,16 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "JUSTIN",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "JENNIFER",
     "Tran_NamL": "ANDERSON"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "JENNIFER",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "JUSTIN",
     "Tran_NamL": "ANDERSON"
   },
   {
@@ -149,14 +149,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-10",
+    "Tran_Date": "2016-07-21",
     "Tran_NamF": "LISSETTE",
     "Tran_NamL": "AVERHOFF"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-07-21",
+    "Tran_Date": "2016-08-10",
     "Tran_NamF": "LISSETTE",
     "Tran_NamL": "AVERHOFF"
   },
@@ -275,7 +275,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-19",
+    "Tran_Date": "2016-01-19",
+    "Tran_NamF": "BRUCE",
+    "Tran_NamL": "BUCKELEW"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-19",
     "Tran_NamF": "BRUCE",
     "Tran_NamL": "BUCKELEW"
   },
@@ -289,14 +296,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-19",
-    "Tran_NamF": "BRUCE",
-    "Tran_NamL": "BUCKELEW"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-19",
+    "Tran_Date": "2016-04-19",
     "Tran_NamF": "BRUCE",
     "Tran_NamL": "BUCKELEW"
   },
@@ -344,15 +344,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-17",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
     "Tran_NamF": "WILLIAM",
     "Tran_NamL": "CARDENAS"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-17",
     "Tran_NamF": "WILLIAM",
     "Tran_NamL": "CARDENAS"
   },
@@ -484,14 +484,14 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-11",
     "Tran_NamF": "MAGGIE",
     "Tran_NamL": "CROUSHORE"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
+    "Tran_Amt1": 40.0,
     "Tran_Date": "2016-08-11",
     "Tran_NamF": "MAGGIE",
     "Tran_NamL": "CROUSHORE"
@@ -534,14 +534,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-29",
+    "Tran_Date": "2016-03-16",
     "Tran_NamF": "DIANE",
     "Tran_NamL": "DODGE"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
+    "Tran_Date": "2016-06-29",
     "Tran_NamF": "DIANE",
     "Tran_NamL": "DODGE"
   },
@@ -561,15 +561,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-17",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-09",
     "Tran_NamF": "JEAN",
     "Tran_NamL": "DRISCOLL"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-09",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-17",
     "Tran_NamF": "JEAN",
     "Tran_NamL": "DRISCOLL"
   },
@@ -604,20 +604,6 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "TARA",
-    "Tran_NamL": "FELD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-01-15",
     "Tran_NamF": "TARA",
     "Tran_NamL": "FELD"
@@ -626,6 +612,13 @@
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-02-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-15",
     "Tran_NamF": "TARA",
     "Tran_NamL": "FELD"
   },
@@ -646,14 +639,21 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-15",
+    "Tran_Date": "2016-06-15",
     "Tran_NamF": "TARA",
     "Tran_NamL": "FELD"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-15",
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "TARA",
+    "Tran_NamL": "FELD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-15",
     "Tran_NamF": "TARA",
     "Tran_NamL": "FELD"
   },
@@ -715,13 +715,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "EDWARD",
-    "Tran_NamL": "GERBER"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "EDWARD",
@@ -736,16 +729,23 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "TRACEY",
-    "Tran_NamL": "GILLESPIE"
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "EDWARD",
+    "Tran_NamL": "GERBER"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "ABBY",
+    "Tran_NamL": "GILLESPIE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "TRACEY",
     "Tran_NamL": "GILLESPIE"
   },
   {
@@ -758,14 +758,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-03-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-09-28",
+    "Tran_Date": "2016-02-03",
     "Tran_NamF": null,
     "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
   },
@@ -779,14 +772,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-07-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-02-03",
+    "Tran_Date": "2016-03-21",
     "Tran_NamF": null,
     "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
   },
@@ -800,14 +786,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-12-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-10-13",
+    "Tran_Date": "2016-07-05",
     "Tran_NamF": null,
     "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
   },
@@ -821,6 +800,27 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 0.0,
     "Tran_Date": "2016-11-17",
     "Tran_NamF": null,
     "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
@@ -828,7 +828,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 0.0,
-    "Tran_Date": "2016-09-15",
+    "Tran_Date": "2016-12-21",
     "Tran_NamF": null,
     "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
   },
@@ -863,14 +863,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-18",
+    "Tran_Date": "2016-01-18",
     "Tran_NamF": "JILL",
     "Tran_NamL": "HABIG"
   },
@@ -883,22 +876,8 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "JILL",
-    "Tran_NamL": "HABIG"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-18",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-16",
     "Tran_NamF": "JILL",
     "Tran_NamL": "HABIG"
   },
@@ -919,14 +898,35 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-18",
+    "Tran_Date": "2016-05-18",
     "Tran_NamF": "JILL",
     "Tran_NamL": "HABIG"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-18",
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-18",
     "Tran_NamF": "JILL",
     "Tran_NamL": "HABIG"
   },
@@ -940,14 +940,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-18",
+    "Tran_Date": "2016-11-18",
     "Tran_NamF": "JILL",
     "Tran_NamL": "HABIG"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-16",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-18",
     "Tran_NamF": "JILL",
     "Tran_NamL": "HABIG"
   },
@@ -1030,15 +1030,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-06-28",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-16",
     "Tran_NamF": "EMMA",
     "Tran_NamL": "HIZA"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-16",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-06-28",
     "Tran_NamF": "EMMA",
     "Tran_NamL": "HIZA"
   },
@@ -1059,21 +1059,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "JACK",
-    "Tran_NamL": "HOLZMAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-11-18",
+    "Tran_Date": "2016-07-28",
     "Tran_NamF": "JACK",
     "Tran_NamL": "HOLZMAN"
   },
@@ -1087,7 +1073,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-07-28",
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-09-18",
     "Tran_NamF": "JACK",
     "Tran_NamL": "HOLZMAN"
   },
@@ -1101,7 +1094,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-09-18",
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "JACK",
+    "Tran_NamL": "HOLZMAN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-12-18",
     "Tran_NamF": "JACK",
     "Tran_NamL": "HOLZMAN"
   },
@@ -1150,14 +1150,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-02-18",
+    "Tran_Date": "2016-01-18",
     "Tran_NamF": "LAILA",
     "Tran_NamL": "JENKINS-PEREZ"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-01-18",
+    "Tran_Date": "2016-02-18",
     "Tran_NamF": "LAILA",
     "Tran_NamL": "JENKINS-PEREZ"
   },
@@ -1177,6 +1177,13 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "JOHNSTONE SUPPLY"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 1000.0,
     "Tran_Date": "2016-08-08",
     "Tran_NamF": null,
@@ -1184,10 +1191,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "JOHNSTONE SUPPLY"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "BOBBY",
+    "Tran_NamL": "JORDAN"
   },
   {
     "Filer_ID": "1331137",
@@ -1200,13 +1207,6 @@
     "Filer_ID": "1331137",
     "Tran_Amt1": 5.0,
     "Tran_Date": "2016-08-17",
-    "Tran_NamF": "BOBBY",
-    "Tran_NamL": "JORDAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
     "Tran_NamF": "BOBBY",
     "Tran_NamL": "JORDAN"
   },
@@ -1283,43 +1283,8 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
     "Tran_Date": "2016-01-18",
     "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-28",
-    "Tran_NamF": "R. JANE",
     "Tran_NamL": "KLEIN"
   },
   {
@@ -1332,35 +1297,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
     "Tran_Date": "2016-02-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-18",
     "Tran_NamF": "AMANDA",
     "Tran_NamL": "KLEIN"
   },
@@ -1374,50 +1311,8 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-03-15",
     "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "GREG",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "R. JANE",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "AMANDA",
     "Tran_NamL": "KLEIN"
   },
   {
@@ -1425,13 +1320,6 @@
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "JONATHAN",
-    "Tran_NamL": "KLEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": "GREG",
     "Tran_NamL": "KLEIN"
   },
   {
@@ -1506,6 +1394,13 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-06-21",
     "Tran_NamF": "R. JANE",
@@ -1521,15 +1416,15 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-28",
+    "Tran_Date": "2016-06-28",
     "Tran_NamF": "R. JANE",
     "Tran_NamL": "KLEIN"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "R. JANE",
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "GREG",
     "Tran_NamL": "KLEIN"
   },
   {
@@ -1542,8 +1437,113 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-16",
     "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-28",
+    "Tran_NamF": "R. JANE",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-16",
+    "Tran_NamF": "GREG",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-12-18",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "KLEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-28",
+    "Tran_NamF": "R. JANE",
     "Tran_NamL": "KLEIN"
   },
   {
@@ -1605,49 +1605,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-02-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "GLORIA",
-    "Tran_NamL": "LEE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-01",
     "Tran_NamF": "GLORIA",
     "Tran_NamL": "LEE"
   },
@@ -1661,6 +1619,13 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-05-01",
     "Tran_NamF": "GLORIA",
     "Tran_NamL": "LEE"
@@ -1668,7 +1633,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-01",
+    "Tran_Date": "2016-06-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-01",
     "Tran_NamF": "GLORIA",
     "Tran_NamL": "LEE"
   },
@@ -1682,35 +1654,42 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-01",
+    "Tran_Date": "2016-08-01",
     "Tran_NamF": "GLORIA",
     "Tran_NamL": "LEE"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 148.0,
-    "Tran_Date": "2016-06-03",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "LEWIS"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "LEWIS"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-01",
+    "Tran_NamF": "GLORIA",
+    "Tran_NamL": "LEE"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 30.0,
     "Tran_Date": "2016-02-05",
-    "Tran_NamF": "RONALD",
-    "Tran_NamL": "LEWIS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-06-29",
     "Tran_NamF": "RONALD",
     "Tran_NamL": "LEWIS"
   },
@@ -1723,8 +1702,8 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 68.0,
-    "Tran_Date": "2016-05-20",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-18",
     "Tran_NamF": "RONALD",
     "Tran_NamL": "LEWIS"
   },
@@ -1732,6 +1711,27 @@
     "Filer_ID": "1331137",
     "Tran_Amt1": 49.0,
     "Tran_Date": "2016-05-05",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "LEWIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 68.0,
+    "Tran_Date": "2016-05-20",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "LEWIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 148.0,
+    "Tran_Date": "2016-06-03",
+    "Tran_NamF": "RONALD",
+    "Tran_NamL": "LEWIS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-06-29",
     "Tran_NamF": "RONALD",
     "Tran_NamL": "LEWIS"
   },
@@ -1779,6 +1779,13 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "ASHLEY",
+    "Tran_NamL": "MARTIN"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "ASHLEY",
@@ -1794,13 +1801,6 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "ASHLEY",
-    "Tran_NamL": "MARTIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-01-21",
     "Tran_NamF": "MARIA",
     "Tran_NamL": "MASSELLA"
@@ -1808,14 +1808,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-21",
+    "Tran_Date": "2016-02-21",
     "Tran_NamF": "MARIA",
     "Tran_NamL": "MASSELLA"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-21",
+    "Tran_Date": "2016-03-21",
     "Tran_NamF": "MARIA",
     "Tran_NamL": "MASSELLA"
   },
@@ -1849,15 +1849,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-10",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-03-09",
     "Tran_NamF": "AUTUMN",
     "Tran_NamL": "MCDONALD"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-03-09",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-10",
     "Tran_NamF": "AUTUMN",
     "Tran_NamL": "MCDONALD"
   },
@@ -1867,6 +1867,62 @@
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "TERON",
     "Tran_NamL": "MCGREW"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-12",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "SONYA",
+    "Tran_NamL": "MEHTA"
   },
   {
     "Filer_ID": "1331137",
@@ -1885,14 +1941,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-12",
+    "Tran_Date": "2016-08-13",
     "Tran_NamF": "SONYA",
     "Tran_NamL": "MEHTA"
   },
@@ -1905,52 +1954,10 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-12",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "SONYA",
-    "Tran_NamL": "MEHTA"
+    "Tran_Date": "2016-01-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
   },
   {
     "Filer_ID": "1331137",
@@ -1962,14 +1969,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-21",
+    "Tran_Date": "2016-03-21",
     "Tran_NamF": "MATTHEW",
     "Tran_NamL": "MEYER"
   },
@@ -1997,23 +1997,16 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-21",
-    "Tran_NamF": "MATTHEW",
-    "Tran_NamL": "MEYER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
     "Tran_Date": "2016-07-21",
     "Tran_NamF": "MATTHEW",
     "Tran_NamL": "MEYER"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "ADAM",
-    "Tran_NamL": "MILLER"
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "MATTHEW",
+    "Tran_NamL": "MEYER"
   },
   {
     "Filer_ID": "1331137",
@@ -2024,9 +2017,9 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 115.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "EVAN",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "ADAM",
     "Tran_NamL": "MILLER"
   },
   {
@@ -2038,9 +2031,16 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-21",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-11",
     "Tran_NamF": "ADAM",
+    "Tran_NamL": "MILLER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 115.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "EVAN",
     "Tran_NamL": "MILLER"
   },
   {
@@ -2095,28 +2095,28 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "DORAN",
-    "Tran_NamL": "MORGAN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
     "Tran_Date": "2016-05-03",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "MORGAN"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "SARAH",
-    "Tran_NamL": "MORRILL"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "DORAN",
+    "Tran_NamL": "MORGAN"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-03-16",
+    "Tran_NamF": "SARAH",
+    "Tran_NamL": "MORRILL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-22",
     "Tran_NamF": "SARAH",
     "Tran_NamL": "MORRILL"
   },
@@ -2129,13 +2129,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "KYRA",
-    "Tran_NamL": "MUNGIA"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 20.0,
     "Tran_Date": "2016-03-14",
     "Tran_NamF": "KYRA",
@@ -2143,8 +2136,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-11",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "KYRA",
+    "Tran_NamL": "MUNGIA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
     "Tran_NamF": "WILLIAM",
     "Tran_NamL": "NEE"
   },
@@ -2157,13 +2157,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "WILLIAM",
-    "Tran_NamL": "NEE"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 75.0,
     "Tran_Date": "2016-06-29",
     "Tran_NamF": "WILLIAM",
@@ -2171,22 +2164,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 27.37,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "VYLINH",
-    "Tran_NamL": "NGUYEN"
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "WILLIAM",
+    "Tran_NamL": "NEE"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "STEPHANIE",
-    "Tran_NamL": "NGUYEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-15",
+    "Tran_Date": "2016-01-15",
     "Tran_NamF": "STEPHANIE",
     "Tran_NamL": "NGUYEN"
   },
@@ -2200,14 +2186,56 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-15",
+    "Tran_Date": "2016-03-15",
     "Tran_NamF": "STEPHANIE",
     "Tran_NamL": "NGUYEN"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "STEPHANIE",
+    "Tran_NamL": "NGUYEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 27.37,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "VYLINH",
+    "Tran_NamL": "NGUYEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-15",
     "Tran_NamF": "BRANDON",
     "Tran_NamL": "NICHOLSON"
   },
@@ -2220,8 +2248,22 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-15",
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "NICHOLSON"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-15",
     "Tran_NamF": "BRANDON",
     "Tran_NamL": "NICHOLSON"
   },
@@ -2242,49 +2284,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-11-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "NICHOLSON"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-15",
     "Tran_NamF": "BRANDON",
     "Tran_NamL": "NICHOLSON"
   },
@@ -2304,20 +2304,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 270.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "FRANCISCO",
-    "Tran_NamL": "NIETO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-20",
-    "Tran_NamF": "FRANCISCO",
-    "Tran_NamL": "NIETO"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
     "Tran_Date": "2016-01-20",
     "Tran_NamF": "FRANCISCO",
@@ -2332,16 +2318,30 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "SHERRY",
-    "Tran_NamL": "NOVICK"
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-20",
+    "Tran_NamF": "FRANCISCO",
+    "Tran_NamL": "NIETO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 270.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "FRANCISCO",
+    "Tran_NamL": "NIETO"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 106.49,
     "Tran_Date": "2016-06-28",
     "Tran_NamF": "MARSHA",
+    "Tran_NamL": "NOVICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "SHERRY",
     "Tran_NamL": "NOVICK"
   },
   {
@@ -2388,14 +2388,14 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 11.54,
+    "Tran_Amt1": 75.0,
     "Tran_Date": "2016-08-12",
     "Tran_NamF": "BEN",
     "Tran_NamL": "OCHSTEIN"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
+    "Tran_Amt1": 11.54,
     "Tran_Date": "2016-08-12",
     "Tran_NamF": "BEN",
     "Tran_NamL": "OCHSTEIN"
@@ -2410,14 +2410,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
+    "Tran_Date": "2016-07-15",
     "Tran_NamF": "DAISY",
     "Tran_NamL": "PADILLA"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
+    "Tran_Date": "2016-07-26",
     "Tran_NamF": "DAISY",
     "Tran_NamL": "PADILLA"
   },
@@ -2430,15 +2430,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 2800.0,
-    "Tran_Date": "2016-09-12",
+    "Tran_Amt1": 2600.0,
+    "Tran_Date": "2016-09-07",
     "Tran_NamF": null,
     "Tran_NamL": "PARENT TEACHER ALLIANCE"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 2600.0,
-    "Tran_Date": "2016-09-07",
+    "Tran_Amt1": 2800.0,
+    "Tran_Date": "2016-09-12",
     "Tran_NamF": null,
     "Tran_NamL": "PARENT TEACHER ALLIANCE"
   },
@@ -2452,6 +2452,13 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-02-15",
     "Tran_NamF": "SUE",
     "Tran_NamL": "PARK"
@@ -2459,21 +2466,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "SUE",
-    "Tran_NamL": "PARK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-15",
+    "Tran_Date": "2016-03-15",
     "Tran_NamF": "SUE",
     "Tran_NamL": "PARK"
   },
@@ -2487,7 +2480,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-15",
+    "Tran_Date": "2016-05-15",
     "Tran_NamF": "SUE",
     "Tran_NamL": "PARK"
   },
@@ -2508,21 +2501,28 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-15",
+    "Tran_Date": "2016-08-15",
     "Tran_NamF": "SUE",
     "Tran_NamL": "PARK"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-15",
+    "Tran_Date": "2016-09-15",
     "Tran_NamF": "SUE",
     "Tran_NamL": "PARK"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-15",
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "SUE",
+    "Tran_NamL": "PARK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-15",
     "Tran_NamF": "SUE",
     "Tran_NamL": "PARK"
   },
@@ -2577,15 +2577,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-08-12",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-02-18",
     "Tran_NamF": "MARTEL",
     "Tran_NamL": "PRICE"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-18",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-08-12",
     "Tran_NamF": "MARTEL",
     "Tran_NamL": "PRICE"
   },
@@ -2620,34 +2620,6 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-01-25",
     "Tran_NamF": "NICK",
     "Tran_NamL": "RESNICK"
@@ -2655,14 +2627,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-25",
-    "Tran_NamF": "NICK",
-    "Tran_NamL": "RESNICK"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-25",
+    "Tran_Date": "2016-02-25",
     "Tran_NamF": "NICK",
     "Tran_NamL": "RESNICK"
   },
@@ -2676,21 +2641,35 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-25",
+    "Tran_Date": "2016-03-25",
     "Tran_NamF": "NICK",
     "Tran_NamL": "RESNICK"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-25",
+    "Tran_Date": "2016-04-25",
     "Tran_NamF": "NICK",
     "Tran_NamL": "RESNICK"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-25",
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-25",
     "Tran_NamF": "NICK",
     "Tran_NamL": "RESNICK"
   },
@@ -2704,7 +2683,28 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-25",
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-25",
+    "Tran_NamF": "NICK",
+    "Tran_NamL": "RESNICK"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-25",
     "Tran_NamF": "NICK",
     "Tran_NamL": "RESNICK"
   },
@@ -2725,70 +2725,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-01-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "ROBELL"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-18",
     "Tran_NamF": "LAURA",
     "Tran_NamL": "ROBELL"
   },
@@ -2802,6 +2739,62 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-10-18",
     "Tran_NamF": "LAURA",
     "Tran_NamL": "ROBELL"
@@ -2809,7 +2802,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-18",
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "ROBELL"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-12-18",
     "Tran_NamF": "LAURA",
     "Tran_NamL": "ROBELL"
   },
@@ -2829,15 +2829,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-13",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-09",
     "Tran_NamF": "AMY",
     "Tran_NamL": "RODRIGUEZ BOLAR"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-09",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-13",
     "Tran_NamF": "AMY",
     "Tran_NamL": "RODRIGUEZ BOLAR"
   },
@@ -2847,13 +2847,6 @@
     "Tran_Date": "2016-08-19",
     "Tran_NamF": "AMY",
     "Tran_NamL": "RODRIGUEZ BOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "EDGAR",
-    "Tran_NamL": "RODRIGUEZ-RAMIREZ"
   },
   {
     "Filer_ID": "1331137",
@@ -2865,16 +2858,9 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-19",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "EDGAR",
+    "Tran_NamL": "RODRIGUEZ-RAMIREZ"
   },
   {
     "Filer_ID": "1331137",
@@ -2885,15 +2871,8 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "ROE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-19",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-28",
     "Tran_NamF": "DAVID",
     "Tran_NamL": "ROE"
   },
@@ -2907,14 +2886,35 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-09-19",
     "Tran_NamF": "DAVID",
     "Tran_NamL": "ROE"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-28",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-19",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "ROE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-19",
     "Tran_NamF": "DAVID",
     "Tran_NamL": "ROE"
   },
@@ -2934,16 +2934,16 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "LYNNE",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "HARVEY",
     "Tran_NamL": "ROSEN"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "HARVEY",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "LYNNE",
     "Tran_NamL": "ROSEN"
   },
   {
@@ -2956,28 +2956,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-06-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
     "Tran_Date": "2016-01-19",
-    "Tran_NamF": "LISA",
-    "Tran_NamL": "ROTHBARD"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-03-19",
     "Tran_NamF": "LISA",
     "Tran_NamL": "ROTHBARD"
   },
@@ -2991,7 +2970,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-07-19",
+    "Tran_Date": "2016-03-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-04-19",
     "Tran_NamF": "LISA",
     "Tran_NamL": "ROTHBARD"
   },
@@ -3005,7 +2991,21 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 15.0,
-    "Tran_Date": "2016-04-19",
+    "Tran_Date": "2016-06-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-07-19",
+    "Tran_NamF": "LISA",
+    "Tran_NamL": "ROTHBARD"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 15.0,
+    "Tran_Date": "2016-08-19",
     "Tran_NamF": "LISA",
     "Tran_NamL": "ROTHBARD"
   },
@@ -3054,7 +3054,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-18",
+    "Tran_Date": "2016-08-18",
     "Tran_NamF": "AMY",
     "Tran_NamL": "SAXTON"
   },
@@ -3068,7 +3068,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-18",
+    "Tran_Date": "2016-10-18",
     "Tran_NamF": "AMY",
     "Tran_NamL": "SAXTON"
   },
@@ -3082,7 +3082,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-18",
+    "Tran_Date": "2016-12-18",
     "Tran_NamF": "AMY",
     "Tran_NamL": "SAXTON"
   },
@@ -3152,14 +3152,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-21",
+    "Tran_Date": "2016-03-16",
     "Tran_NamF": "CLAIRE",
     "Tran_NamL": "SHORALL"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
+    "Tran_Date": "2016-06-21",
     "Tran_NamF": "CLAIRE",
     "Tran_NamL": "SHORALL"
   },
@@ -3173,65 +3173,16 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "THOMAS",
-    "Tran_NamL": "SMITH"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "RYAN",
     "Tran_NamL": "SMITH"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "BRYAN",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "ASH",
-    "Tran_NamL": "SOLAR"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "THOMAS",
+    "Tran_NamL": "SMITH"
   },
   {
     "Filer_ID": "1331137",
@@ -3243,14 +3194,42 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-18",
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "BRYAN",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-18",
     "Tran_NamF": "ASH",
     "Tran_NamL": "SOLAR"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-18",
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-18",
     "Tran_NamF": "ASH",
     "Tran_NamL": "SOLAR"
   },
@@ -3264,7 +3243,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-18",
+    "Tran_Date": "2016-07-18",
     "Tran_NamF": "ASH",
     "Tran_NamL": "SOLAR"
   },
@@ -3278,35 +3257,56 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-18",
+    "Tran_Date": "2016-08-18",
     "Tran_NamF": "ASH",
     "Tran_NamL": "SOLAR"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-18",
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "ASH",
+    "Tran_NamL": "SOLAR"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-12-18",
     "Tran_NamF": "ASH",
     "Tran_NamL": "SOLAR"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-12-18",
+    "Tran_Date": "2016-01-18",
     "Tran_NamF": "RHONNEL",
     "Tran_NamL": "SOTELO"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-18",
+    "Tran_Date": "2016-02-18",
     "Tran_NamF": "RHONNEL",
     "Tran_NamL": "SOTELO"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-18",
+    "Tran_Date": "2016-03-18",
     "Tran_NamF": "RHONNEL",
     "Tran_NamL": "SOTELO"
   },
@@ -3327,14 +3327,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "RHONNEL",
-    "Tran_NamL": "SOTELO"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-18",
+    "Tran_Date": "2016-06-18",
     "Tran_NamF": "RHONNEL",
     "Tran_NamL": "SOTELO"
   },
@@ -3348,14 +3341,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-18",
+    "Tran_Date": "2016-08-18",
     "Tran_NamF": "RHONNEL",
     "Tran_NamL": "SOTELO"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-18",
+    "Tran_Date": "2016-09-18",
     "Tran_NamF": "RHONNEL",
     "Tran_NamL": "SOTELO"
   },
@@ -3369,7 +3362,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-18",
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "RHONNEL",
+    "Tran_NamL": "SOTELO"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-12-18",
     "Tran_NamF": "RHONNEL",
     "Tran_NamL": "SOTELO"
   },
@@ -3383,35 +3383,21 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-18",
+    "Tran_Date": "2016-01-18",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "SPENCER"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-07-18",
+    "Tran_Date": "2016-02-18",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "SPENCER"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-18",
+    "Tran_Date": "2016-03-18",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "SPENCER"
   },
@@ -3425,7 +3411,28 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-18",
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "SPENCER"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-07-18",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "SPENCER"
   },
@@ -3453,14 +3460,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "SPENCER"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-18",
+    "Tran_Date": "2016-11-18",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "SPENCER"
   },
@@ -3473,6 +3473,13 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "CELESTE",
+    "Tran_NamL": "STANLEY"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
     "Tran_Date": "2016-08-13",
     "Tran_NamF": "BRIAN",
@@ -3480,10 +3487,52 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "CELESTE",
-    "Tran_NamL": "STANLEY"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "DAVID",
+    "Tran_NamL": "STEIN"
   },
   {
     "Filer_ID": "1331137",
@@ -3502,7 +3551,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-18",
+    "Tran_Date": "2016-09-18",
     "Tran_NamF": "DAVID",
     "Tran_NamL": "STEIN"
   },
@@ -3516,55 +3565,6 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "DAVID",
-    "Tran_NamL": "STEIN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-11-18",
     "Tran_NamF": "DAVID",
     "Tran_NamL": "STEIN"
@@ -3572,15 +3572,15 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-18",
+    "Tran_Date": "2016-12-18",
     "Tran_NamF": "DAVID",
     "Tran_NamL": "STEIN"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-28",
-    "Tran_NamF": "JESSICA",
+    "Tran_Date": "2016-01-23",
+    "Tran_NamF": "JONATHON",
     "Tran_NamL": "STEWART"
   },
   {
@@ -3593,112 +3593,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "JONATHAN",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-08",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-02-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-11-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": "JONATHON",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-23",
     "Tran_NamF": "JONATHON",
     "Tran_NamL": "STEWART"
   },
@@ -3711,15 +3606,8 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "STEWART"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 260.0,
-    "Tran_Date": "2016-06-30",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-08",
     "Tran_NamF": "JESSICA",
     "Tran_NamL": "STEWART"
   },
@@ -3733,7 +3621,119 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-03-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-04-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "JONATHAN",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 260.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "JONATHON",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "STEWART"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-11-23",
     "Tran_NamF": "JONATHON",
     "Tran_NamL": "STEWART"
   },
@@ -3761,63 +3761,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-02-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "RUTH",
-    "Tran_NamL": "STRUOP"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-15",
     "Tran_NamF": "RUTH",
     "Tran_NamL": "STRUOP"
   },
@@ -3831,7 +3775,63 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "RUTH",
+    "Tran_NamL": "STRUOP"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-12-15",
     "Tran_NamF": "RUTH",
     "Tran_NamL": "STRUOP"
   },
@@ -3844,15 +3844,15 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-12",
+    "Tran_Amt1": 65.0,
+    "Tran_Date": "2016-03-16",
     "Tran_NamF": "MICHELE",
     "Tran_NamL": "SUTTON"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 65.0,
-    "Tran_Date": "2016-03-16",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-12",
     "Tran_NamF": "MICHELE",
     "Tran_NamL": "SUTTON"
   },
@@ -3874,6 +3874,13 @@
     "Filer_ID": "1331137",
     "Tran_Amt1": 16.82,
     "Tran_Date": "2016-06-30",
+    "Tran_NamF": "STEVE",
+    "Tran_NamL": "TAFOLLA"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 16.82,
+    "Tran_Date": "2016-06-30",
     "Tran_NamF": "KAY",
     "Tran_NamL": "TAFOLLA"
   },
@@ -3886,22 +3893,8 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 16.82,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "STEVE",
-    "Tran_NamL": "TAFOLLA"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-28",
+    "Tran_Date": "2016-01-28",
     "Tran_NamF": "MIYE",
     "Tran_NamL": "TAKAGI"
   },
@@ -3909,27 +3902,6 @@
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-02-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 550.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 450.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-28",
     "Tran_NamF": "MIYE",
     "Tran_NamL": "TAKAGI"
   },
@@ -3943,14 +3915,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-28",
-    "Tran_NamF": "MIYE",
-    "Tran_NamL": "TAKAGI"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-28",
+    "Tran_Date": "2016-03-28",
     "Tran_NamF": "MIYE",
     "Tran_NamL": "TAKAGI"
   },
@@ -3958,6 +3923,20 @@
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-04-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-05-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 550.0,
+    "Tran_Date": "2016-06-16",
     "Tran_NamF": "MIYE",
     "Tran_NamL": "TAKAGI"
   },
@@ -3977,8 +3956,22 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-28",
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-28",
     "Tran_NamF": "MIYE",
     "Tran_NamL": "TAKAGI"
   },
@@ -3992,7 +3985,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-05-28",
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "MIYE",
+    "Tran_NamL": "TAKAGI"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-28",
     "Tran_NamF": "MIYE",
     "Tran_NamL": "TAKAGI"
   },
@@ -4006,14 +4006,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
+    "Tran_Date": "2016-06-16",
     "Tran_NamF": "DIRK",
     "Tran_NamL": "TILLOTSON"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-16",
+    "Tran_Date": "2016-06-30",
     "Tran_NamF": "DIRK",
     "Tran_NamL": "TILLOTSON"
   },
@@ -4034,7 +4034,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-15",
+    "Tran_Date": "2016-01-15",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "TORNEY"
   },
@@ -4048,28 +4048,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-15",
+    "Tran_Date": "2016-03-15",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "TORNEY"
   },
@@ -4083,14 +4062,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-21",
+    "Tran_Date": "2016-04-15",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "TORNEY"
   },
@@ -4104,7 +4076,49 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-15",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "TORNEY"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-15",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "TORNEY"
   },
@@ -4118,21 +4132,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "TORNEY"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-15",
+    "Tran_Date": "2016-12-15",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "TORNEY"
   },
@@ -4167,14 +4167,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "SEDRICK",
-    "Tran_NamL": "TYDUS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-04-18",
+    "Tran_Date": "2016-01-18",
     "Tran_NamF": "SEDRICK",
     "Tran_NamL": "TYDUS"
   },
@@ -4188,14 +4181,28 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-18",
+    "Tran_Date": "2016-03-18",
     "Tran_NamF": "SEDRICK",
     "Tran_NamL": "TYDUS"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-18",
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "SEDRICK",
+    "Tran_NamL": "TYDUS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "SEDRICK",
+    "Tran_NamL": "TYDUS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-18",
     "Tran_NamF": "SEDRICK",
     "Tran_NamL": "TYDUS"
   },
@@ -4209,14 +4216,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "SEDRICK",
-    "Tran_NamL": "TYDUS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-18",
+    "Tran_Date": "2016-08-18",
     "Tran_NamF": "SEDRICK",
     "Tran_NamL": "TYDUS"
   },
@@ -4264,13 +4264,6 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "BRANDON",
-    "Tran_NamL": "WALL"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 170.0,
     "Tran_Date": "2016-08-11",
     "Tran_NamF": "BRANDON",
@@ -4285,22 +4278,22 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "BRANDON",
+    "Tran_NamL": "WALL"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-15",
+    "Tran_Date": "2016-01-15",
     "Tran_NamF": "CRAIG",
     "Tran_NamL": "WALLACE"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-15",
+    "Tran_Date": "2016-02-15",
     "Tran_NamF": "CRAIG",
     "Tran_NamL": "WALLACE"
   },
@@ -4342,63 +4335,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-12-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-15",
+    "Tran_Date": "2016-05-14",
     "Tran_NamF": "CRAIG",
     "Tran_NamL": "WALLACE"
   },
@@ -4419,6 +4356,13 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
     "Tran_Date": "2016-07-14",
     "Tran_NamF": "CRAIG",
     "Tran_NamL": "WALLACE"
@@ -4426,21 +4370,77 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-14",
-    "Tran_NamF": "CRAIG",
-    "Tran_NamL": "WALLACE"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
     "Tran_Date": "2016-07-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-11-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-12-14",
+    "Tran_NamF": "CRAIG",
+    "Tran_NamL": "WALLACE"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-12-15",
     "Tran_NamF": "CRAIG",
     "Tran_NamL": "WALLACE"
   },
@@ -4474,23 +4474,23 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "PATRICIA",
-    "Tran_NamL": "WILLIAMS"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "PATRICIA",
-    "Tran_NamL": "WILLIAMS"
-  },
-  {
-    "Filer_ID": "1331137",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-03-16",
     "Tran_NamF": "PHIL",
+    "Tran_NamL": "WILLIAMS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "PATRICIA",
+    "Tran_NamL": "WILLIAMS"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "PATRICIA",
     "Tran_NamL": "WILLIAMS"
   },
   {
@@ -4510,7 +4510,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-26",
+    "Tran_Date": "2016-02-26",
     "Tran_NamF": "IRIS",
     "Tran_NamL": "WINOGROND"
   },
@@ -4524,21 +4524,21 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-26",
-    "Tran_NamF": "IRIS",
-    "Tran_NamL": "WINOGROND"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-02-26",
-    "Tran_NamF": "IRIS",
-    "Tran_NamL": "WINOGROND"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-04-26",
+    "Tran_NamF": "IRIS",
+    "Tran_NamL": "WINOGROND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "IRIS",
+    "Tran_NamL": "WINOGROND"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-26",
     "Tran_NamF": "IRIS",
     "Tran_NamL": "WINOGROND"
   },
@@ -4566,7 +4566,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-19",
+    "Tran_Date": "2016-01-19",
     "Tran_NamF": "LYNZI",
     "Tran_NamL": "ZIEGENHAGEN"
   },
@@ -4594,7 +4594,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-11-19",
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "LYNZI",
+    "Tran_NamL": "ZIEGENHAGEN"
+  },
+  {
+    "Filer_ID": "1331137",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-19",
     "Tran_NamF": "LYNZI",
     "Tran_NamL": "ZIEGENHAGEN"
   },
@@ -4608,14 +4615,14 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-19",
+    "Tran_Date": "2016-08-19",
     "Tran_NamF": "LYNZI",
     "Tran_NamL": "ZIEGENHAGEN"
   },
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-19",
+    "Tran_Date": "2016-09-19",
     "Tran_NamF": "LYNZI",
     "Tran_NamL": "ZIEGENHAGEN"
   },
@@ -4629,14 +4636,7 @@
   {
     "Filer_ID": "1331137",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-19",
-    "Tran_NamF": "LYNZI",
-    "Tran_NamL": "ZIEGENHAGEN"
-  },
-  {
-    "Filer_ID": "1331137",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-05-19",
+    "Tran_Date": "2016-11-19",
     "Tran_NamF": "LYNZI",
     "Tran_NamL": "ZIEGENHAGEN"
   },
@@ -4649,16 +4649,16 @@
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "BRIANNE",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "BRI",
     "Tran_NamL": "ZIKA"
   },
   {
     "Filer_ID": "1331137",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "BRI",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "BRIANNE",
     "Tran_NamL": "ZIKA"
   }
 ]

--- a/build/committee/1342695/contributions/index.json
+++ b/build/committee/1342695/contributions/index.json
@@ -2,184 +2,16 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "40th Street Apartments"
+    "Tran_Date": "2016-01-13",
+    "Tran_NamF": "Sidhardha",
+    "Tran_NamL": "Lakireddy"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "40th Street Apartments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "510 Properties"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "510 Properties"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Ambassador Aparments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Ambassador Aparments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Anthony Associates"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Anthony Associates"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Beacon Properties"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-03-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Beacon Properties"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Diane",
-    "Tran_NamL": "Bevis"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Diane",
-    "Tran_NamL": "Bevis"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-11-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Birch Street Investments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-11-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Birch Street Investments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Bitzer"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Bitzer"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Bruck"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Bruck"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Laurie",
-    "Tran_NamL": "Burke"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Laurie",
-    "Tran_NamL": "Burke"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-07-29",
-    "Tran_NamF": "Dennis",
-    "Tran_NamL": "Chen"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-07-29",
-    "Tran_NamF": "Dennis",
-    "Tran_NamL": "Chen"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "DiMaggio Investment Co."
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "DiMaggio Investment Co."
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "EEN Property Management"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "EEN Property Management"
+    "Tran_Date": "2016-01-13",
+    "Tran_NamF": "Sidhardha",
+    "Tran_NamL": "Lakireddy"
   },
   {
     "Filer_ID": "1342695",
@@ -198,30 +30,16 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-03-22",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Faussner"
+    "Tran_Date": "2016-01-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Merit Enterprises"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-22",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Faussner"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-05-06",
+    "Tran_Date": "2016-01-22",
     "Tran_NamF": null,
-    "Tran_NamL": "Foxfire Property Management"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-05-06",
-    "Tran_NamF": null,
-    "Tran_NamL": "Foxfire Property Management"
+    "Tran_NamL": "Merit Enterprises"
   },
   {
     "Filer_ID": "1342695",
@@ -232,153 +50,6 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-02-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Gallagher & Lindsey"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-02-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Gallagher & Lindsey"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Homayoun",
-    "Tran_NamL": "Ghaderi"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Homayoun",
-    "Tran_NamL": "Ghaderi"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Grand Lake Towers"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Grand Lake Towers"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Don",
-    "Tran_NamL": "Gravestock"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Don",
-    "Tran_NamL": "Gravestock"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Greenwood Norwood LLC"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Greenwood Norwood LLC"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Luise",
-    "Tran_NamL": "Hall"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-02-08",
-    "Tran_NamF": "Diane",
-    "Tran_NamL": "Henry"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-02-08",
-    "Tran_NamF": "Diane",
-    "Tran_NamL": "Henry"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Highland Property Group LLC"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Highland Property Group LLC"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-04-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Hillcrest Management/Commodore Apartments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-04-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Hillcrest Management/Commodore Apartments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "J & R Associates"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "J & R Associates"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-01-13",
-    "Tran_NamF": "Sidhardha",
-    "Tran_NamL": "Lakireddy"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-01-13",
-    "Tran_NamF": "Sidhardha",
-    "Tran_NamL": "Lakireddy"
-  },
-  {
-    "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
     "Tran_Date": "2016-01-29",
     "Tran_NamF": null,
@@ -393,136 +64,31 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-07-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lapham Company"
-  },
-  {
-    "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-07-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lapham Company"
+    "Tran_Date": "2016-01-29",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Zolly"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Leapfrog Properties"
+    "Tran_Date": "2016-01-29",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Zolly"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Leapfrog Properties"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Philippe",
-    "Tran_NamL": "Lehot"
+    "Tran_Date": "2016-02-08",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Henry"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-06-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Library Gardens"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-06-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Library Gardens"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-02-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Markenkev Properties"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-02-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Markenkev Properties"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Martinez Real Estate Inv."
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Martinez Real Estate Inv."
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-08-24",
-    "Tran_NamF": "Ann",
-    "Tran_NamL": "McClain"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-24",
-    "Tran_NamF": "Ann",
-    "Tran_NamL": "McClain"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Jack",
-    "Tran_NamL": "McPhail"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Jack",
-    "Tran_NamL": "McPhail"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Melba Lake Apts"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Melba Lake Apts"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-01-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Merit Enterprises"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-01-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Merit Enterprises"
+    "Tran_Date": "2016-02-08",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Henry"
   },
   {
     "Filer_ID": "1342695",
@@ -541,44 +107,247 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-07-22",
+    "Tran_Date": "2016-02-29",
     "Tran_NamF": null,
-    "Tran_NamL": "Morse Management"
+    "Tran_NamL": "Gallagher & Lindsey"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-07-22",
+    "Tran_Date": "2016-02-29",
     "Tran_NamF": null,
-    "Tran_NamL": "Morse Management"
+    "Tran_NamL": "Gallagher & Lindsey"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-12",
+    "Tran_Date": "2016-02-29",
     "Tran_NamF": null,
-    "Tran_NamL": "Moyer Realty Company"
+    "Tran_NamL": "Markenkev Properties"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-08-12",
+    "Tran_Date": "2016-02-29",
     "Tran_NamF": null,
-    "Tran_NamL": "Moyer Realty Company"
+    "Tran_NamL": "Markenkev Properties"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "Lorane",
-    "Tran_NamL": "Owens"
+    "Tran_Date": "2016-03-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "Beacon Properties"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "Lorane",
-    "Tran_NamL": "Owens"
+    "Tran_Date": "2016-03-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "Beacon Properties"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Greenwood Norwood LLC"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Greenwood Norwood LLC"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Melba Lake Apts"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Melba Lake Apts"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-03-22",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Faussner"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-03-22",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Faussner"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Grand Lake Towers"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Grand Lake Towers"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Anthony Associates"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Anthony Associates"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Bruck"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Bruck"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Leapfrog Properties"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Leapfrog Properties"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-04-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Hillcrest Management/Commodore Apartments"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-04-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Hillcrest Management/Commodore Apartments"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "EEN Property Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "EEN Property Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Ambassador Aparments"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Ambassador Aparments"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "J & R Associates"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "J & R Associates"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-05-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "Foxfire Property Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-05-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "Foxfire Property Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-05-06",
+    "Tran_NamF": "Mitch",
+    "Tran_NamL": "Tunick"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-05-06",
+    "Tran_NamF": "Mitch",
+    "Tran_NamL": "Tunick"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-06-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Library Gardens"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-06-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Library Gardens"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-06-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "Palmview Apartments"
   },
   {
     "Filer_ID": "1342695",
@@ -586,41 +355,6 @@
     "Tran_Date": "2016-06-16",
     "Tran_NamF": null,
     "Tran_NamL": "Palmview Apartments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "Palmview Apartments"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Rowland Property Management"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-07-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Rowland Property Management"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Salles Group"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Salles Group"
   },
   {
     "Filer_ID": "1342695",
@@ -632,6 +366,181 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Laurie",
+    "Tran_NamL": "Burke"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Laurie",
+    "Tran_NamL": "Burke"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-07-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Rowland Property Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Rowland Property Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Morse Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Morse Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Wagers"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Wagers"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-07-29",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Chen"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-07-29",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Chen"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-07-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lapham Company"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-07-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lapham Company"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "DiMaggio Investment Co."
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "DiMaggio Investment Co."
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Moyer Realty Company"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Moyer Realty Company"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Bevis"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Bevis"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Ann",
+    "Tran_NamL": "McClain"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Ann",
+    "Tran_NamL": "McClain"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "510 Properties"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "510 Properties"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Philippe",
+    "Tran_NamL": "Lehot"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Jack",
+    "Tran_NamL": "McPhail"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Jack",
+    "Tran_NamL": "McPhail"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-09-09",
     "Tran_NamF": null,
     "Tran_NamL": "Taylor Springs Management"
@@ -642,6 +551,111 @@
     "Tran_Date": "2016-09-09",
     "Tran_NamF": null,
     "Tran_NamL": "Taylor Springs Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Homayoun",
+    "Tran_NamL": "Ghaderi"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Homayoun",
+    "Tran_NamL": "Ghaderi"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "40th Street Apartments"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "40th Street Apartments"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Don",
+    "Tran_NamL": "Gravestock"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Don",
+    "Tran_NamL": "Gravestock"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Bitzer"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Bitzer"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Salles Group"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Salles Group"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Luise",
+    "Tran_NamL": "Hall"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Martinez Real Estate Inv."
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Martinez Real Estate Inv."
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Highland Property Group LLC"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Highland Property Group LLC"
   },
   {
     "Filer_ID": "1342695",
@@ -659,44 +673,30 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-05-06",
-    "Tran_NamF": "Mitch",
-    "Tran_NamL": "Tunick"
-  },
-  {
-    "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-05-06",
-    "Tran_NamF": "Mitch",
-    "Tran_NamL": "Tunick"
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "Lorane",
+    "Tran_NamL": "Owens"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Wagers"
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "Lorane",
+    "Tran_NamL": "Owens"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Wagers"
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Birch Street Investments"
   },
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-01-29",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Zolly"
-  },
-  {
-    "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-01-29",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Zolly"
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Birch Street Investments"
   }
 ]

--- a/build/committee/1342695/contributions/index.json
+++ b/build/committee/1342695/contributions/index.json
@@ -1,14 +1,14 @@
 [
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-01-13",
     "Tran_NamF": "Sidhardha",
     "Tran_NamL": "Lakireddy"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-01-13",
     "Tran_NamF": "Sidhardha",
     "Tran_NamL": "Lakireddy"
@@ -29,14 +29,14 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-01-22",
     "Tran_NamF": null,
     "Tran_NamL": "Merit Enterprises"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-01-22",
     "Tran_NamF": null,
     "Tran_NamL": "Merit Enterprises"
@@ -106,13 +106,6 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-02-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Gallagher & Lindsey"
-  },
-  {
-    "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
     "Tran_Date": "2016-02-29",
     "Tran_NamF": null,
@@ -121,13 +114,20 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-02-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Gallagher & Lindsey"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-02-29",
     "Tran_NamF": null,
     "Tran_NamL": "Markenkev Properties"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-02-29",
     "Tran_NamF": null,
     "Tran_NamL": "Markenkev Properties"
@@ -162,14 +162,14 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-03-18",
     "Tran_NamF": null,
     "Tran_NamL": "Melba Lake Apts"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-03-18",
     "Tran_NamF": null,
     "Tran_NamL": "Melba Lake Apts"
@@ -204,13 +204,6 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Anthony Associates"
-  },
-  {
-    "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
     "Tran_Date": "2016-03-25",
     "Tran_NamF": null,
@@ -219,13 +212,20 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Anthony Associates"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-03-25",
     "Tran_NamF": "David",
     "Tran_NamL": "Bruck"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-03-25",
     "Tran_NamF": "David",
     "Tran_NamL": "Bruck"
@@ -316,13 +316,6 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-05-06",
-    "Tran_NamF": "Mitch",
-    "Tran_NamL": "Tunick"
-  },
-  {
-    "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
     "Tran_Date": "2016-05-06",
     "Tran_NamF": "Mitch",
@@ -331,9 +324,9 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-06-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Library Gardens"
+    "Tran_Date": "2016-05-06",
+    "Tran_NamF": "Mitch",
+    "Tran_NamL": "Tunick"
   },
   {
     "Filer_ID": "1342695",
@@ -345,13 +338,20 @@
   {
     "Filer_ID": "1342695",
     "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-06-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Library Gardens"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-06-16",
     "Tran_NamF": null,
     "Tran_NamL": "Palmview Apartments"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-06-16",
     "Tran_NamF": null,
     "Tran_NamL": "Palmview Apartments"
@@ -393,14 +393,14 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-07-22",
     "Tran_NamF": null,
     "Tran_NamL": "Morse Management"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-07-22",
     "Tran_NamF": null,
     "Tran_NamL": "Morse Management"
@@ -505,14 +505,14 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-08-31",
     "Tran_NamF": null,
     "Tran_NamL": "510 Properties"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-08-31",
     "Tran_NamF": null,
     "Tran_NamL": "510 Properties"
@@ -554,14 +554,14 @@
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 95.0,
+    "Tran_Amt1": 30.0,
     "Tran_Date": "2016-09-17",
     "Tran_NamF": "Homayoun",
     "Tran_NamL": "Ghaderi"
   },
   {
     "Filer_ID": "1342695",
-    "Tran_Amt1": 30.0,
+    "Tran_Amt1": 95.0,
     "Tran_Date": "2016-09-17",
     "Tran_NamF": "Homayoun",
     "Tran_NamL": "Ghaderi"

--- a/build/committee/1345259/contributions/index.json
+++ b/build/committee/1345259/contributions/index.json
@@ -1,20 +1,6 @@
 [
   {
     "Filer_ID": "1345259",
-    "Tran_Amt1": 12000.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "CTA/ABC PAC"
-  },
-  {
-    "Filer_ID": "1345259",
-    "Tran_Amt1": 13000.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "CTA/ABC PAC"
-  },
-  {
-    "Filer_ID": "1345259",
     "Tran_Amt1": 958.33,
     "Tran_Date": "2016-01-04",
     "Tran_NamF": null,
@@ -71,6 +57,13 @@
   },
   {
     "Filer_ID": "1345259",
+    "Tran_Amt1": 958.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
+  },
+  {
+    "Filer_ID": "1345259",
     "Tran_Amt1": 958.33,
     "Tran_Date": "2016-09-01",
     "Tran_NamF": null,
@@ -78,10 +71,17 @@
   },
   {
     "Filer_ID": "1345259",
-    "Tran_Amt1": 958.0,
-    "Tran_Date": "2016-09-01",
+    "Tran_Amt1": 12000.0,
+    "Tran_Date": "2016-09-25",
     "Tran_NamF": null,
-    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
+    "Tran_NamL": "CTA/ABC PAC"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 13000.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "CTA/ABC PAC"
   },
   {
     "Filer_ID": "1345259",

--- a/build/committee/1345259/contributions/index.json
+++ b/build/committee/1345259/contributions/index.json
@@ -16,6 +16,20 @@
   {
     "Filer_ID": "1345259",
     "Tran_Amt1": 958.33,
+    "Tran_Date": "2016-01-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 958.33,
+    "Tran_Date": "2016-02-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 958.33,
     "Tran_Date": "2016-03-01",
     "Tran_NamF": null,
     "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
@@ -57,14 +71,14 @@
   },
   {
     "Filer_ID": "1345259",
-    "Tran_Amt1": 958.0,
+    "Tran_Amt1": 958.33,
     "Tran_Date": "2016-09-01",
     "Tran_NamF": null,
     "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
   },
   {
     "Filer_ID": "1345259",
-    "Tran_Amt1": 958.33,
+    "Tran_Amt1": 958.0,
     "Tran_Date": "2016-09-01",
     "Tran_NamF": null,
     "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
@@ -78,22 +92,8 @@
   },
   {
     "Filer_ID": "1345259",
-    "Tran_Amt1": 958.33,
-    "Tran_Date": "2016-01-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
-  },
-  {
-    "Filer_ID": "1345259",
     "Tran_Amt1": 750.0,
     "Tran_Date": "2016-12-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
-  },
-  {
-    "Filer_ID": "1345259",
-    "Tran_Amt1": 958.33,
-    "Tran_Date": "2016-02-01",
     "Tran_NamF": null,
     "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
   }

--- a/build/committee/1362261/contributions/index.json
+++ b/build/committee/1362261/contributions/index.json
@@ -465,14 +465,14 @@
     "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Mia",
+    "Tran_NamF": "Michael",
     "Tran_NamL": "Levy"
   },
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Michael",
+    "Tran_NamF": "Mia",
     "Tran_NamL": "Levy"
   },
   {
@@ -512,15 +512,15 @@
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-23",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-11",
     "Tran_NamF": "Arabella",
     "Tran_NamL": "Martinez"
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-11",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
     "Tran_NamF": "Arabella",
     "Tran_NamL": "Martinez"
   },

--- a/build/committee/1362261/contributions/index.json
+++ b/build/committee/1362261/contributions/index.json
@@ -1,115 +1,10 @@
 [
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "2 FB, Inc."
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "Willam",
-    "Tran_NamL": "Abbott"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Ablon"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-20",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Alexander"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Alexander"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Annalee",
-    "Tran_NamL": "Allen"
-  },
-  {
-    "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-14",
-    "Tran_NamF": "Roy",
-    "Tran_NamL": "Alper"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-24",
+    "Tran_Date": "2016-03-18",
     "Tran_NamF": null,
-    "Tran_NamL": "American Foy Larue Inc."
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "Tim",
-    "Tran_NamL": "Anderson"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-17",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Anthony"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Avery"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Justin",
-    "Tran_NamL": "Bank"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "Anthony",
-    "Tran_NamL": "Barr"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Base Ventures LLC"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bay Area Citizens PAC"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Bell"
+    "Tran_NamL": "ParkSmart, Inc."
   },
   {
     "Filer_ID": "1362261",
@@ -117,27 +12,6 @@
     "Tran_Date": "2016-05-09",
     "Tran_NamF": "Rochelle",
     "Tran_NamL": "Benning"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-14",
-    "Tran_NamF": "Shefali",
-    "Tran_NamL": "Billon"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bliss"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-05-18",
-    "Tran_NamF": "Larry",
-    "Tran_NamL": "Bodner"
   },
   {
     "Filer_ID": "1362261",
@@ -156,16 +30,226 @@
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "Matt",
-    "Tran_NamL": "Brown"
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Pam",
+    "Tran_NamL": "Clemmons"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Jean",
+    "Tran_NamL": "Driscoll"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Isaac",
+    "Tran_NamL": "Kos-Read"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Joanne",
+    "Tran_NamL": "Karchmer"
   },
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-09",
-    "Tran_NamF": "Pam",
-    "Tran_NamL": "Clemmons"
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Rick",
+    "Tran_NamL": "Rickard"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Sanchez"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Priya",
+    "Tran_NamL": "Sanger"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Stroup"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Heywood"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Arabella",
+    "Tran_NamL": "Martinez"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Mcpherson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Lisa",
+    "Tran_NamL": "Pingatore"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Tawasha"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Webber"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Matt",
+    "Tran_NamL": "Ewing"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Harden"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Lloyd Kirk",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Susanne",
+    "Tran_NamL": "Monson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": "Jim",
+    "Tran_NamL": "Ross"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Hopkins"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Ireland"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Lyman"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Monica",
+    "Tran_NamL": "Marcone"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Allyson",
+    "Tran_NamL": "Purcell"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Christina",
+    "Tran_NamL": "Stearns"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "Roy",
+    "Tran_NamL": "Alper"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "Shefali",
+    "Tran_NamL": "Billon"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Kershaw"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "Miye",
+    "Tran_NamL": "Takagi"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Tim",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Matt",
+    "Tran_NamL": "Brown"
   },
   {
     "Filer_ID": "1362261",
@@ -183,10 +267,45 @@
   },
   {
     "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Lori",
+    "Tran_NamL": "Durbin"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Jessee"
+  },
+  {
+    "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Core Security Solutions, LLC"
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Bill",
+    "Tran_NamL": "Phua"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Lorraine",
+    "Tran_NamL": "Sadler"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-15",
+    "Tran_NamF": "Kim",
+    "Tran_NamL": "Thompson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Ablon"
   },
   {
     "Filer_ID": "1362261",
@@ -194,34 +313,6 @@
     "Tran_Date": "2016-05-16",
     "Tran_NamF": "Bruce",
     "Tran_NamL": "Cox"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Edward",
-    "Tran_NamL": "Cranston"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "DMC Real Estate Consulting LLC"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-20",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Davies"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "Sean",
-    "Tran_NamL": "Donahoe"
   },
   {
     "Filer_ID": "1362261",
@@ -246,38 +337,143 @@
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-09",
-    "Tran_NamF": "Jean",
-    "Tran_NamL": "Driscoll"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 1300.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Drive Committee"
-  },
-  {
-    "Filer_ID": "1362261",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "Lori",
-    "Tran_NamL": "Durbin"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-12",
-    "Tran_NamF": "Matt",
-    "Tran_NamL": "Ewing"
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Julie",
+    "Tran_NamL": "Hess"
   },
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Avril",
-    "Tran_NamL": "Fitzgerald"
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Victoria",
+    "Tran_NamL": "Howell"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "O'Malley"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Peterson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Melissa",
+    "Tran_NamL": "Schoen"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Story"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Tina",
+    "Tran_NamL": "Thomas"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Phillip",
+    "Tran_NamL": "Usher"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Zimmer"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-17",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Anthony"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Barr"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-05-18",
+    "Tran_NamF": "Larry",
+    "Tran_NamL": "Bodner"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Haley"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Jack",
+    "Tran_NamL": "Klingelhofer"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Stephens"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Nanine",
+    "Tran_NamL": "Watson"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-20",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Alexander"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-20",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Davies"
   },
   {
     "Filer_ID": "1362261",
@@ -285,6 +481,160 @@
     "Tran_Date": "2016-05-21",
     "Tran_NamF": "Nancy",
     "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Charlie",
+    "Tran_NamL": "Hale"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Holmgren"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Vivian",
+    "Tran_NamL": "Kahn"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Helen",
+    "Tran_NamL": "Nicholas"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Avery"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Sean",
+    "Tran_NamL": "Donahoe"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Vincent",
+    "Tran_NamL": "Leung"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Arabella",
+    "Tran_NamL": "Martinez"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Nye"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Erich",
+    "Tran_NamL": "Pfuehler"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Lee",
+    "Tran_NamL": "Richter"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Alexander"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Annalee",
+    "Tran_NamL": "Allen"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "American Foy Larue Inc."
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Justin",
+    "Tran_NamL": "Bank"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Base Ventures LLC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bay Area Citizens PAC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Core Security Solutions, LLC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Cranston"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "DMC Real Estate Consulting LLC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Avril",
+    "Tran_NamL": "Fitzgerald"
   },
   {
     "Filer_ID": "1362261",
@@ -317,65 +667,9 @@
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-22",
-    "Tran_NamF": "Charlie",
-    "Tran_NamL": "Hale"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-19",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Haley"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-12",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Harden"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-05-24",
     "Tran_NamF": "Renee",
     "Tran_NamL": "Heider"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Julie",
-    "Tran_NamL": "Hess"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-11",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Heywood"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-22",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Holmgren"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Pamela",
-    "Tran_NamL": "Hopkins"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Victoria",
-    "Tran_NamL": "Howell"
   },
   {
     "Filer_ID": "1362261",
@@ -393,62 +687,6 @@
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Ireland"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Jessee"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-22",
-    "Tran_NamF": "Vivian",
-    "Tran_NamL": "Kahn"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-10",
-    "Tran_NamF": "Joanne",
-    "Tran_NamL": "Karchmer"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-14",
-    "Tran_NamF": "Pamela",
-    "Tran_NamL": "Kershaw"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-19",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Kidd"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-19",
-    "Tran_NamF": "Jack",
-    "Tran_NamL": "Klingelhofer"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-05-09",
-    "Tran_NamF": "Isaac",
-    "Tran_NamL": "Kos-Read"
-  },
-  {
-    "Filer_ID": "1362261",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-05-24",
     "Tran_NamF": "Amanda",
@@ -456,23 +694,16 @@
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "Vincent",
-    "Tran_NamL": "Leung"
-  },
-  {
-    "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Michael",
+    "Tran_NamF": "Mia",
     "Tran_NamL": "Levy"
   },
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Mia",
+    "Tran_NamF": "Michael",
     "Tran_NamL": "Levy"
   },
   {
@@ -491,20 +722,6 @@
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Lyman"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Monica",
-    "Tran_NamL": "Marcone"
-  },
-  {
-    "Filer_ID": "1362261",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-05-24",
     "Tran_NamF": "Christopher",
@@ -512,66 +729,10 @@
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-11",
-    "Tran_NamF": "Arabella",
-    "Tran_NamL": "Martinez"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "Arabella",
-    "Tran_NamL": "Martinez"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-11",
-    "Tran_NamF": "Linda",
-    "Tran_NamL": "Mcpherson"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-12",
-    "Tran_NamF": "Lloyd Kirk",
-    "Tran_NamL": "Miller"
-  },
-  {
-    "Filer_ID": "1362261",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-05-24",
     "Tran_NamF": "Arpad",
     "Tran_NamL": "Molnar"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-12",
-    "Tran_NamF": "Susanne",
-    "Tran_NamL": "Monson"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-22",
-    "Tran_NamF": "Helen",
-    "Tran_NamL": "Nicholas"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "Bruce",
-    "Tran_NamL": "Nye"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "O'Malley"
   },
   {
     "Filer_ID": "1362261",
@@ -583,37 +744,9 @@
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Civil Liberties Alliance"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-05-24",
     "Tran_NamF": "Jen",
     "Tran_NamL": "Pahlka"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "ParkSmart, Inc."
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Peterson"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "Erich",
-    "Tran_NamL": "Pfuehler"
   },
   {
     "Filer_ID": "1362261",
@@ -625,37 +758,9 @@
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "Bill",
-    "Tran_NamL": "Phua"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-11",
-    "Tran_NamF": "Lisa",
-    "Tran_NamL": "Pingatore"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-05-24",
     "Tran_NamF": null,
     "Tran_NamL": "Plumbers and Steamfitters Union Local 342 PAC"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Allyson",
-    "Tran_NamL": "Purcell"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-05",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Raich"
   },
   {
     "Filer_ID": "1362261",
@@ -674,72 +779,9 @@
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "Lee",
-    "Tran_NamL": "Richter"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-10",
-    "Tran_NamF": "Rick",
-    "Tran_NamL": "Rickard"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-12",
-    "Tran_NamF": "Jim",
-    "Tran_NamL": "Ross"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "Lorraine",
-    "Tran_NamL": "Sadler"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-10",
-    "Tran_NamF": "Diane",
-    "Tran_NamL": "Sanchez"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-10",
-    "Tran_NamF": "Priya",
-    "Tran_NamL": "Sanger"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-05-24",
     "Tran_NamF": "Barbara",
     "Tran_NamL": "Schaaf Schock"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Schnitzer Steel Indurstries"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Melissa",
-    "Tran_NamL": "Schoen"
   },
   {
     "Filer_ID": "1362261",
@@ -747,55 +789,6 @@
     "Tran_Date": "2016-05-24",
     "Tran_NamF": "Ralph",
     "Tran_NamL": "Sklar"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sprinkler Fitters & Apprentices Local 483 Local PAC"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Christina",
-    "Tran_NamL": "Stearns"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-19",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Stephens"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Joan",
-    "Tran_NamL": "Story"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-10",
-    "Tran_NamF": "Ruth",
-    "Tran_NamL": "Stroup"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-14",
-    "Tran_NamF": "Miye",
-    "Tran_NamL": "Takagi"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-11",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Tawasha"
   },
   {
     "Filer_ID": "1362261",
@@ -815,36 +808,15 @@
     "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Christian",
-    "Tran_NamL": "Thede"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-24",
     "Tran_NamF": "Alexandra Yolles",
     "Tran_NamL": "Thede"
   },
   {
     "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Tina",
-    "Tran_NamL": "Thomas"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-15",
-    "Tran_NamF": "Kim",
-    "Tran_NamL": "Thompson"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Brook",
-    "Tran_NamL": "Turner"
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Christian",
+    "Tran_NamL": "Thede"
   },
   {
     "Filer_ID": "1362261",
@@ -855,38 +827,10 @@
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Phillip",
-    "Tran_NamL": "Usher"
-  },
-  {
-    "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-05-24",
     "Tran_NamF": "Danny",
     "Tran_NamL": "Wan"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-19",
-    "Tran_NamF": "Nanine",
-    "Tran_NamL": "Watson"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-11",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Webber"
-  },
-  {
-    "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Terri",
-    "Tran_NamL": "Witriol"
   },
   {
     "Filer_ID": "1362261",
@@ -899,14 +843,70 @@
     "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Terri",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-24",
     "Tran_NamF": null,
     "Tran_NamL": "YHLA Architects Inc."
   },
   {
     "Filer_ID": "1362261",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "Willam",
+    "Tran_NamL": "Abbott"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 1300.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Drive Committee"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "2 FB, Inc."
+  },
+  {
+    "Filer_ID": "1362261",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "George",
-    "Tran_NamL": "Zimmer"
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Brook",
+    "Tran_NamL": "Turner"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Civil Liberties Alliance"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-05",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Raich"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sprinkler Fitters & Apprentices Local 483 Local PAC"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-07-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Schnitzer Steel Indurstries"
   }
 ]

--- a/build/committee/1364564/contributions/index.json
+++ b/build/committee/1364564/contributions/index.json
@@ -1,171 +1,31 @@
 [
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-04-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "ACCE Institute"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 40000.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "ACCE Institute"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Orson",
-    "Tran_NamL": "Aguilar"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Orson",
-    "Tran_NamL": "Aguilar"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Nilofer",
-    "Tran_NamL": "Ahsan"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Josephine",
-    "Tran_NamL": "Alioto"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Janet",
-    "Tran_NamL": "Arnold"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Asian Pacific Environmental Network"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Asian Pacific Environmental Network"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": -3000.0,
-    "Tran_Date": "2016-05-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Asian Pacific Environmental Network"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 3591.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "Asian Pacific Environmental Network"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 5363.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Asian Pacific Environmental Network"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Nikki",
-    "Tran_NamL": "Bas"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Bassein"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Angela G",
-    "Tran_NamL": "Blackwell"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Rachel",
-    "Tran_NamL": "Brahinsky"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Donna",
-    "Tran_NamL": "Bransford"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Joe",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Brophy"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Brophy"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Brophy"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Nurses Association Political Action Committee"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Tessa",
-    "Tran_NamL": "Callejo"
-  },
-  {
-    "Filer_ID": "1364564",
     "Tran_Amt1": 13315.74,
     "Tran_Date": "2016-01-01",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1450.24,
+    "Tran_Date": "2016-01-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 2900.48,
+    "Tran_Date": "2016-01-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 4350.74,
+    "Tran_Date": "2016-01-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021"
   },
   {
     "Filer_ID": "1364564",
@@ -197,6 +57,160 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-04-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "ACCE Institute"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 3000.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Asian Pacific Environmental Network"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 4000.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Community Organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-04-20",
+    "Tran_NamF": "Daniel Louis",
+    "Tran_NamL": "Robinson"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-04-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "Communities for a Better Environment"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-21",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Heller"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "East Bay Alliance for a Sustainable Economy"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": "Luke",
+    "Tran_NamL": "Newton"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 3000.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Asian Pacific Environmental Network"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "John George Democratic Club"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Manel",
+    "Tran_NamL": "Kappagoda"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Daniel M.",
+    "Tran_NamL": "Siegel"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-04-28",
+    "Tran_NamF": "Lin A.",
+    "Tran_NamL": "Chin"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-05-03",
+    "Tran_NamF": "Margaretta",
+    "Tran_NamL": "Lin"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Unite Here Local 2850"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": -3000.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Asian Pacific Environmental Network"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Wellstone Democratic Renewal Club PAC"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Alanya",
+    "Tran_NamL": "Snyder"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-05-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Movement Strategy Center"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 21000.0,
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021 Issues PAC"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-06-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "East Bay Housing Organization"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-05",
+    "Tran_NamF": "Alanya",
+    "Tran_NamL": "Snyder"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 89.0,
     "Tran_Date": "2016-07-09",
     "Tran_NamF": null,
@@ -211,10 +225,38 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Luke",
+    "Tran_NamL": "Newton"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 355.95,
     "Tran_Date": "2016-07-29",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Janowitz"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Kristen",
+    "Tran_NamL": "Loomis"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-06",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Schacher"
   },
   {
     "Filer_ID": "1364564",
@@ -232,8 +274,64 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-16",
+    "Tran_NamF": "Kalima",
+    "Tran_NamL": "Rose"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Brophy"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Donna",
+    "Tran_NamL": "Bransford"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "Arnold"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Hood"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Marc",
+    "Tran_NamL": "Janowitz"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 1020.82,
     "Tran_Date": "2016-08-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-03",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Tobener"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 89.0,
+    "Tran_Date": "2016-09-09",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
@@ -246,10 +344,17 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 89.0,
-    "Tran_Date": "2016-09-09",
+    "Tran_Amt1": 40000.0,
+    "Tran_Date": "2016-09-12",
     "Tran_NamF": null,
-    "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+    "Tran_NamL": "ACCE Institute"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Bassein"
   },
   {
     "Filer_ID": "1364564",
@@ -260,10 +365,52 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Schacher"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "John George Democratic Club"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 12000.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021 Issues PAC"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 35000.0,
     "Tran_Date": "2016-09-23",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1650.76,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Rowell"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Alexandra",
+    "Tran_NamL": "Desautels"
   },
   {
     "Filer_ID": "1364564",
@@ -274,10 +421,570 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Layla",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Marie",
+    "Tran_NamL": "Fox"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Osler"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Enterprise Community Investment, Inc."
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Lynette",
+    "Tran_NamL": "Gibson"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Kalb"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Levin"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 3420.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Celine",
+    "Tran_NamL": "Liu"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Perry"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Wampler"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Brophy"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Nurses Association Political Action Committee"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Antonio",
+    "Tran_NamL": "Diaz"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Senai",
+    "Tran_NamL": "Kidane"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 178.66,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 24966.0,
+    "Tran_Date": "2016-10-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Rising Committee sponsored by Movement Strategy Action Center"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 471.78,
+    "Tran_Date": "2016-10-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "SEIU Local 2015 Issues PAC"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Anna",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Werth"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Claiborne",
+    "Tran_NamL": "Deming, Jr."
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Jarmon"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Christine",
+    "Tran_NamL": "Schildt"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Allan",
+    "Tran_NamL": "Treseder"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Josephine",
+    "Tran_NamL": "Alioto"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Rachel",
+    "Tran_NamL": "Brahinsky"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Fieber"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Lifschitz"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Vrinda",
+    "Tran_NamL": "Manglik"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Gregory",
+    "Tran_NamL": "Michalec"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1200.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mayor Libby Schaaf for Oakland"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Merchant"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Orson",
+    "Tran_NamL": "Aguilar"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Orson",
+    "Tran_NamL": "Aguilar"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Joe",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Brophy"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Fraser"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Hooshmand"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 11845.16,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Rhine"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Vanderwarker"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-08",
+    "Tran_NamF": "Amie",
+    "Tran_NamL": "Fishman"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-08",
+    "Tran_NamF": "Ang",
+    "Tran_NamL": "Hadwin"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-08",
+    "Tran_NamF": "Shiela",
+    "Tran_NamL": "Park"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Tessa",
+    "Tran_NamL": "Callejo"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 4821.82,
     "Tran_Date": "2016-10-09",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Qi",
+    "Tran_NamL": "Chen"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Mary Quinn",
+    "Tran_NamL": "Delaney"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Corinne",
+    "Tran_NamL": "Jan"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Kathryn",
+    "Tran_NamL": "Kasch"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 228.09,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Rossoff"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 3591.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Asian Pacific Environmental Network"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Britta",
+    "Tran_NamL": "Houser"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "See Forward Fund, Inc."
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Heena",
+    "Tran_NamL": "Shah"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 33.79,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Alexandra",
+    "Tran_NamL": "Desautels"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Federation of Professional and Technical Engineers, Local 21 Issues PAC"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 50000.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "The San Francisco Foundation"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Arthur",
+    "Tran_NamL": "Clinton"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Abel",
+    "Tran_NamL": "Guillen"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "East Bay Asian Local Development Corporation"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 3970.84,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mayor Libby Schaaf for Oakland"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "McAfee"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 1750.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Kalima",
+    "Tran_NamL": "Rose"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Angela G",
+    "Tran_NamL": "Blackwell"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 121.97,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Victor",
+    "Tran_NamL": "Rubin"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Nikki",
+    "Tran_NamL": "Bas"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Vivian",
+    "Tran_NamL": "Huang"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Iny"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Safir"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Travis",
+    "Tran_NamL": "Winfrey"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 5363.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Asian Pacific Environmental Network"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 12296.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Rising Committee sponsored by Movement Strategy Action Center"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Phung"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Instructional Telecommunications Foundation, Inc. dba Voqal USA"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 53.4,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Eliza",
+    "Tran_NamL": "Hersh"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Meena",
+    "Tran_NamL": "Palaniappan"
   },
   {
     "Filer_ID": "1364564",
@@ -288,10 +995,94 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Education Association Political Action Committee"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 11845.16,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Lauren L.",
+    "Tran_NamL": "Webster"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-30",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "MacLeod"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Kathryn",
+    "Tran_NamL": "Gilje"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Daniel M.",
+    "Tran_NamL": "Siegel"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Harris"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Nilofer",
+    "Tran_NamL": "Ahsan"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 53.18,
     "Tran_Date": "2016-11-03",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "Skinner for Senate 2016"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "Youth Uprising"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 134.19,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 7388.87,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "SEIU Local 2015 Issues PAC"
   },
   {
     "Filer_ID": "1364564",
@@ -316,6 +1107,13 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-11-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sheet Metal Workers' International Association Local Union No. 104 Issues Committee"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 1990.75,
     "Tran_Date": "2016-11-12",
     "Tran_NamF": null,
@@ -334,803 +1132,5 @@
     "Tran_Date": "2016-12-09",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Qi",
-    "Tran_NamL": "Chen"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-04-28",
-    "Tran_NamF": "Lin A.",
-    "Tran_NamL": "Chin"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Arthur",
-    "Tran_NamL": "Clinton"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-04-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "Communities for a Better Environment"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Layla",
-    "Tran_NamL": "Cooper"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Mary Quinn",
-    "Tran_NamL": "Delaney"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Claiborne",
-    "Tran_NamL": "Deming, Jr."
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Alexandra",
-    "Tran_NamL": "Desautels"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Alexandra",
-    "Tran_NamL": "Desautels"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "Antonio",
-    "Tran_NamL": "Diaz"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "East Bay Alliance for a Sustainable Economy"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "East Bay Asian Local Development Corporation"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-06-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "East Bay Housing Organization"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Enterprise Community Investment, Inc."
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Fieber"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-08",
-    "Tran_NamF": "Amie",
-    "Tran_NamL": "Fishman"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Marie",
-    "Tran_NamL": "Fox"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Fraser"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Lynette",
-    "Tran_NamL": "Gibson"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Kathryn",
-    "Tran_NamL": "Gilje"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Abel",
-    "Tran_NamL": "Guillen"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-08",
-    "Tran_NamF": "Ang",
-    "Tran_NamL": "Hadwin"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Harris"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-21",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Heller"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Eliza",
-    "Tran_NamL": "Hersh"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Hood"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Hooshmand"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Britta",
-    "Tran_NamL": "Houser"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Vivian",
-    "Tran_NamL": "Huang"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Instructional Telecommunications Foundation, Inc. dba Voqal USA"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Federation of Professional and Technical Engineers, Local 21 Issues PAC"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Edward",
-    "Tran_NamL": "Iny"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Corinne",
-    "Tran_NamL": "Jan"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Janowitz"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Marc",
-    "Tran_NamL": "Janowitz"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Jarmon"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "John George Democratic Club"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "John George Democratic Club"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Kalb"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Manel",
-    "Tran_NamL": "Kappagoda"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Kathryn",
-    "Tran_NamL": "Kasch"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Kaufman"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "Senai",
-    "Tran_NamL": "Kidane"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Anna",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Levin"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Lifschitz"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 450.0,
-    "Tran_Date": "2016-05-03",
-    "Tran_NamF": "Margaretta",
-    "Tran_NamL": "Lin"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 3420.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Celine",
-    "Tran_NamL": "Liu"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Kristen",
-    "Tran_NamL": "Loomis"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-30",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "MacLeod"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Vrinda",
-    "Tran_NamL": "Manglik"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1200.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": null,
-    "Tran_NamL": "Mayor Libby Schaaf for Oakland"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 3970.84,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Mayor Libby Schaaf for Oakland"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "McAfee"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Alex",
-    "Tran_NamL": "Merchant"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Gregory",
-    "Tran_NamL": "Michalec"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-05-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Movement Strategy Center"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": "Luke",
-    "Tran_NamL": "Newton"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Luke",
-    "Tran_NamL": "Newton"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 4000.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Community Organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Education Association Political Action Committee"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 24966.0,
-    "Tran_Date": "2016-10-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Rising Committee sponsored by Movement Strategy Action Center"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 12296.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Rising Committee sponsored by Movement Strategy Action Center"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1650.76,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 178.66,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 11845.16,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 228.09,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 33.79,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 121.97,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 53.4,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 11845.16,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 134.19,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Osler"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Meena",
-    "Tran_NamL": "Palaniappan"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-08",
-    "Tran_NamF": "Shiela",
-    "Tran_NamL": "Park"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Pamela",
-    "Tran_NamL": "Perry"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Phung"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Rhine"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-04-20",
-    "Tran_NamF": "Daniel Louis",
-    "Tran_NamL": "Robinson"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": "Kalima",
-    "Tran_NamL": "Rose"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1750.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Kalima",
-    "Tran_NamL": "Rose"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Rossoff"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Ronald",
-    "Tran_NamL": "Rowell"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Victor",
-    "Tran_NamL": "Rubin"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 471.78,
-    "Tran_Date": "2016-10-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "SEIU Local 2015 Issues PAC"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 7388.87,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "SEIU Local 2015 Issues PAC"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Safir"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-06",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Schacher"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Schacher"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Christine",
-    "Tran_NamL": "Schildt"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "See Forward Fund, Inc."
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1450.24,
-    "Tran_Date": "2016-01-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 2900.48,
-    "Tran_Date": "2016-01-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 4350.74,
-    "Tran_Date": "2016-01-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 21000.0,
-    "Tran_Date": "2016-05-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021 Issues PAC"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 12000.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021 Issues PAC"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Heena",
-    "Tran_NamL": "Shah"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-11-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sheet Metal Workers' International Association Local Union No. 104 Issues Committee"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Daniel M.",
-    "Tran_NamL": "Siegel"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Daniel M.",
-    "Tran_NamL": "Siegel"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "Skinner for Senate 2016"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-11",
-    "Tran_NamF": "Alanya",
-    "Tran_NamL": "Snyder"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-05",
-    "Tran_NamF": "Alanya",
-    "Tran_NamL": "Snyder"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 50000.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "The San Francisco Foundation"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-03",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Tobener"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Allan",
-    "Tran_NamL": "Treseder"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-05-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "Unite Here Local 2850"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Vanderwarker"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Wampler"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Lauren L.",
-    "Tran_NamL": "Webster"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Wellstone Democratic Renewal Club PAC"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Alex",
-    "Tran_NamL": "Werth"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Travis",
-    "Tran_NamL": "Winfrey"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "Youth Uprising"
   }
 ]

--- a/build/committee/1364564/contributions/index.json
+++ b/build/committee/1364564/contributions/index.json
@@ -1,13 +1,6 @@
 [
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 40000.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "ACCE Institute"
-  },
-  {
-    "Filer_ID": "1364564",
     "Tran_Amt1": 2000.0,
     "Tran_Date": "2016-04-14",
     "Tran_NamF": null,
@@ -15,14 +8,21 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 5000.0,
+    "Tran_Amt1": 40000.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "ACCE Institute"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-07",
     "Tran_NamF": "Orson",
     "Tran_NamL": "Aguilar"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
+    "Tran_Amt1": 5000.0,
     "Tran_Date": "2016-10-07",
     "Tran_NamF": "Orson",
     "Tran_NamL": "Aguilar"
@@ -50,22 +50,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 3591.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "Asian Pacific Environmental Network"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 5363.0,
-    "Tran_Date": "2016-10-23",
+    "Tran_Amt1": 3000.0,
+    "Tran_Date": "2016-04-15",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
   {
     "Filer_ID": "1364564",
     "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-04-15",
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
@@ -78,8 +71,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": 3591.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Asian Pacific Environmental Network"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 5363.0,
+    "Tran_Date": "2016-10-23",
     "Tran_NamF": null,
     "Tran_NamL": "Asian Pacific Environmental Network"
   },
@@ -127,6 +127,13 @@
   },
   {
     "Filer_ID": "1364564",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Brophy"
+  },
+  {
+    "Filer_ID": "1364564",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-09-29",
     "Tran_NamF": "Brian",
@@ -136,13 +143,6 @@
     "Filer_ID": "1364564",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Brophy"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-22",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Brophy"
   },
@@ -239,14 +239,14 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 89.0,
+    "Tran_Amt1": 59000.0,
     "Tran_Date": "2016-09-09",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 59000.0,
+    "Tran_Amt1": 89.0,
     "Tran_Date": "2016-09-09",
     "Tran_NamF": null,
     "Tran_NamL": "Causa Justa :: Just Cause (Nonprofit 501 (C)(3))"
@@ -386,15 +386,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-17",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-25",
     "Tran_NamF": "Alexandra",
     "Tran_NamL": "Desautels"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-25",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-17",
     "Tran_NamF": "Alexandra",
     "Tran_NamL": "Desautels"
   },
@@ -568,16 +568,16 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Marc",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Mark",
     "Tran_NamL": "Janowitz"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Mark",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Marc",
     "Tran_NamL": "Janowitz"
   },
   {
@@ -778,13 +778,6 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 11845.16,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
     "Tran_Amt1": 1650.76,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": null,
@@ -801,13 +794,6 @@
     "Filer_ID": "1364564",
     "Tran_Amt1": 11845.16,
     "Tran_Date": "2016-10-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
-  },
-  {
-    "Filer_ID": "1364564",
-    "Tran_Amt1": 134.19,
-    "Tran_Date": "2016-11-04",
     "Tran_NamF": null,
     "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
   },
@@ -836,6 +822,20 @@
     "Filer_ID": "1364564",
     "Tran_Amt1": 53.4,
     "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 11845.16,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
+  },
+  {
+    "Filer_ID": "1364564",
+    "Tran_Amt1": 134.19,
+    "Tran_Date": "2016-11-04",
     "Tran_NamF": null,
     "Tran_NamL": "Oakland Working Families, sponsored by labor and community organizations"
   },
@@ -890,15 +890,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 1750.0,
-    "Tran_Date": "2016-10-19",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-16",
     "Tran_NamF": "Kalima",
     "Tran_NamL": "Rose"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-16",
+    "Tran_Amt1": 1750.0,
+    "Tran_Date": "2016-10-19",
     "Tran_NamF": "Kalima",
     "Tran_NamL": "Rose"
   },
@@ -947,14 +947,14 @@
   {
     "Filer_ID": "1364564",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-14",
+    "Tran_Date": "2016-08-06",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Schacher"
   },
   {
     "Filer_ID": "1364564",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-06",
+    "Tran_Date": "2016-09-14",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Schacher"
   },
@@ -974,7 +974,7 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 4350.74,
+    "Tran_Amt1": 1450.24,
     "Tran_Date": "2016-01-08",
     "Tran_NamF": null,
     "Tran_NamL": "Service Employees International Union Local 1021"
@@ -988,7 +988,7 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 1450.24,
+    "Tran_Amt1": 4350.74,
     "Tran_Date": "2016-01-08",
     "Tran_NamF": null,
     "Tran_NamL": "Service Employees International Union Local 1021"
@@ -1044,15 +1044,15 @@
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-05",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-11",
     "Tran_NamF": "Alanya",
     "Tran_NamL": "Snyder"
   },
   {
     "Filer_ID": "1364564",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-11",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-05",
     "Tran_NamF": "Alanya",
     "Tran_NamL": "Snyder"
   },

--- a/build/committee/1372459/contributions/index.json
+++ b/build/committee/1372459/contributions/index.json
@@ -1,17 +1,17 @@
 [
   {
     "Filer_ID": "1372459",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Conrad"
-  },
-  {
-    "Filer_ID": "1372459",
     "Tran_Amt1": 2000.0,
     "Tran_Date": "2016-05-23",
     "Tran_NamF": "Dale",
     "Tran_NamL": "Gieringer"
+  },
+  {
+    "Filer_ID": "1372459",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Conrad"
   },
   {
     "Filer_ID": "1372459",

--- a/build/committee/1375179/contributions/index.json
+++ b/build/committee/1375179/contributions/index.json
@@ -78,15 +78,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-06-17",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-14",
     "Tran_NamF": "John",
     "Tran_NamL": "Bliss"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-14",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-06-17",
     "Tran_NamF": "John",
     "Tran_NamL": "Bliss"
   },
@@ -99,15 +99,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-05-05",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Bohm"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-05-05",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Bohm"
   },
@@ -141,15 +141,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": -730.95,
-    "Tran_Date": "2016-06-17",
+    "Tran_Amt1": 730.95,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": "Conley",
     "Tran_NamL": "Byrnes"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 730.95,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": -730.95,
+    "Tran_Date": "2016-06-17",
     "Tran_NamF": "Conley",
     "Tran_NamL": "Byrnes"
   },
@@ -176,15 +176,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-30",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": "Carl",
     "Tran_NamL": "Chan"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-30",
     "Tran_NamF": "Carl",
     "Tran_NamL": "Chan"
   },
@@ -288,14 +288,14 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
+    "Tran_Amt1": -700.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": null,
     "Tran_NamL": "Feld Entertainment"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": -700.0,
+    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": null,
     "Tran_NamL": "Feld Entertainment"
@@ -323,15 +323,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-29",
+    "Tran_Amt1": 118.04,
+    "Tran_Date": "2016-04-22",
     "Tran_NamF": "Donald",
     "Tran_NamL": "Gilmore"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 118.04,
-    "Tran_Date": "2016-04-22",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-29",
     "Tran_NamF": "Donald",
     "Tran_NamL": "Gilmore"
   },
@@ -519,15 +519,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-30",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "Keith Carson For Alameda County Supervisor"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-30",
     "Tran_NamF": null,
     "Tran_NamL": "Keith Carson For Alameda County Supervisor"
   },
@@ -610,9 +610,9 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Jeffrey",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Yui Hay",
     "Tran_NamL": "Lee"
   },
   {
@@ -624,9 +624,9 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Yui Hay",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Jeffrey",
     "Tran_NamL": "Lee"
   },
   {
@@ -659,15 +659,15 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-29",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": "Larry",
     "Tran_NamL": "Manning"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-29",
     "Tran_NamF": "Larry",
     "Tran_NamL": "Manning"
   },
@@ -869,20 +869,6 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Robert Arnold & Co"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Robert Arnold & Co"
-  },
-  {
-    "Filer_ID": "1375179",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-24",
     "Tran_NamF": null,
@@ -890,15 +876,29 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 236.08,
+    "Tran_Amt1": 250.0,
     "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Sarapochillo"
+    "Tran_NamF": null,
+    "Tran_NamL": "Robert Arnold & Co"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Robert Arnold & Co"
   },
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 177.06,
     "Tran_Date": "2016-04-23",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Sarapochillo"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 236.08,
+    "Tran_Date": "2016-04-27",
     "Tran_NamF": "Laura",
     "Tran_NamL": "Sarapochillo"
   },

--- a/build/committee/1375179/contributions/index.json
+++ b/build/committee/1375179/contributions/index.json
@@ -1,6 +1,13 @@
 [
   {
     "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-01-11",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Malet"
+  },
+  {
+    "Filer_ID": "1375179",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-01-27",
     "Tran_NamF": null,
@@ -8,31 +15,199 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-14",
     "Tran_NamF": null,
-    "Tran_NamL": "A Squared Ventures"
+    "Tran_NamL": "Construction & General Laborers Local Union 304 PAC"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Feld Entertainment"
   },
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Gerald",
-    "Tran_NamL": "Agee"
+    "Tran_Date": "2016-03-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Robert Arnold & Co"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-24",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Vettel"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-28",
+    "Tran_NamF": "Trent",
+    "Tran_NamL": "Holsman"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Jesse",
+    "Tran_NamL": "Blout"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Cohen"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Ramsey",
+    "Tran_NamL": "Daya"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Kroger"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Lindsey",
+    "Tran_NamL": "Meyersieck"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Taquino"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-04-12",
+    "Tran_NamF": "Elisabeth",
+    "Tran_NamL": "Jewel"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-13",
+    "Tran_NamF": "Paula",
+    "Tran_NamL": "Hawthorn"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-13",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Ubell"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-14",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-20",
+    "Tran_NamF": "Rulette",
+    "Tran_NamL": "Mapp"
   },
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-27",
-    "Tran_NamF": "Adamaka",
-    "Tran_NamL": "Ajaelo"
+    "Tran_Date": "2016-04-20",
+    "Tran_NamF": "Georgia",
+    "Tran_NamL": "Richardson"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-21",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 118.04,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": "Donald",
+    "Tran_NamL": "Gilmore"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Peterson"
   },
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Allen"
+    "Tran_Date": "2016-04-23",
+    "Tran_NamF": "Adhi",
+    "Tran_NamL": "Nagraj"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 177.06,
+    "Tran_Date": "2016-04-23",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Sarapochillo"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-25",
+    "Tran_NamF": "Elaine",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-04-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Curtis Development & Consulting"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-26",
+    "Tran_NamF": "Chloe",
+    "Tran_NamL": "Kwon"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-26",
+    "Tran_NamF": "Joseph Forbes",
+    "Tran_NamL": "McCarthy"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-26",
+    "Tran_NamF": "Rossana",
+    "Tran_NamL": "Peniche"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-26",
+    "Tran_NamF": "Kelly",
+    "Tran_NamL": "Persky"
   },
   {
     "Filer_ID": "1375179",
@@ -40,20 +215,6 @@
     "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "Arda LLC"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "BBI-Con, Inc"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Chuck",
-    "Tran_NamL": "Baker"
   },
   {
     "Filer_ID": "1375179",
@@ -79,65 +240,9 @@
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-14",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bliss"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bliss"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Jesse",
-    "Tran_NamL": "Blout"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-04-27",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Bohm"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-05-05",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Bohm"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Julina",
-    "Tran_NamL": "Bonilla"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-25",
-    "Tran_NamF": "Elaine",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": -100.0,
-    "Tran_Date": "2016-07-27",
-    "Tran_NamF": "Elaine",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Anita",
-    "Tran_NamL": "Butler"
   },
   {
     "Filer_ID": "1375179",
@@ -145,34 +250,6 @@
     "Tran_Date": "2016-04-27",
     "Tran_NamF": "Conley",
     "Tran_NamL": "Byrnes"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": -730.95,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": "Conley",
-    "Tran_NamL": "Byrnes"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Real Estate Political Action Committee (CREPAC) - California Association of Realtors"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Darnell",
-    "Tran_NamL": "Carey"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Williams",
-    "Tran_NamL": "Carol"
   },
   {
     "Filer_ID": "1375179",
@@ -184,51 +261,9 @@
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Carl",
-    "Tran_NamL": "Chan"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": -250.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "Carl",
-    "Tran_NamL": "Chan"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
     "Tran_Date": "2016-04-27",
     "Tran_NamF": "Judy",
     "Tran_NamL": "Chu"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Judy",
-    "Tran_NamL": "Chu"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Cohen"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Coleman"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "Construction & General Laborers Local Union 304 PAC"
   },
   {
     "Filer_ID": "1375179",
@@ -236,27 +271,6 @@
     "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "Core Security Solutions"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-04-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Curtis Development & Consulting"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Ramsey",
-    "Tran_NamL": "Daya"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "District Council Of Iron Workers PAC"
   },
   {
     "Filer_ID": "1375179",
@@ -268,100 +282,9 @@
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "East Bay Small Business Council"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Emerson Westreich Community Property Trust"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Feld Entertainment"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Feld Entertainment"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Feld Entertainment"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
     "Tran_Date": "2016-04-27",
     "Tran_NamF": null,
     "Tran_NamL": "Floor Sure Interiors"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": -500.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Floor Sure Interiors"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Focon"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 118.04,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": "Donald",
-    "Tran_NamL": "Gilmore"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Donald",
-    "Tran_NamL": "Gilmore"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Joyce",
-    "Tran_NamL": "Gordon"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Grace"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Orlando",
-    "Tran_NamL": "Graves"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Navdeep",
-    "Tran_NamL": "Grewal"
   },
   {
     "Filer_ID": "1375179",
@@ -369,27 +292,6 @@
     "Tran_Date": "2016-04-27",
     "Tran_NamF": "Bill",
     "Tran_NamL": "Harrigan"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "Harris"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-13",
-    "Tran_NamF": "Paula",
-    "Tran_NamL": "Hawthorn"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Stan",
-    "Tran_NamL": "Hebert"
   },
   {
     "Filer_ID": "1375179",
@@ -414,17 +316,150 @@
   },
   {
     "Filer_ID": "1375179",
+    "Tran_Amt1": 650.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Association of Fire Fighters Local 55 Political Action Committee"
+  },
+  {
+    "Filer_ID": "1375179",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "CJ",
-    "Tran_NamL": "Hirschfield"
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Shawn",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Keith Carson For Alameda County Supervisor"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "LaMumba Inc"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Yui Hay",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Judy",
+    "Tran_NamL": "Liu"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Larry",
+    "Tran_NamL": "Manning"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Jennie",
+    "Tran_NamL": "Ong"
   },
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-28",
-    "Tran_NamF": "Trent",
-    "Tran_NamL": "Holsman"
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Paxio"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Alexis",
+    "Tran_NamL": "Pelosi"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Bernida",
+    "Tran_NamL": "Reagan"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 318.04,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Tony",
+    "Tran_NamL": "Rishell"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Robert Arnold & Co"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 236.08,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Sarapochillo"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Celsa",
+    "Tran_NamL": "Snead"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Becky Lou",
+    "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Uche",
+    "Tran_NamL": "Uwahemu"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Wallace"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Lauren",
+    "Tran_NamL": "Westreich"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Anna",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-27",
+    "Tran_NamF": "Marzena",
+    "Tran_NamL": "Wright"
   },
   {
     "Filer_ID": "1375179",
@@ -435,31 +470,262 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Hood"
-  },
-  {
-    "Filer_ID": "1375179",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Salwa",
-    "Tran_NamL": "Ibrahim"
+    "Tran_Date": "2016-04-30",
+    "Tran_NamF": "Sheila",
+    "Tran_NamL": "Wells"
   },
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-07-29",
-    "Tran_NamF": "Salwa",
-    "Tran_NamL": "Ibrahim"
+    "Tran_Date": "2016-05-05",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Bohm"
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 650.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-16",
+    "Tran_NamF": "Andrea",
+    "Tran_NamL": "Wilson"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-20",
     "Tran_NamF": null,
-    "Tran_NamL": "International Association of Fire Fighters Local 55 Political Action Committee"
+    "Tran_NamL": "District Council Of Iron Workers PAC"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Patients' Mutual Assistance Collective Corporation"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Joshua Ruth",
+    "Tran_NamL": "Simon"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-27",
+    "Tran_NamF": "Adamaka",
+    "Tran_NamL": "Ajaelo"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-27",
+    "Tran_NamF": "Daxa",
+    "Tran_NamL": "Patel"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sheet Metal Workers' International Association Local No. 104"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "West Oakland Partners, LLC"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-27",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Wilkins"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": -730.95,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": "Conley",
+    "Tran_NamL": "Byrnes"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": -500.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Floor Sure Interiors"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": "Yui Hay",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": "Anna",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Chuck",
+    "Tran_NamL": "Baker"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Williams",
+    "Tran_NamL": "Carol"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Coleman"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Stan",
+    "Tran_NamL": "Hebert"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Shahidah",
+    "Tran_NamL": "Lacy"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Raymond",
+    "Tran_NamL": "Lankford"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Teron",
+    "Tran_NamL": "McGrew"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Simmons"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 106.49,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Charlette",
+    "Tran_NamL": "Viney"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Tesha",
+    "Tran_NamL": "Williams"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "A Squared Ventures"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Anita",
+    "Tran_NamL": "Butler"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Judy",
+    "Tran_NamL": "Chu"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "East Bay Small Business Council"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Focon"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Orlando",
+    "Tran_NamL": "Graves"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Masterpiece Painting"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "NDO Group LLC"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Jennie",
+    "Tran_NamL": "Ong"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Navdeep",
+    "Tran_NamL": "Grewal"
   },
   {
     "Filer_ID": "1375179",
@@ -477,31 +743,73 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-04-12",
-    "Tran_NamF": "Elisabeth",
-    "Tran_NamL": "Jewel"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-21",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Shawn",
-    "Tran_NamL": "Jones"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Koziol"
   },
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-30",
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Danilo",
+    "Tran_NamL": "Mayorga"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Alexis",
+    "Tran_NamL": "Parle"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Enoch",
+    "Tran_NamL": "Shin"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Kulwinder",
+    "Tran_NamL": "Singh"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Vishavdeep",
+    "Tran_NamL": "Singh"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Rosalba",
+    "Tran_NamL": "Vergara"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-06-30",
     "Tran_NamF": null,
-    "Tran_NamL": "Kal Krishnan Consulting Services"
+    "Tran_NamL": "Feld Entertainment"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Feld Entertainment"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Salwa",
+    "Tran_NamL": "Ibrahim"
   },
   {
     "Filer_ID": "1375179",
@@ -512,6 +820,34 @@
   },
   {
     "Filer_ID": "1375179",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Lindquist"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Steamfitters Local 342 PAC"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": -100.0,
+    "Tran_Date": "2016-07-27",
+    "Tran_NamF": "Elaine",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-07-29",
+    "Tran_NamF": "Salwa",
+    "Tran_NamL": "Ibrahim"
+  },
+  {
+    "Filer_ID": "1375179",
     "Tran_Amt1": -700.0,
     "Tran_Date": "2016-07-29",
     "Tran_NamF": "Martin",
@@ -519,10 +855,101 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-04-27",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Hood"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Allen"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Donald",
+    "Tran_NamL": "Gilmore"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Larry",
+    "Tran_NamL": "Manning"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Gerald",
+    "Tran_NamL": "Agee"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-30",
     "Tran_NamF": null,
-    "Tran_NamL": "Keith Carson For Alameda County Supervisor"
+    "Tran_NamL": "BBI-Con, Inc"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Julina",
+    "Tran_NamL": "Bonilla"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Darnell",
+    "Tran_NamL": "Carey"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Carl",
+    "Tran_NamL": "Chan"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Emerson Westreich Community Property Trust"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Joyce",
+    "Tran_NamL": "Gordon"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Harris"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "CJ",
+    "Tran_NamL": "Hirschfield"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Kal Krishnan Consulting Services"
   },
   {
     "Filer_ID": "1375179",
@@ -548,51 +975,9 @@
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Koziol"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Kroger"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "Chris",
     "Tran_NamL": "Kwei"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-26",
-    "Tran_NamF": "Chloe",
-    "Tran_NamL": "Kwon"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "LaMumba Inc"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Shahidah",
-    "Tran_NamL": "Lacy"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Raymond",
-    "Tran_NamL": "Lankford"
   },
   {
     "Filer_ID": "1375179",
@@ -603,45 +988,10 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "League of Conservation Voters of the East Bay"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Yui Hay",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": "Yui Hay",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1375179",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "Jeffrey",
     "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Lindquist"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Judy",
-    "Tran_NamL": "Liu"
   },
   {
     "Filer_ID": "1375179",
@@ -652,87 +1002,10 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-01-11",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Malet"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Larry",
-    "Tran_NamL": "Manning"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Larry",
-    "Tran_NamL": "Manning"
-  },
-  {
-    "Filer_ID": "1375179",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "Larry",
     "Tran_NamL": "Manning"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-20",
-    "Tran_NamF": "Rulette",
-    "Tran_NamL": "Mapp"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Masterpiece Painting"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Danilo",
-    "Tran_NamL": "Mayorga"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-26",
-    "Tran_NamF": "Joseph Forbes",
-    "Tran_NamL": "McCarthy"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Teron",
-    "Tran_NamL": "McGrew"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Lindsey",
-    "Tran_NamL": "Meyersieck"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "NDO Group LLC"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-23",
-    "Tran_NamF": "Adhi",
-    "Tran_NamL": "Nagraj"
   },
   {
     "Filer_ID": "1375179",
@@ -750,41 +1023,6 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Neustadt"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Northern California Construction Teamsters PAC"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce (OakPAC)"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Jennie",
-    "Tran_NamL": "Ong"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Jennie",
-    "Tran_NamL": "Ong"
-  },
-  {
-    "Filer_ID": "1375179",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "Harry",
@@ -792,185 +1030,10 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Alexis",
-    "Tran_NamL": "Parle"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-27",
-    "Tran_NamF": "Daxa",
-    "Tran_NamL": "Patel"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Patients' Mutual Assistance Collective Corporation"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Paxio"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Alexis",
-    "Tran_NamL": "Pelosi"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-26",
-    "Tran_NamF": "Rossana",
-    "Tran_NamL": "Peniche"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-26",
-    "Tran_NamF": "Kelly",
-    "Tran_NamL": "Persky"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "Peterson"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Bernida",
-    "Tran_NamL": "Reagan"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-20",
-    "Tran_NamF": "Georgia",
-    "Tran_NamL": "Richardson"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 318.04,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Tony",
-    "Tran_NamL": "Rishell"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Robert Arnold & Co"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Robert Arnold & Co"
-  },
-  {
-    "Filer_ID": "1375179",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": null,
     "Tran_NamL": "Robert Arnold & Co"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 177.06,
-    "Tran_Date": "2016-04-23",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Sarapochillo"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 236.08,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Sarapochillo"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sebastian Ridley-Thomas for Assembly 2016"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sheet Metal Workers' International Association Local No. 104"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Enoch",
-    "Tran_NamL": "Shin"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Silver"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Simmons"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-22",
-    "Tran_NamF": "Joshua Ruth",
-    "Tran_NamL": "Simon"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Vishavdeep",
-    "Tran_NamL": "Singh"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Kulwinder",
-    "Tran_NamL": "Singh"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Celsa",
-    "Tran_NamL": "Snead"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "Steamfitters Local 342 PAC"
   },
   {
     "Filer_ID": "1375179",
@@ -982,170 +1045,16 @@
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Taquino"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Becky Lou",
-    "Tran_NamL": "Taylor"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Taylor"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-22",
+    "Tran_Date": "2016-08-30",
     "Tran_NamF": null,
-    "Tran_NamL": "Transamerican Engineers"
+    "Tran_NamL": "YHLA Architects Inc."
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-06",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
     "Tran_NamF": null,
-    "Tran_NamL": "Transport Oakland"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Henry Joseph",
-    "Tran_NamL": "Trapp"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Sara",
-    "Tran_NamL": "Ubelhart"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-13",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Ubell"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "Unite Here TIP State & Local Fund"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Unity PAC, A Sponsored Committee of the Alameda Labor Council, AFL-CIO"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Uche",
-    "Tran_NamL": "Uwahemu"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Rosalba",
-    "Tran_NamL": "Vergara"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-24",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Vettel"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 106.49,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Charlette",
-    "Tran_NamL": "Viney"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Jason",
-    "Tran_NamL": "Wallace"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Danny",
-    "Tran_NamL": "Wan"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-30",
-    "Tran_NamF": "Sheila",
-    "Tran_NamL": "Wells"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "West Oakland Partners, LLC"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Lauren",
-    "Tran_NamL": "Westreich"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-27",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Wilkins"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Tesha",
-    "Tran_NamL": "Williams"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-16",
-    "Tran_NamF": "Andrea",
-    "Tran_NamL": "Wilson"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Anna",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1375179",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": "Anna",
-    "Tran_NamL": "Wong"
+    "Tran_NamL": "Sebastian Ridley-Thomas for Assembly 2016"
   },
   {
     "Filer_ID": "1375179",
@@ -1156,16 +1065,107 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-27",
-    "Tran_NamF": "Marzena",
-    "Tran_NamL": "Wright"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California Construction Teamsters PAC"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Transamerican Engineers"
   },
   {
     "Filer_ID": "1375179",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-30",
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Grace"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Sara",
+    "Tran_NamL": "Ubelhart"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": -250.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Carl",
+    "Tran_NamL": "Chan"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-04",
     "Tran_NamF": null,
-    "Tran_NamL": "YHLA Architects Inc."
+    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce (OakPAC)"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "Transport Oakland"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "League of Conservation Voters of the East Bay"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Unite Here TIP State & Local Fund"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Danny",
+    "Tran_NamL": "Wan"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Real Estate Political Action Committee (CREPAC) - California Association of Realtors"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Unity PAC, A Sponsored Committee of the Alameda Labor Council, AFL-CIO"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Neustadt"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Henry Joseph",
+    "Tran_NamL": "Trapp"
   }
 ]

--- a/build/committee/1379121/contributions/index.json
+++ b/build/committee/1379121/contributions/index.json
@@ -78,16 +78,16 @@
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "Rudy",
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Martin",
     "Tran_NamL": "Caraves"
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 450.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Martin",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "Rudy",
     "Tran_NamL": "Caraves"
   },
   {
@@ -156,14 +156,14 @@
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-10",
+    "Tran_Date": "2016-06-24",
     "Tran_NamF": "Gerry",
     "Tran_NamL": "Garzon"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-24",
+    "Tran_Date": "2016-09-10",
     "Tran_NamF": "Gerry",
     "Tran_NamL": "Garzon"
   },
@@ -379,15 +379,15 @@
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-29",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-27",
     "Tran_NamF": "Bruce",
     "Tran_NamL": "Quan, Jr."
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-27",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-29",
     "Tran_NamF": "Bruce",
     "Tran_NamL": "Quan, Jr."
   },
@@ -470,8 +470,8 @@
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-08",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-01",
     "Tran_NamF": "Lydia",
     "Tran_NamL": "Torres"
   },
@@ -484,8 +484,8 @@
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-05-01",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-08",
     "Tran_NamF": "Lydia",
     "Tran_NamL": "Torres"
   },

--- a/build/committee/1379121/contributions/index.json
+++ b/build/committee/1379121/contributions/index.json
@@ -1,52 +1,73 @@
 [
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "Curtis",
-    "Tran_NamL": "Acosta"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-01-04",
+    "Tran_NamF": "Linnea",
+    "Tran_NamL": "Peery"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-03",
+    "Tran_NamF": "Krystell",
+    "Tran_NamL": "Guzman"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Catalina Guevara",
-    "Tran_NamL": "Alvarado"
+    "Tran_Date": "2016-04-20",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Lerma"
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Winnie",
-    "Tran_NamL": "Anderson"
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-04-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California Carpenters Regional Council Small Contributor Committee"
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "David M.",
-    "Tran_NamL": "Angelillo"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-20",
+    "Tran_NamF": "Emma C.",
+    "Tran_NamL": "Roos"
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Maria",
-    "Tran_NamL": "Anguiano"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Apodaca"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-01",
+    "Tran_NamF": "Lydia",
+    "Tran_NamL": "Torres"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "Nathaly",
-    "Tran_NamL": "Arriola"
+    "Tran_Date": "2016-05-03",
+    "Tran_NamF": "Melvin",
+    "Tran_NamL": "Harrison"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-04",
+    "Tran_NamF": "Uduak-Joe",
+    "Tran_NamL": "Ntuk"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-30",
+    "Tran_NamF": "Victor",
+    "Tran_NamL": "Griego"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-02",
+    "Tran_NamF": "Helen",
+    "Tran_NamL": "Torres"
   },
   {
     "Filer_ID": "1379121",
@@ -58,51 +79,9 @@
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Yelda",
-    "Tran_NamL": "Bartlett"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Blain"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Rosemarie",
-    "Tran_NamL": "Boothe-Bey"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 450.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Martin",
-    "Tran_NamL": "Caraves"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "Rudy",
-    "Tran_NamL": "Caraves"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Xochitl",
-    "Tran_NamL": "Carrion"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "Eddy",
-    "Tran_NamL": "Cervantes"
+    "Tran_Date": "2016-06-10",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Slater"
   },
   {
     "Filer_ID": "1379121",
@@ -120,157 +99,24 @@
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Raquel",
-    "Tran_NamL": "Donoso"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 750.0,
-    "Tran_Date": "2016-11-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "East Bay Women's Political Caucus (EBWPC) PAC"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-13",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Vela"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Flores"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Romeo",
-    "Tran_NamL": "Garcia"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Garcia for Assembly 2016"
+    "Tran_Date": "2016-06-13",
+    "Tran_NamF": "Linda A.",
+    "Tran_NamL": "Weisbach"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "Gerry",
-    "Tran_NamL": "Garzon"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-10",
-    "Tran_NamF": "Gerry",
-    "Tran_NamL": "Garzon"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Gerry",
-    "Tran_NamL": "Garzon"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Shanthi",
-    "Tran_NamL": "Gonzales"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-30",
-    "Tran_NamF": "Victor",
-    "Tran_NamL": "Griego"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Abel",
-    "Tran_NamL": "Guillen"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-03",
-    "Tran_NamF": "Krystell",
-    "Tran_NamL": "Guzman"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-03",
-    "Tran_NamF": "Melvin",
-    "Tran_NamL": "Harrison"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Melvin",
-    "Tran_NamL": "Harrison"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Huayllasco"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Floyd",
-    "Tran_NamL": "Huen"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Sylvia",
-    "Tran_NamL": "Kubota"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Andrew",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Xochitl",
-    "Tran_NamL": "Leon"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-20",
-    "Tran_NamF": "George",
-    "Tran_NamL": "Lerma"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Donna P.",
-    "Tran_NamL": "Liang"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Life Law Group, LLP"
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Apodaca"
   },
   {
     "Filer_ID": "1379121",
@@ -281,13 +127,6 @@
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Vinny",
-    "Tran_NamL": "Manguyen"
-  },
-  {
-    "Filer_ID": "1379121",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-06-20",
     "Tran_NamF": "Marco",
@@ -295,87 +134,31 @@
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Mar Con Company"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Jacquelyn",
-    "Tran_NamL": "McCormick"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Rene A.",
-    "Tran_NamL": "Mendieta"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Alex",
-    "Tran_NamL": "Miller-Cole"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "National Electrical Contractors Association (NECA) Northern California Chapter PAC"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Thai",
-    "Tran_NamL": "Nguyen"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-04-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Northern California Carpenters Regional Council Small Contributor Committee"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-04",
-    "Tran_NamF": "Uduak-Joe",
-    "Tran_NamL": "Ntuk"
-  },
-  {
-    "Filer_ID": "1379121",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-29",
-    "Tran_NamF": "Rene",
-    "Tran_NamL": "Ocon"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Lawrence",
-    "Tran_NamL": "Patrick"
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "Gerry",
+    "Tran_NamL": "Garzon"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-01-04",
-    "Tran_NamF": "Linnea",
-    "Tran_NamL": "Peery"
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Catalina Guevara",
+    "Tran_NamL": "Alvarado"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Rosemarie",
+    "Tran_NamL": "Boothe-Bey"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-08",
-    "Tran_NamF": "Gabriel",
-    "Tran_NamL": "Perez"
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Romeo",
+    "Tran_NamL": "Garcia"
   },
   {
     "Filer_ID": "1379121",
@@ -386,38 +169,80 @@
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Bruce",
-    "Tran_NamL": "Quan, Jr."
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Tulum Innovative Engineering, Inc."
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Andres",
-    "Tran_NamL": "Quintero"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-20",
-    "Tran_NamF": "Emma C.",
-    "Tran_NamL": "Roos"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Sharon",
-    "Tran_NamL": "Rose"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Melvin",
+    "Tran_NamL": "Harrison"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Maria A.",
-    "Tran_NamL": "Sager"
+    "Tran_Date": "2016-07-29",
+    "Tran_NamF": "Rene",
+    "Tran_NamL": "Ocon"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Maria",
+    "Tran_NamL": "Anguiano"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Flores"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Martin",
+    "Tran_NamL": "Caraves"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Lawrence",
+    "Tran_NamL": "Patrick"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "Curtis",
+    "Tran_NamL": "Acosta"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Xochitl",
+    "Tran_NamL": "Carrion"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "Rudy",
+    "Tran_NamL": "Caraves"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "Angela",
+    "Tran_NamL": "Warren"
   },
   {
     "Filer_ID": "1379121",
@@ -429,37 +254,93 @@
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Eddy",
+    "Tran_NamL": "Cervantes"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Nathaly",
+    "Tran_NamL": "Arriola"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Yelda",
+    "Tran_NamL": "Bartlett"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Floyd",
+    "Tran_NamL": "Huen"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Donna P.",
+    "Tran_NamL": "Liang"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Rene A.",
+    "Tran_NamL": "Mendieta"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Quan, Jr."
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Jacquelyn",
+    "Tran_NamL": "McCormick"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-02",
     "Tran_NamF": "Naomi",
     "Tran_NamL": "Schiff"
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sheet Metal Workers' International Association Local No. 104 PAC"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Lydia",
+    "Tran_NamL": "Torres"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-10",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Slater"
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Abel",
+    "Tran_NamL": "Guillen"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Sara",
-    "Tran_NamL": "Somera"
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Sharon",
+    "Tran_NamL": "Rose"
   },
   {
     "Filer_ID": "1379121",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sprinkler Fitters and Apprentices Local 483 Local PAC"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Gerry",
+    "Tran_NamL": "Garzon"
   },
   {
     "Filer_ID": "1379121",
@@ -471,30 +352,9 @@
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-05-01",
-    "Tran_NamF": "Lydia",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-02",
-    "Tran_NamF": "Helen",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Lydia",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "1379121",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Tulum Innovative Engineering, Inc."
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Xochitl",
+    "Tran_NamL": "Leon"
   },
   {
     "Filer_ID": "1379121",
@@ -505,10 +365,94 @@
   },
   {
     "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sara",
+    "Tran_NamL": "Somera"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Blain"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Sylvia",
+    "Tran_NamL": "Kubota"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-08",
+    "Tran_NamF": "Gabriel",
+    "Tran_NamL": "Perez"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Thai",
+    "Tran_NamL": "Nguyen"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Gerry",
+    "Tran_NamL": "Garzon"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Winnie",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Garcia for Assembly 2016"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Huayllasco"
+  },
+  {
+    "Filer_ID": "1379121",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-13",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Vela"
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Andrew",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Miller-Cole"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Maria A.",
+    "Tran_NamL": "Sager"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sprinkler Fitters and Apprentices Local 483 Local PAC"
   },
   {
     "Filer_ID": "1379121",
@@ -520,16 +464,44 @@
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "Angela",
-    "Tran_NamL": "Warren"
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Shanthi",
+    "Tran_NamL": "Gonzales"
   },
   {
     "Filer_ID": "1379121",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-13",
-    "Tran_NamF": "Linda A.",
-    "Tran_NamL": "Weisbach"
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Raquel",
+    "Tran_NamL": "Donoso"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "David M.",
+    "Tran_NamL": "Angelillo"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Life Law Group, LLP"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Vinny",
+    "Tran_NamL": "Manguyen"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mar Con Company"
   },
   {
     "Filer_ID": "1379121",
@@ -544,5 +516,33 @@
     "Tran_Date": "2016-10-27",
     "Tran_NamF": "John F.",
     "Tran_NamL": "Zilber"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Andres",
+    "Tran_NamL": "Quintero"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "National Electrical Contractors Association (NECA) Northern California Chapter PAC"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sheet Metal Workers' International Association Local No. 104 PAC"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 750.0,
+    "Tran_Date": "2016-11-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "East Bay Women's Political Caucus (EBWPC) PAC"
   }
 ]

--- a/build/committee/1379618/contributions/index.json
+++ b/build/committee/1379618/contributions/index.json
@@ -1,174 +1,6 @@
 [
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "3800 San Pablo, LLC"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "AECOM Technical Services, Inc."
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-10",
-    "Tran_NamF": "Alfonso",
-    "Tran_NamL": "Alvarez"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Bair"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Bair"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Bair"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "Danielle",
-    "Tran_NamL": "Baskin"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-07-19",
-    "Tran_NamF": "Danielle",
-    "Tran_NamL": "Baskin"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-02-23",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Bomberg"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-14",
-    "Tran_NamF": "Libby",
-    "Tran_NamL": "Brittain"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-12",
-    "Tran_NamF": "Farimah",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Farimah",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-17",
-    "Tran_NamF": "Alice",
-    "Tran_NamL": "Chen"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Alice",
-    "Tran_NamL": "Chen"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-23",
-    "Tran_NamF": "Danielle",
-    "Tran_NamL": "Dai"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-06",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Davis"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "Colin",
-    "Tran_NamL": "Dentel-Post"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-12-11",
-    "Tran_NamF": "Colin",
-    "Tran_NamL": "Dentel-Post"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-06-14",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Eckels"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-08",
-    "Tran_NamF": "Lisa",
-    "Tran_NamL": "Ellis"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Elsa Ortiz for AC Transit Ward 3"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "Elsa Ortiz for AC Transit Ward 3"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-09",
-    "Tran_NamF": "Irissa",
-    "Tran_NamL": "Everett"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Ferro"
-  },
-  {
-    "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-01-07",
     "Tran_NamF": "Sarah",
@@ -176,80 +8,10 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-22",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Fine"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Fine"
-  },
-  {
-    "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Torrie",
-    "Tran_NamL": "Fischer"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Garrett"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Garrett"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "HNTB Corporation"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-25",
-    "Tran_NamF": "Diny",
-    "Tran_NamL": "Huang"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-12",
-    "Tran_NamF": "Diny",
-    "Tran_NamL": "Huang"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-07-27",
-    "Tran_NamF": "Nicholas Frederick Myron",
-    "Tran_NamL": "Josefowitz"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Jonathon",
-    "Tran_NamL": "Kass"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-24",
-    "Tran_NamF": "Shira",
-    "Tran_NamL": "Katz"
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "Colin",
+    "Tran_NamL": "Dentel-Post"
   },
   {
     "Filer_ID": "1379618",
@@ -261,86 +23,37 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-22",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Kidd"
+    "Tran_Date": "2016-02-17",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Miller"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-05",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Kidd"
+    "Tran_Date": "2016-02-23",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bomberg"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Kidd"
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "Samuel",
+    "Tran_NamL": "Maurer"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-09",
-    "Tran_NamF": "Tal",
-    "Tran_NamL": "Klement"
+    "Tran_Date": "2016-03-17",
+    "Tran_NamF": "Alice",
+    "Tran_NamL": "Chen"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Levoit"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Levoit"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Levoit"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Levoit"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Levoit"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Levoit"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Lilie"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lyft, Inc. NetSuite"
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Miller"
   },
   {
     "Filer_ID": "1379618",
@@ -352,16 +65,58 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "Samuel",
-    "Tran_NamL": "Maurer"
+    "Tran_Date": "2016-03-22",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Fine"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-22",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-24",
+    "Tran_NamF": "Shira",
+    "Tran_NamL": "Katz"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Samuel",
-    "Tran_NamL": "Maurer"
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Bair"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-04-14",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Snyder"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-04-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "3800 San Pablo, LLC"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": "David",
+    "Tran_NamL": "McCaig"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-25",
+    "Tran_NamF": "Diny",
+    "Tran_NamL": "Huang"
   },
   {
     "Filer_ID": "1379618",
@@ -373,9 +128,23 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-22",
-    "Tran_NamF": "David",
-    "Tran_NamL": "McCaig"
+    "Tran_Date": "2016-06-08",
+    "Tran_NamF": "Lisa",
+    "Tran_NamL": "Ellis"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-09",
+    "Tran_NamF": "Irissa",
+    "Tran_NamL": "Everett"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-09",
+    "Tran_NamF": "Tal",
+    "Tran_NamL": "Klement"
   },
   {
     "Filer_ID": "1379618",
@@ -387,51 +156,23 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-02-17",
-    "Tran_NamF": "Ruth",
-    "Tran_NamL": "Miller"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "Ruth",
-    "Tran_NamL": "Miller"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "Ruth",
-    "Tran_NamL": "Miller"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-13",
-    "Tran_NamF": "Ruth",
-    "Tran_NamL": "Miller"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Mott MacDonald, LLC"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Dina",
-    "Tran_NamL": "Potter"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-06-10",
     "Tran_NamF": "Michelle",
     "Tran_NamL": "Powers"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-12",
+    "Tran_NamF": "Farimah",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-12",
+    "Tran_NamF": "Diny",
+    "Tran_NamL": "Huang"
   },
   {
     "Filer_ID": "1379618",
@@ -442,10 +183,45 @@
   },
   {
     "Filer_ID": "1379618",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-14",
+    "Tran_NamF": "Libby",
+    "Tran_NamL": "Brittain"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-06-14",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Eckels"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "HNTB Corporation"
+  },
+  {
+    "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "Ian",
-    "Tran_NamL": "Rees"
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Garrett"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Lilie"
   },
   {
     "Filer_ID": "1379618",
@@ -456,38 +232,38 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-14",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Sensenig"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Sensenig"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-04-14",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Snyder"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Elsa Ortiz for AC Transit Ward 3"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Snyder"
+    "Tran_Date": "2016-06-26",
+    "Tran_NamF": "Alan",
+    "Tran_NamL": "Uy"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-18",
-    "Tran_NamF": "Noah",
-    "Tran_NamL": "Swartz"
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Ferro"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Samuel",
+    "Tran_NamL": "Maurer"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Dina",
+    "Tran_NamL": "Potter"
   },
   {
     "Filer_ID": "1379618",
@@ -499,51 +275,100 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Temescal Brewing"
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Snyder"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Bair"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Toole Design"
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Jonathon",
+    "Tran_NamL": "Kass"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-26",
-    "Tran_NamF": "Alan",
-    "Tran_NamL": "Uy"
+    "Tran_Date": "2016-07-05",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-06",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-13",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-14",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Sensenig"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Levoit"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "VIA Architecture"
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "Danielle",
+    "Tran_NamL": "Baskin"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "VIA Architecture"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "Ian",
+    "Tran_NamL": "Rees"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": -200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "VIA Architecture"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-18",
+    "Tran_NamF": "Noah",
+    "Tran_NamL": "Swartz"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Van Meter, Williams, Pollack, LLP"
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-07-19",
+    "Tran_NamF": "Danielle",
+    "Tran_NamL": "Baskin"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-07-27",
+    "Tran_NamF": "Nicholas Frederick Myron",
+    "Tran_NamL": "Josefowitz"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Farimah",
+    "Tran_NamL": "Brown"
   },
   {
     "Filer_ID": "1379618",
@@ -561,9 +386,184 @@
   },
   {
     "Filer_ID": "1379618",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mott MacDonald, LLC"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Levoit"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Bair"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Temescal Brewing"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "VIA Architecture"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Alfonso",
+    "Tran_NamL": "Alvarez"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "VIA Architecture"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Torrie",
+    "Tran_NamL": "Fischer"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Levoit"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "Elsa Ortiz for AC Transit Ward 3"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Sensenig"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Alice",
+    "Tran_NamL": "Chen"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Garrett"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Fine"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Toole Design"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": -200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "VIA Architecture"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lyft, Inc. NetSuite"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "AECOM Technical Services, Inc."
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Levoit"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Van Meter, Williams, Pollack, LLP"
+  },
+  {
+    "Filer_ID": "1379618",
     "Tran_Amt1": 36.88,
     "Tran_Date": "2016-11-02",
     "Tran_NamF": "Frank",
     "Tran_NamL": "Wheeler"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Levoit"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-23",
+    "Tran_NamF": "Danielle",
+    "Tran_NamL": "Dai"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-12-11",
+    "Tran_NamF": "Colin",
+    "Tran_NamL": "Dentel-Post"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-12-15",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Levoit"
   }
 ]

--- a/build/committee/1379618/contributions/index.json
+++ b/build/committee/1379618/contributions/index.json
@@ -23,6 +23,13 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Bair"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "Jonathan",
     "Tran_NamL": "Bair"
@@ -36,22 +43,15 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Bair"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-07-19",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-18",
     "Tran_NamF": "Danielle",
     "Tran_NamL": "Baskin"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-18",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-07-19",
     "Tran_NamF": "Danielle",
     "Tran_NamL": "Baskin"
   },
@@ -71,15 +71,15 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-08-01",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-12",
     "Tran_NamF": "Farimah",
     "Tran_NamL": "Brown"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-12",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-08-01",
     "Tran_NamF": "Farimah",
     "Tran_NamL": "Brown"
   },
@@ -169,13 +169,6 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Fine"
-  },
-  {
-    "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-01-07",
     "Tran_NamF": "Sarah",
@@ -190,6 +183,13 @@
   },
   {
     "Filer_ID": "1379618",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Fine"
+  },
+  {
+    "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-15",
     "Tran_NamF": "Torrie",
@@ -198,14 +198,14 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-21",
+    "Tran_Date": "2016-06-22",
     "Tran_NamF": "Christopher",
     "Tran_NamL": "Garrett"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-22",
+    "Tran_Date": "2016-09-21",
     "Tran_NamF": "Christopher",
     "Tran_NamL": "Garrett"
   },
@@ -218,15 +218,15 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-12",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-04-25",
     "Tran_NamF": "Diny",
     "Tran_NamL": "Huang"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-25",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-12",
     "Tran_NamF": "Diny",
     "Tran_NamL": "Huang"
   },
@@ -253,16 +253,16 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-22",
-    "Tran_NamF": "Robert",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-02-04",
+    "Tran_NamF": "Christopher",
     "Tran_NamL": "Kidd"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-02-04",
-    "Tran_NamF": "Christopher",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-22",
+    "Tran_NamF": "Robert",
     "Tran_NamL": "Kidd"
   },
   {
@@ -289,6 +289,13 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Levoit"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 20.0,
     "Tran_Date": "2016-08-23",
     "Tran_NamF": "Derek",
     "Tran_NamL": "Levoit"
@@ -303,6 +310,13 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Levoit"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 20.0,
     "Tran_Date": "2016-11-15",
     "Tran_NamF": "Derek",
     "Tran_NamL": "Levoit"
@@ -310,21 +324,7 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Levoit"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 20.0,
     "Tran_Date": "2016-12-15",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Levoit"
-  },
-  {
-    "Filer_ID": "1379618",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-10-15",
     "Tran_NamF": "Derek",
     "Tran_NamL": "Levoit"
   },
@@ -352,14 +352,14 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-28",
+    "Tran_Date": "2016-03-16",
     "Tran_NamF": "Samuel",
     "Tran_NamL": "Maurer"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-03-16",
+    "Tran_Date": "2016-06-28",
     "Tran_NamF": "Samuel",
     "Tran_NamL": "Maurer"
   },
@@ -386,8 +386,8 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-06-15",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-02-17",
     "Tran_NamF": "Ruth",
     "Tran_NamL": "Miller"
   },
@@ -400,15 +400,15 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-13",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-06-15",
     "Tran_NamF": "Ruth",
     "Tran_NamL": "Miller"
   },
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-02-17",
+    "Tran_Date": "2016-07-13",
     "Tran_NamF": "Ruth",
     "Tran_NamL": "Miller"
   },
@@ -470,15 +470,15 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-29",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-04-14",
     "Tran_NamF": "David",
     "Tran_NamL": "Snyder"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-04-14",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-29",
     "Tran_NamF": "David",
     "Tran_NamL": "Snyder"
   },
@@ -520,6 +520,13 @@
   {
     "Filer_ID": "1379618",
     "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "VIA Architecture"
+  },
+  {
+    "Filer_ID": "1379618",
+    "Tran_Amt1": 200.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": null,
     "Tran_NamL": "VIA Architecture"
@@ -533,13 +540,6 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "VIA Architecture"
-  },
-  {
-    "Filer_ID": "1379618",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-10-17",
     "Tran_NamF": null,
@@ -547,15 +547,15 @@
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-13",
+    "Tran_Amt1": 36.88,
+    "Tran_Date": "2016-08-01",
     "Tran_NamF": "Frank",
     "Tran_NamL": "Wheeler"
   },
   {
     "Filer_ID": "1379618",
-    "Tran_Amt1": 36.88,
-    "Tran_Date": "2016-08-01",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-13",
     "Tran_NamF": "Frank",
     "Tran_NamL": "Wheeler"
   },

--- a/build/committee/1381041/contributions/index.json
+++ b/build/committee/1381041/contributions/index.json
@@ -1051,14 +1051,14 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 1556290.0,
+    "Tran_Amt1": 1554290.0,
     "Tran_Date": "2016-11-01",
     "Tran_NamF": "MICHAEL",
     "Tran_NamL": "BLOOMBERG"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 1554290.0,
+    "Tran_Amt1": 1556290.0,
     "Tran_Date": "2016-11-01",
     "Tran_NamF": "MICHAEL",
     "Tran_NamL": "BLOOMBERG"

--- a/build/committee/1381041/contributions/index.json
+++ b/build/committee/1381041/contributions/index.json
@@ -43,15 +43,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-29",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-25",
     "Tran_NamF": "VICKI",
     "Tran_NamL": "ALEXANDER"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-25",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-29",
     "Tran_NamF": "VICKI",
     "Tran_NamL": "ALEXANDER"
   },
@@ -113,120 +113,8 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 10150.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 11250.0,
-    "Tran_Date": "2016-12-23",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 15000.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 14500.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 40000.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1556290.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1554290.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1600030.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1525030.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 18275.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1348738.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 12625.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1362093.5,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
     "Tran_Amt1": 75000.0,
     "Tran_Date": "2016-07-14",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 501546.51,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 588670.5,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 504040.0,
-    "Tran_Date": "2016-09-27",
     "Tran_NamF": "MICHAEL",
     "Tran_NamL": "BLOOMBERG"
   },
@@ -255,6 +143,118 @@
     "Filer_ID": "1381041",
     "Tran_Amt1": 421355.0,
     "Tran_Date": "2016-09-21",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 504040.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 588670.5,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 10150.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 501546.51,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1362093.5,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 12625.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1348738.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 18275.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1600030.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1525030.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1556290.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1554290.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 40000.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 15000.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 14500.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 11250.0,
+    "Tran_Date": "2016-12-23",
     "Tran_NamF": "MICHAEL",
     "Tran_NamL": "BLOOMBERG"
   },
@@ -442,15 +442,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-24",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-29",
     "Tran_NamF": "MICHAEL",
     "Tran_NamL": "DIMOCK"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-29",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": "MICHAEL",
     "Tran_NamL": "DIMOCK"
   },
@@ -694,15 +694,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-24",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-26",
     "Tran_NamF": "JOANNE",
     "Tran_NamL": "LAGOS"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-26",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-24",
     "Tran_NamF": "JOANNE",
     "Tran_NamL": "LAGOS"
   },
@@ -799,15 +799,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-02",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "MEYERS"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-02",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
     "Tran_NamF": "ROBERT",
     "Tran_NamL": "MEYERS"
   },
@@ -925,15 +925,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-20",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-25",
     "Tran_NamF": "RONA",
     "Tran_NamL": "RENNER"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-25",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-20",
     "Tran_NamF": "RONA",
     "Tran_NamL": "RENNER"
   },
@@ -981,15 +981,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-05-14",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-03-23",
     "Tran_NamF": "LYNN",
     "Tran_NamL": "SILVER"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-03-23",
+    "Tran_Amt1": 80.0,
+    "Tran_Date": "2016-05-14",
     "Tran_NamF": "LYNN",
     "Tran_NamL": "SILVER"
   },
@@ -1107,15 +1107,15 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 200000.0,
-    "Tran_Date": "2016-12-09",
+    "Tran_Amt1": 214.72,
+    "Tran_Date": "2016-10-28",
     "Tran_NamF": null,
     "Tran_NamL": "Yes on Proposition V  San Franciscans United to Reduce Diabetes in Children by Imposing 1 Cent Sales Tax on Distribution of Sugary Drinks with Major Funding by Michael Bloomberg & Action Now Iniative"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 214.72,
-    "Tran_Date": "2016-10-28",
+    "Tran_Amt1": 200000.0,
+    "Tran_Date": "2016-12-09",
     "Tran_NamF": null,
     "Tran_NamL": "Yes on Proposition V  San Franciscans United to Reduce Diabetes in Children by Imposing 1 Cent Sales Tax on Distribution of Sugary Drinks with Major Funding by Michael Bloomberg & Action Now Iniative"
   }

--- a/build/committee/1381041/contributions/index.json
+++ b/build/committee/1381041/contributions/index.json
@@ -1,619 +1,10 @@
 [
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 75000.0,
-    "Tran_Date": "2016-07-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "ACTION NOW INITIATIVE"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 500000.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "ACTION NOW INITIATIVE"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 500000.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "ACTION NOW INITIATIVE"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "MICHELLE",
-    "Tran_NamL": "AGAZZI"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "ALAMEDA PEDIATRIC DENTISTRY"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "ALAMEDA-CONTRA COSTA PHYSICIAN'S COMMITTEE"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "VICKI",
-    "Tran_NamL": "ALEXANDER"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "VICKI",
-    "Tran_NamL": "ALEXANDER"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "AMERICAN HEART ASSOCIATION  INC."
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "AMERICAN HEART ASSOCIATION, INC."
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-19",
-    "Tran_NamF": "LEE",
-    "Tran_NamL": "AURICH"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "AUSINHEILER PHYSICAL THERAPY AND PERSONAL TRAINING  PC"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "AUSINHEILER PHYSICAL THERAPY AND PERSONAL TRAINING, PC"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "Bret",
-    "Tran_NamL": "Andrews"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-16",
-    "Tran_NamF": "Janan",
-    "Tran_NamL": "Apaydin"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "KAREN",
-    "Tran_NamL": "BIXBY"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 75000.0,
-    "Tran_Date": "2016-07-14",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 440955.5,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 348155.5,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 487496.5,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 421355.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 504040.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 588670.5,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 10150.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 501546.51,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1362093.5,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 12625.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1348738.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 18275.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1600030.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1525030.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1556290.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1554290.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 40000.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 15000.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 14500.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 11250.0,
-    "Tran_Date": "2016-12-23",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "BLOOMBERG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "BRUCE",
-    "Tran_NamL": "BOTHWELL"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "MARTIN",
-    "Tran_NamL": "BOURQUE"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-25",
-    "Tran_NamF": "NORMAN",
-    "Tran_NamL": "BURG"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Randall",
-    "Tran_NamL": "Block"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Boxer"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Frits",
-    "Tran_NamL": "Brevet"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Ericac",
-    "Tran_NamL": "Brevet-Stott"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "LAURIE",
-    "Tran_NamL": "CAPITELLI"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "MARIANELA M.",
-    "Tran_NamL": "CARTER"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "CHEZ PANISSE"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "CORAZON B. MANALOTO, D.D.S., INC."
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "MELISSA",
-    "Tran_NamL": "CRAGO"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "RICHARD J.",
-    "Tran_NamL": "CUROTTO"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 28750.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Dental Association"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Dental Association"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Julia",
-    "Tran_NamL": "Caplan"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Chase & Chase"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Cohen"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Cohen"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "Justin",
-    "Tran_NamL": "Cooper"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Cowan"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "DANIEL V. LEWIS, D.D.S., A PROFESSIONAL CORPORATION"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-04",
-    "Tran_NamF": "JOSHUA",
-    "Tran_NamL": "DANIELS"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "MARY JANE",
-    "Tran_NamL": "DEAN"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "CHARLOTTE",
-    "Tran_NamL": "DICKSON"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "DIMOCK"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "MICHAEL",
-    "Tran_NamL": "DIMOCK"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Niccolo",
-    "Tran_NamL": "De Luca"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Elissa",
-    "Tran_NamL": "Dennis"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Alan",
-    "Tran_NamL": "Dones"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "EILEEN",
-    "Tran_NamL": "ESPEJO"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "EILEEN",
-    "Tran_NamL": "ESPEJO"
-  },
-  {
-    "Filer_ID": "1381041",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-01-29",
     "Tran_NamF": "JARED",
     "Tran_NamL": "FINE"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "FINN H. TONSBERG D.D.S., INC."
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-25",
-    "Tran_NamF": "RACHEL",
-    "Tran_NamL": "FLYNN"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-25",
-    "Tran_NamF": "LARRY",
-    "Tran_NamL": "FRANZ"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "DARLENE",
-    "Tran_NamL": "FUJII"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "ED",
-    "Tran_NamL": "GERBER"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-07",
-    "Tran_NamF": "JOSEPH",
-    "Tran_NamL": "GREAVES"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "KATHLEEN",
-    "Tran_NamL": "GUSHONEY"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Glupczynski"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "ANN",
-    "Tran_NamL": "HARVEY"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "EDWARD",
-    "Tran_NamL": "HOLT"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "DANA",
-    "Tran_NamL": "HUGHES"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "DANA",
-    "Tran_NamL": "HUGHES"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-16",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Hamlin"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Harcourt"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Healthplus Shared Services"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Thomas J.",
-    "Tran_NamL": "Higgins"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Federation of Professional and Technical Engineers  Local 21 Issues PAC"
   },
   {
     "Filer_ID": "1381041",
@@ -624,87 +15,10 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "JASBIR S. BEDI, D.D.S. FAMILY DENTISTRY"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "JEFFREY P. ALEXANDER DDS, A DENTAL CORPORATION"
-  },
-  {
-    "Filer_ID": "1381041",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-01-29",
     "Tran_NamF": "DAVID W.",
     "Tran_NamL": "JOHNSON"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "John George Democratic Club"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 180.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "REBECCA",
-    "Tran_NamL": "KAPLAN"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-01",
-    "Tran_NamF": "JOHN",
-    "Tran_NamL": "KWAN"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Mitchell",
-    "Tran_NamL": "Karno"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Kamaljeet",
-    "Tran_NamL": "Khaira"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "Kiwi Pediatrics Medical Group  Inc."
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-25",
-    "Tran_NamF": "JOANNE",
-    "Tran_NamL": "LAGOS"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": "JOANNE",
-    "Tran_NamL": "LAGOS"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "JOANNE",
-    "Tran_NamL": "LAGOS"
   },
   {
     "Filer_ID": "1381041",
@@ -716,23 +30,100 @@
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": "AMANDA",
-    "Tran_NamL": "LEONG"
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": "LYNN",
+    "Tran_NamL": "SILVER"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-04-06",
+    "Tran_NamF": "DONALD",
+    "Tran_NamL": "RUDDELL"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "JULIETTE",
-    "Tran_NamL": "LINZER"
+    "Tran_Date": "2016-04-25",
+    "Tran_NamF": "NORMAN",
+    "Tran_NamL": "BURG"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": "BERTRAM",
-    "Tran_NamL": "LUBIN"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-25",
+    "Tran_NamF": "LARRY",
+    "Tran_NamL": "FRANZ"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-25",
+    "Tran_NamF": "JOANNE",
+    "Tran_NamL": "LAGOS"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-04",
+    "Tran_NamF": "JOSHUA",
+    "Tran_NamL": "DANIELS"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-07",
+    "Tran_NamF": "JOSEPH",
+    "Tran_NamL": "GREAVES"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "JEFF",
+    "Tran_NamL": "RITTERMAN"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 80.0,
+    "Tran_Date": "2016-05-14",
+    "Tran_NamF": "LYNN",
+    "Tran_NamL": "SILVER"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "MICHELLE",
+    "Tran_NamL": "AGAZZI"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "VICKI",
+    "Tran_NamL": "ALEXANDER"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "CORAZON B. MANALOTO, D.D.S., INC."
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "RICHARD J.",
+    "Tran_NamL": "CUROTTO"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "MARY JANE",
+    "Tran_NamL": "DEAN"
   },
   {
     "Filer_ID": "1381041",
@@ -744,30 +135,58 @@
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "JESSICA",
-    "Tran_NamL": "LUNA"
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "RONA",
+    "Tran_NamL": "RENNER"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Alan",
-    "Tran_NamL": "Lans"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "SHARON L. ALBRIGHT, D.D.S., INC."
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-25",
+    "Tran_NamF": "SAM",
+    "Tran_NamL": "WONG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "ALAMEDA PEDIATRIC DENTISTRY"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "FINN H. TONSBERG D.D.S., INC."
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "JASBIR S. BEDI, D.D.S. FAMILY DENTISTRY"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Lindheim"
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "JOANNE",
+    "Tran_NamL": "LAGOS"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "JOHN",
-    "Tran_NamL": "MAA"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "AMANDA",
+    "Tran_NamL": "LEONG"
   },
   {
     "Filer_ID": "1381041",
@@ -778,73 +197,73 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "KAREN",
-    "Tran_NamL": "MERYASH"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "NORMA",
+    "Tran_NamL": "SOLARZ"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "KAREN",
-    "Tran_NamL": "MERYASH"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "WENDY P LIAO DDS, INC."
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-07-05",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "MEYERS"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "MEYERS"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-31",
+    "Tran_NamF": "BRUCE",
+    "Tran_NamL": "BOTHWELL"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "ROBERT",
-    "Tran_NamL": "MEYERS"
+    "Tran_Date": "2016-05-31",
+    "Tran_NamF": "MARIANELA M.",
+    "Tran_NamL": "CARTER"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "JEFFREY P. ALEXANDER DDS, A DENTAL CORPORATION"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "PETERSON-CHAN DENTAL GROUP"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-01",
+    "Tran_NamF": "JOHN",
+    "Tran_NamL": "KWAN"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-06",
+    "Tran_NamF": "MARIANNE",
+    "Tran_NamL": "SZETO"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "DANIEL V. LEWIS, D.D.S., A PROFESSIONAL CORPORATION"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Kristine",
-    "Tran_NamL": "Madsen"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Marsom"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Matthiessen"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Mudge"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "OAKLAND POLICE OFFICERS ASSOCIATION POLITICAL ACTION COMMITTEE"
+    "Tran_Date": "2016-06-14",
+    "Tran_NamF": "LULA",
+    "Tran_NamL": "TSEGAY"
   },
   {
     "Filer_ID": "1381041",
@@ -862,6 +281,279 @@
   },
   {
     "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "ED",
+    "Tran_NamL": "GERBER"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "RONA",
+    "Tran_NamL": "RENNER"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "MARTIN",
+    "Tran_NamL": "BOURQUE"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "MELISSA",
+    "Tran_NamL": "CRAGO"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": "BERTRAM",
+    "Tran_NamL": "LUBIN"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "JULIETTE",
+    "Tran_NamL": "LINZER"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "JOANNE",
+    "Tran_NamL": "LAGOS"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 80.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "LYNN",
+    "Tran_NamL": "SILVER"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-25",
+    "Tran_NamF": "RACHEL",
+    "Tran_NamL": "FLYNN"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "AUSINHEILER PHYSICAL THERAPY AND PERSONAL TRAINING, PC"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "EILEEN",
+    "Tran_NamL": "ESPEJO"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "JESSICA",
+    "Tran_NamL": "LUNA"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "VICKI",
+    "Tran_NamL": "ALEXANDER"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "AMERICAN HEART ASSOCIATION, INC."
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "CHARLOTTE",
+    "Tran_NamL": "DICKSON"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "DIMOCK"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "DARLENE",
+    "Tran_NamL": "FUJII"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "ALAMEDA-CONTRA COSTA PHYSICIAN'S COMMITTEE"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "LAURIE",
+    "Tran_NamL": "CAPITELLI"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "KATHLEEN",
+    "Tran_NamL": "GUSHONEY"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "DANA",
+    "Tran_NamL": "HUGHES"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "REBECCA",
+    "Tran_NamL": "KAPLAN"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "LAURA",
+    "Tran_NamL": "VANDUREN"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-03",
+    "Tran_NamF": "JIM",
+    "Tran_NamL": "RATLIFF"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-07-05",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "MEYERS"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 75000.0,
+    "Tran_Date": "2016-07-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "ACTION NOW INITIATIVE"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 75000.0,
+    "Tran_Date": "2016-07-14",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-19",
+    "Tran_NamF": "LEE",
+    "Tran_NamL": "AURICH"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "ANN",
+    "Tran_NamL": "HARVEY"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "WELLSTONE DEMOCRATIC RENEWAL CLUB PAC"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 28750.0,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Dental Association"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "KAREN",
+    "Tran_NamL": "MERYASH"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "DOUGLAS",
+    "Tran_NamL": "YOSHIDA"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "KAREN",
+    "Tran_NamL": "BIXBY"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "SKINNER FOR SENATE 2016"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "EDWARD",
+    "Tran_NamL": "HOLT"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "JEANINE",
+    "Tran_NamL": "SAPERSTEIN"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "CHEZ PANISSE"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "JOHN",
+    "Tran_NamL": "MAA"
+  },
+  {
+    "Filer_ID": "1381041",
     "Tran_Amt1": 1000.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "EDWARD",
@@ -876,31 +568,80 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "PETERSON-CHAN DENTAL GROUP"
+    "Tran_Amt1": 3000.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "STEPHEN",
+    "Tran_NamL": "SILBERSTEIN"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 900.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Philip",
-    "Tran_NamL": "Perkins"
+    "Tran_Amt1": 440955.5,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-19",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "Justin",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "MEYERS"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Boxer"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Niccolo",
+    "Tran_NamL": "De Luca"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 348155.5,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-07",
     "Tran_NamF": "David",
-    "Tran_NamL": "Perry"
+    "Tran_NamL": "Cohen"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Ericac",
+    "Tran_NamL": "Brevet-Stott"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Cheri",
-    "Tran_NamL": "Pies"
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Cohen"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "EILEEN",
+    "Tran_NamL": "ESPEJO"
   },
   {
     "Filer_ID": "1381041",
@@ -911,136 +652,94 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Pyatok"
+    "Tran_Amt1": 487496.5,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-03",
-    "Tran_NamF": "JIM",
-    "Tran_NamL": "RATLIFF"
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Mitchell",
+    "Tran_NamL": "Karno"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "RONA",
-    "Tran_NamL": "RENNER"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "RONA",
-    "Tran_NamL": "RENNER"
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "ROBERT",
+    "Tran_NamL": "MEYERS"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-14",
-    "Tran_NamF": "JEFF",
-    "Tran_NamL": "RITTERMAN"
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Bell"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-06",
-    "Tran_NamF": "DONALD",
-    "Tran_NamL": "RUDDELL"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Randall",
+    "Tran_NamL": "Block"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Andrew",
-    "Tran_NamL": "Rose"
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Frits",
+    "Tran_NamL": "Brevet"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "JEANINE",
-    "Tran_NamL": "SAPERSTEIN"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-25",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-18",
     "Tran_NamF": null,
-    "Tran_NamL": "SHARON L. ALBRIGHT, D.D.S., INC."
+    "Tran_NamL": "Chase & Chase"
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 3000.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "STEPHEN",
-    "Tran_NamL": "SILBERSTEIN"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Harcourt"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "KAREN",
+    "Tran_NamL": "MERYASH"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Cheri",
+    "Tran_NamL": "Pies"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "John George Democratic Club"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": "LYNN",
-    "Tran_NamL": "SILVER"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-05-14",
-    "Tran_NamF": "LYNN",
-    "Tran_NamL": "SILVER"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "LYNN",
-    "Tran_NamL": "SILVER"
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Lindheim"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "SKINNER FOR SENATE 2016"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": "NORMA",
-    "Tran_NamL": "SOLARZ"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-06",
-    "Tran_NamF": "MARIANNE",
-    "Tran_NamL": "SZETO"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 3500.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sheet Metal Workers' International Association Local No. 104 Issues Account"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Spencer"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Marguerite",
-    "Tran_NamL": "Stricklin"
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Perry"
   },
   {
     "Filer_ID": "1381041",
@@ -1051,45 +750,80 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-14",
-    "Tran_NamF": "LULA",
-    "Tran_NamL": "TSEGAY"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 25000.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Kathryn",
-    "Tran_NamL": "Taylor"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "LAURA",
-    "Tran_NamL": "VANDUREN"
+    "Tran_Amt1": 421355.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-28",
+    "Tran_Date": "2016-09-26",
     "Tran_NamF": null,
-    "Tran_NamL": "WELLSTONE DEMOCRATIC RENEWAL CLUB PAC"
-  },
-  {
-    "Filer_ID": "1381041",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "WENDY P LIAO DDS, INC."
+    "Tran_NamL": "Kiwi Pediatrics Medical Group  Inc."
   },
   {
     "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-25",
-    "Tran_NamF": "SAM",
-    "Tran_NamL": "WONG"
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Marguerite",
+    "Tran_NamL": "Stricklin"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 504040.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Elissa",
+    "Tran_NamL": "Dennis"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500000.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "ACTION NOW INITIATIVE"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Matthiessen"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Dental Association"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 588670.5,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKLAND POLICE OFFICERS ASSOCIATION POLITICAL ACTION COMMITTEE"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Pyatok"
   },
   {
     "Filer_ID": "1381041",
@@ -1100,10 +834,206 @@
   },
   {
     "Filer_ID": "1381041",
+    "Tran_Amt1": 3500.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sheet Metal Workers' International Association Local No. 104 Issues Account"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 25000.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Kathryn",
+    "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 10150.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Glupczynski"
+  },
+  {
+    "Filer_ID": "1381041",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "DOUGLAS",
-    "Tran_NamL": "YOSHIDA"
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Andrew",
+    "Tran_NamL": "Rose"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 501546.51,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 900.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Philip",
+    "Tran_NamL": "Perkins"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "AMERICAN HEART ASSOCIATION  INC."
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1362093.5,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Healthplus Shared Services"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 3000.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Federation of Professional and Technical Engineers  Local 21 Issues PAC"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Bret",
+    "Tran_NamL": "Andrews"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 12625.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1348738.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Mudge"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 18275.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Cowan"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Spencer"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500000.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "ACTION NOW INITIATIVE"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "AUSINHEILER PHYSICAL THERAPY AND PERSONAL TRAINING  PC"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Julia",
+    "Tran_NamL": "Caplan"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "DIMOCK"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "DANA",
+    "Tran_NamL": "HUGHES"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Thomas J.",
+    "Tran_NamL": "Higgins"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Kamaljeet",
+    "Tran_NamL": "Khaira"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Kristine",
+    "Tran_NamL": "Madsen"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Marsom"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1525030.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1600030.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
   },
   {
     "Filer_ID": "1381041",
@@ -1114,9 +1044,79 @@
   },
   {
     "Filer_ID": "1381041",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Alan",
+    "Tran_NamL": "Dones"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1556290.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1554290.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Alan",
+    "Tran_NamL": "Lans"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 40000.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 14500.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 15000.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-16",
+    "Tran_NamF": "Janan",
+    "Tran_NamL": "Apaydin"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-16",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Hamlin"
+  },
+  {
+    "Filer_ID": "1381041",
     "Tran_Amt1": 200000.0,
     "Tran_Date": "2016-12-09",
     "Tran_NamF": null,
     "Tran_NamL": "Yes on Proposition V  San Franciscans United to Reduce Diabetes in Children by Imposing 1 Cent Sales Tax on Distribution of Sugary Drinks with Major Funding by Michael Bloomberg & Action Now Iniative"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 11250.0,
+    "Tran_Date": "2016-12-23",
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "BLOOMBERG"
   }
 ]

--- a/build/committee/1381183/contributions/index.json
+++ b/build/committee/1381183/contributions/index.json
@@ -2,16 +2,16 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "ABC Security Service, Inc."
+    "Tran_Date": "2016-01-05",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Reinhold"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "Lawrence",
-    "Tran_NamL": "Abbott"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-02-04",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Lowe"
   },
   {
     "Filer_ID": "1381183",
@@ -22,31 +22,59 @@
   },
   {
     "Filer_ID": "1381183",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-03-29",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Raich"
+  },
+  {
+    "Filer_ID": "1381183",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-13",
+    "Tran_Date": "2016-04-06",
     "Tran_NamF": null,
-    "Tran_NamL": "Andrew Vincent Electrical Contractor"
+    "Tran_NamL": "Golden Associates Landscape Architects"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "James Michael",
-    "Tran_NamL": "Anthony"
+    "Tran_Date": "2016-04-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lily Hu & Associates"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Kate L.",
-    "Tran_NamL": "Arenchild"
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-04-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021 Candidate PAC Small Contributor Committee"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "M. E.",
-    "Tran_NamL": "Arenchild III"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-04-06",
+    "Tran_NamF": "Michele",
+    "Tran_NamL": "Townsend"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-04-19",
+    "Tran_NamF": "Rick",
+    "Tran_NamL": "Caviglia"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 70.0,
+    "Tran_Date": "2016-04-24",
+    "Tran_NamF": "R. Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-04-28",
+    "Tran_NamF": "Kathy",
+    "Tran_NamL": "Neal"
   },
   {
     "Filer_ID": "1381183",
@@ -58,16 +86,16 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-22",
+    "Tran_Date": "2016-05-13",
     "Tran_NamF": null,
-    "Tran_NamL": "BBI-Con, Inc."
+    "Tran_NamL": "ABC Security Service, Inc."
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 70.0,
-    "Tran_Date": "2016-04-24",
-    "Tran_NamF": "R. Michael",
-    "Tran_NamL": "Barnett"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Andrew Vincent Electrical Contractor"
   },
   {
     "Filer_ID": "1381183",
@@ -75,55 +103,6 @@
     "Tran_Date": "2016-05-13",
     "Tran_NamF": "R. Michael",
     "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 36.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 36.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 46.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 36.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Dale",
-    "Tran_NamL": "Baum"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Bauman"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Adam",
-    "Tran_NamL": "Berkowitz"
   },
   {
     "Filer_ID": "1381183",
@@ -134,38 +113,80 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 460.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Bowden"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Bowden"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Brennan"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Metals Coalition PAC"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Mary A.",
-    "Tran_NamL": "Brown"
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Michael J.",
+    "Tran_NamL": "Colbruno"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Mary A.",
-    "Tran_NamL": "Brown"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Dale Sky",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Jeffrey Wayne",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lamumba, Inc."
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Jennie Y.",
+    "Tran_NamL": "Ong"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Emily D.R.",
+    "Tran_NamL": "Pharr"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Robert Z.",
+    "Tran_NamL": "Wasserman"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-05-23",
+    "Tran_NamF": "Ross",
+    "Tran_NamL": "Walker"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "Lauren",
+    "Tran_NamL": "Westreich"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-31",
+    "Tran_NamF": "Lynn",
+    "Tran_NamL": "Silver"
   },
   {
     "Filer_ID": "1381183",
@@ -177,527 +198,9 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": null,
-    "Tran_NamL": "CWAL, Inc."
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Elizabeth J.",
-    "Tran_NamL": "Cabraser"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Metals Coalition PAC"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 600.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Metals Coalition PAC"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Nurses Association PAC (CNA PAC) Small Contributor Committee"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Nurses Association PAC (CNA PAC) Small Contributor Committee"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Real Estate Small Contributor Committee PAC"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-12-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "Campaign for Equality"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Tuij I.",
-    "Tran_NamL": "Catalano"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-04-19",
-    "Tran_NamF": "Rick",
-    "Tran_NamL": "Caviglia"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Rick",
-    "Tran_NamL": "Caviglia"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": -100.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": "Rick",
-    "Tran_NamL": "Caviglia"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Ada",
-    "Tran_NamL": "Chan"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Alexander",
-    "Tran_NamL": "Clemens"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 36.0,
-    "Tran_Date": "2016-11-17",
-    "Tran_NamF": "Paul L.",
-    "Tran_NamL": "Cobb"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Cohen"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Michael J.",
-    "Tran_NamL": "Colbruno"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-11-17",
-    "Tran_NamF": "Michael J.",
-    "Tran_NamL": "Colbruno"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Community Car Wash"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Construction & General Laborers Local 304 PAC Small Contributor Committee"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Copes"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Dalrymple"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "David Canepa for Supervisor 2016"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-12-22",
-    "Tran_NamF": "Niccolo",
-    "Tran_NamL": "De Luca"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-12-22",
-    "Tran_NamF": "Niccolo",
-    "Tran_NamL": "De Luca"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": -100.0,
-    "Tran_Date": "2016-12-31",
-    "Tran_NamF": "Niccolo",
-    "Tran_NamL": "De Luca"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 146.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Decker"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Mary Quinn",
-    "Tran_NamL": "Delaney"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Doff"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Doff"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Jay F.",
-    "Tran_NamL": "Drake"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Jason W.",
-    "Tran_NamL": "Dreisbach"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "Ronald T.",
-    "Tran_NamL": "Dreisbach"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Elana",
-    "Tran_NamL": "Dykewomon"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Echols"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Kathryn Kelly",
-    "Tran_NamL": "Epstein"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Fasttrack Airport Parking, Inc."
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "George",
-    "Tran_NamL": "Feil"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "George",
-    "Tran_NamL": "Feil"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Fine"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Lora Jo",
-    "Tran_NamL": "Foo"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Theodore",
-    "Tran_NamL": "Franklin"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Frattin"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Frattin"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 180.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Friedman"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Noel",
-    "Tran_NamL": "Gallo"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Andres L.",
-    "Tran_NamL": "Garcia"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Eugene",
-    "Tran_NamL": "Gardner"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "David F.",
-    "Tran_NamL": "Gassman"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "George R. Bianchini dba S.G. Farms"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Dale",
-    "Tran_NamL": "Gieringer"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-06",
-    "Tran_NamF": null,
-    "Tran_NamL": "Golden Associates Landscape Architects"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Andrea",
-    "Tran_NamL": "Goldman"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Goldsberry"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Margaret Mary",
-    "Tran_NamL": "Goulart"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-24",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Grace"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Graham"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Greenstein"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Jon P.",
-    "Tran_NamL": "Guhl"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "HNTB Holdings LTD. Federal PAC"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "Carl",
-    "Tran_NamL": "Hackney"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
     "Tran_Date": "2016-06-06",
     "Tran_NamF": "William J.",
     "Tran_NamL": "Harrison"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Thomas W.",
-    "Tran_NamL": "Hart"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "Bella",
-    "Tran_NamL": "Hazzan"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Hutcher"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 600.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Federation of Professional and Technical Engineers Local 21 (IFPTE) T.J. Anthony PAC Fund"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 900.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Federation of Professional and Technical Engineers Local 21 (IFPTE) T.J. Anthony PAC Fund"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Marc",
-    "Tran_NamL": "Janowitz"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "Marc",
-    "Tran_NamL": "Janowitz"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Jeffrey Wayne",
-    "Tran_NamL": "Jones"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Dale Sky",
-    "Tran_NamL": "Jones"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Wayne D.",
-    "Tran_NamL": "Jordan"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Andrew J.",
-    "Tran_NamL": "Junius"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Kathleen",
-    "Tran_NamL": "Kahn"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Kathleen",
-    "Tran_NamL": "Kahn"
   },
   {
     "Filer_ID": "1381183",
@@ -715,374 +218,10 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 20000.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Rebecca D.",
-    "Tran_NamL": "Kaplan"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 24000.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Rebecca D.",
-    "Tran_NamL": "Kaplan"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Kaplan"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-17",
-    "Tran_NamF": "Rebecca D.",
-    "Tran_NamL": "Kaplan"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Martin",
-    "Tran_NamL": "Kaufman"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Kindler"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Jane",
-    "Tran_NamL": "Klein"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": "William L.",
-    "Tran_NamL": "Koziol"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Kuiper"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Eddie",
-    "Tran_NamL": "Kurtz"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lakeside Non-Ferrous Metals"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lamumba, Inc."
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lamumba, Inc."
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lamumba, Inc."
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Cortlin H.",
-    "Tran_NamL": "Lannin"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-12-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "Law Offices of Charles Tillman Ramsey"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Law Offices of James Anthony"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "League of Conservation Voters of the East Bay"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Ann",
-    "Tran_NamL": "Lederer"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Doron",
-    "Tran_NamL": "Levitan"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Jan H.",
-    "Tran_NamL": "Lewis"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "Jan H.",
-    "Tran_NamL": "Lewis"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Lighy"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-06",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lily Hu & Associates"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Katie",
-    "Tran_NamL": "Liu"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-02-04",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Lowe"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 450.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Lowe"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 108.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": "Susan Lee",
-    "Tran_NamL": "Lubeck"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Ludwig"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-19",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Ludwig"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-12-19",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Ludwig"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "William R.",
-    "Tran_NamL": "Lym"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-09",
-    "Tran_NamF": "Kimberly",
-    "Tran_NamL": "Lymen"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lynette Gibson-McElhaney for City Council 2012 Office Holder Committee"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Mar"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 360.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Marte"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Auryn",
-    "Tran_NamL": "McCafferty"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "Abigail",
-    "Tran_NamL": "McCreath"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Mobile Connectory, LLC"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Eduard S.",
-    "Tran_NamL": "Moody"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "NNF Grewal, Inc. dba Subway"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-12-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "Nate Miley for Supervisor 2016"
-  },
-  {
-    "Filer_ID": "1381183",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-06-06",
     "Tran_NamF": null,
     "Tran_NamL": "National Union of Healthcare Workers Candidate Committee for Quality Patient Care and Union Democracy"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "National Union of Healthcare Workers Candidate Committee for Quality Patient Care and Union Democracy"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-04-28",
-    "Tran_NamF": "Kathy",
-    "Tran_NamL": "Neal"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Kathy",
-    "Tran_NamL": "Neal"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Gavin",
-    "Tran_NamL": "Newsom"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Calvin",
-    "Tran_NamL": "Nguyen"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Henry",
-    "Tran_NamL": "Obermayer"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "One Stop Automotive and Collision Center, Inc."
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Jennie Y.",
-    "Tran_NamL": "Ong"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Jennie Y.",
-    "Tran_NamL": "Ong"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Jennie",
-    "Tran_NamL": "Ong"
   },
   {
     "Filer_ID": "1381183",
@@ -1093,24 +232,38 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Pallatto"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Pallatto"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-06",
+    "Tran_NamF": "William E.",
+    "Tran_NamL": "Purcell"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Bryan",
-    "Tran_NamL": "Parker"
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Fasttrack Airport Parking, Inc."
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": "William L.",
+    "Tran_NamL": "Koziol"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "NNF Grewal, Inc. dba Subway"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "One Stop Automotive and Collision Center, Inc."
   },
   {
     "Filer_ID": "1381183",
@@ -1122,142 +275,16 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Sima P.",
-    "Tran_NamL": "Patel"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "William B.",
-    "Tran_NamL": "Patterson"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 146.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Geoffrey R.",
-    "Tran_NamL": "Pete"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Erik",
-    "Tran_NamL": "Peterson"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Emily D.R.",
-    "Tran_NamL": "Pharr"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "Pho Anh Dao Alameda"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Aimee",
-    "Tran_NamL": "Pomerleau"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-06",
-    "Tran_NamF": "William E.",
-    "Tran_NamL": "Purcell"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "William E.",
-    "Tran_NamL": "Purcell"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Mon Kil",
-    "Tran_NamL": "Quan"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-03-29",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Raich"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Raich"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Leonard",
-    "Tran_NamL": "Raphael"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-01-05",
-    "Tran_NamF": "Sue",
-    "Tran_NamL": "Reinhold"
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": "Paramjit Kaur",
+    "Tran_NamL": "Singh"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Sheryl",
-    "Tran_NamL": "Reuben"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "Rob Bonta for Assembly 2016"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 180.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "Paul",
-    "Tran_NamL": "Robertson"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Loushana",
-    "Tran_NamL": "Rose"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Kevin H.",
-    "Tran_NamL": "Rose"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Mark B.",
-    "Tran_NamL": "Rosin"
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Greenstein"
   },
   {
     "Filer_ID": "1381183",
@@ -1268,41 +295,6 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Ross"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-17",
-    "Tran_NamF": "Sal",
-    "Tran_NamL": "Rosselli"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Rossoff"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 108.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Jaime",
-    "Tran_NamL": "Santos"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Jaime",
-    "Tran_NamL": "Santos"
-  },
-  {
-    "Filer_ID": "1381183",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-06-22",
     "Tran_NamF": "Guy",
@@ -1310,115 +302,52 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Robert A. D.",
-    "Tran_NamL": "Schwartz"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Scott Haggerty for Supervisor 2016"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-04-06",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021 Candidate PAC Small Contributor Committee"
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Friedman"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Sheidlower"
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Wolmark"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
+    "Tran_Amt1": 360.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Marte"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-06-24",
     "Tran_NamF": "Paul",
-    "Tran_NamL": "Siegel"
+    "Tran_NamL": "Robertson"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 460.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Daniel M.",
-    "Tran_NamL": "Siegel"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 240.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Daniel M.",
-    "Tran_NamL": "Siegel"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sign Pictorial & Display"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "Lynn",
-    "Tran_NamL": "Silver"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Karl",
-    "Tran_NamL": "Simmons"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Brennan"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": "Paramjit Kaur",
-    "Tran_NamL": "Singh"
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Jon P.",
+    "Tran_NamL": "Guhl"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Nidhi",
-    "Tran_NamL": "Singh"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Bernestine",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Jeff",
-    "Tran_NamL": "Starkovich"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": "Susan C.",
-    "Tran_NamL": "Stephenson"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Betty",
-    "Tran_NamL": "Stone"
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "William E.",
+    "Tran_NamL": "Purcell"
   },
   {
     "Filer_ID": "1381183",
@@ -1436,164 +365,17 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-07",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
     "Tran_NamF": null,
-    "Tran_NamL": "Sunflower Alliance"
+    "Tran_NamL": "Wildcat, LLC"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Sandre R.",
-    "Tran_NamL": "Swanson"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Sandre R.",
-    "Tran_NamL": "Swanson"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Sandre R.",
-    "Tran_NamL": "Swanson"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Swift"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Scott",
-    "Tran_NamL": "Taylor"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Jean",
-    "Tran_NamL": "Tepperman"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "The Milo Group of California, Inc."
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-04-06",
-    "Tran_NamF": "Michele",
-    "Tran_NamL": "Townsend"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Larry",
-    "Tran_NamL": "Tramutola"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "UNITE HERE Tip State & Local Fund"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Sara E.",
-    "Tran_NamL": "Ubelhart"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Laurie",
-    "Tran_NamL": "Umeh"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Unity PAC , Alameda Labor Council AFL-CIO"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Tikisha",
-    "Tran_NamL": "Upshaw-Ong"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Carlos",
-    "Tran_NamL": "Uribe"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Vail"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Vail"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Vail"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-17",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Vail"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-12-21",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Vail"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-29",
-    "Tran_NamF": "Les",
-    "Tran_NamL": "Vogel"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 180.0,
-    "Tran_Date": "2016-05-23",
-    "Tran_NamF": "Ross",
-    "Tran_NamL": "Walker"
+    "Tran_Amt1": 108.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Jaime",
+    "Tran_NamL": "Santos"
   },
   {
     "Filer_ID": "1381183",
@@ -1604,10 +386,514 @@
   },
   {
     "Filer_ID": "1381183",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Nurses Association PAC (CNA PAC) Small Contributor Committee"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "James Michael",
+    "Tran_NamL": "Anthony"
+  },
+  {
+    "Filer_ID": "1381183",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Robert Z.",
-    "Tran_NamL": "Wasserman"
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Mary A.",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Mary Quinn",
+    "Tran_NamL": "Delaney"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Jason W.",
+    "Tran_NamL": "Dreisbach"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "David F.",
+    "Tran_NamL": "Gassman"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "George R. Bianchini dba S.G. Farms"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "HNTB Holdings LTD. Federal PAC"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 20000.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Rebecca D.",
+    "Tran_NamL": "Kaplan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Kindler"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lamumba, Inc."
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Law Offices of James Anthony"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Gavin",
+    "Tran_NamL": "Newsom"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Jennie Y.",
+    "Tran_NamL": "Ong"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "William B.",
+    "Tran_NamL": "Patterson"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Loushana",
+    "Tran_NamL": "Rose"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Mark B.",
+    "Tran_NamL": "Rosin"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Ross"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Paul",
+    "Tran_NamL": "Siegel"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Nidhi",
+    "Tran_NamL": "Singh"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Sandre R.",
+    "Tran_NamL": "Swanson"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Larry",
+    "Tran_NamL": "Tramutola"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Jim",
+    "Tran_NamL": "Wunderman"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "Ronald T.",
+    "Tran_NamL": "Dreisbach"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Graham"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-29",
+    "Tran_NamF": "Les",
+    "Tran_NamL": "Vogel"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Elizabeth J.",
+    "Tran_NamL": "Cabraser"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Doff"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Auryn",
+    "Tran_NamL": "McCafferty"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Sheidlower"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Karl",
+    "Tran_NamL": "Simmons"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Andres L.",
+    "Tran_NamL": "Garcia"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Kathleen",
+    "Tran_NamL": "Kahn"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Abigail",
+    "Tran_NamL": "McCreath"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Metals Coalition PAC"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 36.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Feil"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "BBI-Con, Inc."
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Bella",
+    "Tran_NamL": "Hazzan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Grace"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 146.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Decker"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Rossoff"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Kathy",
+    "Tran_NamL": "Neal"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 36.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Elana",
+    "Tran_NamL": "Dykewomon"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Henry",
+    "Tran_NamL": "Obermayer"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Tikisha",
+    "Tran_NamL": "Upshaw-Ong"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 46.0,
+    "Tran_Date": "2016-09-05",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Winters"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "CWAL, Inc."
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Raich"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Jeff",
+    "Tran_NamL": "Starkovich"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Vail"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sunflower Alliance"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Cohen"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Feil"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Jaime",
+    "Tran_NamL": "Santos"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 46.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lakeside Non-Ferrous Metals"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Bernestine",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Sandre R.",
+    "Tran_NamL": "Swanson"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Zadik"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 460.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Bowden"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Community Car Wash"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Thomas W.",
+    "Tran_NamL": "Hart"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Kathleen",
+    "Tran_NamL": "Kahn"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Jan H.",
+    "Tran_NamL": "Lewis"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Eduard S.",
+    "Tran_NamL": "Moody"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Jennie",
+    "Tran_NamL": "Ong"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 146.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Geoffrey R.",
+    "Tran_NamL": "Pete"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 460.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Daniel M.",
+    "Tran_NamL": "Siegel"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Sandre R.",
+    "Tran_NamL": "Swanson"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Vail"
   },
   {
     "Filer_ID": "1381183",
@@ -1618,6 +904,13 @@
   },
   {
     "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Fine"
+  },
+  {
+    "Filer_ID": "1381183",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-21",
     "Tran_NamF": "Joel",
@@ -1625,24 +918,136 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": "Lauren",
-    "Tran_NamL": "Westreich"
+    "Tran_Amt1": 36.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Berkowitz"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Wildcat, LLC"
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Gardner"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 46.0,
-    "Tran_Date": "2016-09-05",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Winters"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Bauman"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Bowden"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Ada",
+    "Tran_NamL": "Chan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Doff"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Noel",
+    "Tran_NamL": "Gallo"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Andrea",
+    "Tran_NamL": "Goldman"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Margaret Mary",
+    "Tran_NamL": "Goulart"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 24000.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Rebecca D.",
+    "Tran_NamL": "Kaplan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kaplan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Lighy"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "William R.",
+    "Tran_NamL": "Lym"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lynette Gibson-McElhaney for City Council 2012 Office Holder Committee"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mobile Connectory, LLC"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Robert A. D.",
+    "Tran_NamL": "Schwartz"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 240.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Daniel M.",
+    "Tran_NamL": "Siegel"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sara E.",
+    "Tran_NamL": "Ubelhart"
   },
   {
     "Filer_ID": "1381183",
@@ -1654,16 +1059,450 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Wolmark"
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Young"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Jim",
-    "Tran_NamL": "Wunderman"
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Leonard",
+    "Tran_NamL": "Raphael"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "David Canepa for Supervisor 2016"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Marc",
+    "Tran_NamL": "Janowitz"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Jane",
+    "Tran_NamL": "Klein"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "League of Conservation Voters of the East Bay"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Vail"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Lawrence",
+    "Tran_NamL": "Abbott"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Dale",
+    "Tran_NamL": "Baum"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Lora Jo",
+    "Tran_NamL": "Foo"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Wayne D.",
+    "Tran_NamL": "Jordan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Swift"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Eddie",
+    "Tran_NamL": "Kurtz"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Ann",
+    "Tran_NamL": "Lederer"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Bryan",
+    "Tran_NamL": "Parker"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Marc",
+    "Tran_NamL": "Janowitz"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Rob Bonta for Assembly 2016"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Federation of Professional and Technical Engineers Local 21 (IFPTE) T.J. Anthony PAC Fund"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Erik",
+    "Tran_NamL": "Peterson"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "UNITE HERE Tip State & Local Fund"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Dalrymple"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Ludwig"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Kate L.",
+    "Tran_NamL": "Arenchild"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "M. E.",
+    "Tran_NamL": "Arenchild III"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Real Estate Small Contributor Committee PAC"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Dale",
+    "Tran_NamL": "Gieringer"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Hutcher"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Martin",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Katie",
+    "Tran_NamL": "Liu"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Calvin",
+    "Tran_NamL": "Nguyen"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "Pho Anh Dao Alameda"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Aimee",
+    "Tran_NamL": "Pomerleau"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Mon Kil",
+    "Tran_NamL": "Quan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sign Pictorial & Display"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Yesica",
+    "Tran_NamL": "Zhang"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Mary A.",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Mar"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Sima P.",
+    "Tran_NamL": "Patel"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Unity PAC , Alameda Labor Council AFL-CIO"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Carlos",
+    "Tran_NamL": "Uribe"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 108.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Susan Lee",
+    "Tran_NamL": "Lubeck"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Jean",
+    "Tran_NamL": "Tepperman"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 80.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Kathryn Kelly",
+    "Tran_NamL": "Epstein"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Goldsberry"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lamumba, Inc."
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Scott Haggerty for Supervisor 2016"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Rick",
+    "Tran_NamL": "Caviglia"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Theodore",
+    "Tran_NamL": "Franklin"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Kuiper"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Lowe"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Pallatto"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Pallatto"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Laurie",
+    "Tran_NamL": "Umeh"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Alexander",
+    "Tran_NamL": "Clemens"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Frattin"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Frattin"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Betty",
+    "Tran_NamL": "Stone"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Tuij I.",
+    "Tran_NamL": "Catalano"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Jay F.",
+    "Tran_NamL": "Drake"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Andrew J.",
+    "Tran_NamL": "Junius"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Cortlin H.",
+    "Tran_NamL": "Lannin"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Doron",
+    "Tran_NamL": "Levitan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Sheryl",
+    "Tran_NamL": "Reuben"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Kevin H.",
+    "Tran_NamL": "Rose"
   },
   {
     "Filer_ID": "1381183",
@@ -1674,23 +1513,184 @@
   },
   {
     "Filer_ID": "1381183",
+    "Tran_Amt1": -100.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Rick",
+    "Tran_NamL": "Caviglia"
+  },
+  {
+    "Filer_ID": "1381183",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Young"
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Copes"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-09",
+    "Tran_NamF": "Kimberly",
+    "Tran_NamL": "Lymen"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Construction & General Laborers Local 304 PAC Small Contributor Committee"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Echols"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "Carl",
+    "Tran_NamL": "Hackney"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "Susan C.",
+    "Tran_NamL": "Stephenson"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 36.0,
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": "Paul L.",
+    "Tran_NamL": "Cobb"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": "Michael J.",
+    "Tran_NamL": "Colbruno"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": "Rebecca D.",
+    "Tran_NamL": "Kaplan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": "Sal",
+    "Tran_NamL": "Rosselli"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Zadik"
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "The Milo Group of California, Inc."
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Yesica",
-    "Tran_NamL": "Zhang"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-17",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Vail"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 900.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Federation of Professional and Technical Engineers Local 21 (IFPTE) T.J. Anthony PAC Fund"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "Jan H.",
+    "Tran_NamL": "Lewis"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-19",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Ludwig"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Nurses Association PAC (CNA PAC) Small Contributor Committee"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "National Union of Healthcare Workers Candidate Committee for Quality Patient Care and Union Democracy"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-12-19",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Ludwig"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-12-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "Law Offices of Charles Tillman Ramsey"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-12-21",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Vail"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-12-22",
+    "Tran_NamF": "Niccolo",
+    "Tran_NamL": "De Luca"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-12-22",
+    "Tran_NamF": "Niccolo",
+    "Tran_NamL": "De Luca"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-12-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "Campaign for Equality"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": -100.0,
+    "Tran_Date": "2016-12-31",
+    "Tran_NamF": "Niccolo",
+    "Tran_NamL": "De Luca"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-12-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "Nate Miley for Supervisor 2016"
   }
 ]

--- a/build/committee/1381183/contributions/index.json
+++ b/build/committee/1381183/contributions/index.json
@@ -71,13 +71,6 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 46.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1381183",
     "Tran_Amt1": 36.0,
     "Tran_Date": "2016-05-13",
     "Tran_NamF": "R. Michael",
@@ -94,6 +87,13 @@
     "Filer_ID": "1381183",
     "Tran_Amt1": 36.0,
     "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 46.0,
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Barnett"
   },
@@ -127,13 +127,6 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Bowden"
-  },
-  {
-    "Filer_ID": "1381183",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-05-13",
     "Tran_NamF": "Carolyn",
@@ -148,6 +141,13 @@
   },
   {
     "Filer_ID": "1381183",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Bowden"
+  },
+  {
+    "Filer_ID": "1381183",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-06-27",
     "Tran_NamF": "Steven",
@@ -155,15 +155,15 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-22",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
     "Tran_NamF": "Mary A.",
     "Tran_NamL": "Brown"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-22",
     "Tran_NamF": "Mary A.",
     "Tran_NamL": "Brown"
   },
@@ -204,15 +204,15 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-28",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-06-29",
     "Tran_NamF": null,
     "Tran_NamL": "California Nurses Association PAC (CNA PAC) Small Contributor Committee"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-06-29",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-28",
     "Tran_NamF": null,
     "Tran_NamL": "California Nurses Association PAC (CNA PAC) Small Contributor Committee"
   },
@@ -246,15 +246,15 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": -100.0,
-    "Tran_Date": "2016-11-08",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
     "Tran_NamF": "Rick",
     "Tran_NamL": "Caviglia"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-31",
+    "Tran_Amt1": -100.0,
+    "Tran_Date": "2016-11-08",
     "Tran_NamF": "Rick",
     "Tran_NamL": "Caviglia"
   },
@@ -288,15 +288,15 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-11-17",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-13",
     "Tran_NamF": "Michael J.",
     "Tran_NamL": "Colbruno"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-13",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-11-17",
     "Tran_NamF": "Michael J.",
     "Tran_NamL": "Colbruno"
   },
@@ -337,13 +337,6 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": -100.0,
-    "Tran_Date": "2016-12-31",
-    "Tran_NamF": "Niccolo",
-    "Tran_NamL": "De Luca"
-  },
-  {
-    "Filer_ID": "1381183",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-12-22",
     "Tran_NamF": "Niccolo",
@@ -353,6 +346,13 @@
     "Filer_ID": "1381183",
     "Tran_Amt1": 400.0,
     "Tran_Date": "2016-12-22",
+    "Tran_NamF": "Niccolo",
+    "Tran_NamL": "De Luca"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": -100.0,
+    "Tran_Date": "2016-12-31",
     "Tran_NamF": "Niccolo",
     "Tran_NamL": "De Luca"
   },
@@ -393,16 +393,16 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "Ronald T.",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Jason W.",
     "Tran_NamL": "Dreisbach"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Jason W.",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "Ronald T.",
     "Tran_NamL": "Dreisbach"
   },
   {
@@ -470,14 +470,14 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
+    "Tran_Amt1": 120.0,
     "Tran_Date": "2016-11-03",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Frattin"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 120.0,
+    "Tran_Amt1": 60.0,
     "Tran_Date": "2016-11-03",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Frattin"
@@ -646,14 +646,14 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-13",
+    "Tran_Date": "2016-09-26",
     "Tran_NamF": "Marc",
     "Tran_NamL": "Janowitz"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-26",
+    "Tran_Date": "2016-10-13",
     "Tran_NamF": "Marc",
     "Tran_NamL": "Janowitz"
   },
@@ -687,13 +687,6 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Kathleen",
-    "Tran_NamL": "Kahn"
-  },
-  {
-    "Filer_ID": "1381183",
     "Tran_Amt1": 60.0,
     "Tran_Date": "2016-08-01",
     "Tran_NamF": "Kathleen",
@@ -701,10 +694,10 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 24000.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Rebecca D.",
-    "Tran_NamL": "Kaplan"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Kathleen",
+    "Tran_NamL": "Kahn"
   },
   {
     "Filer_ID": "1381183",
@@ -724,6 +717,13 @@
     "Filer_ID": "1381183",
     "Tran_Amt1": 20000.0,
     "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Rebecca D.",
+    "Tran_NamL": "Kaplan"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 24000.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Rebecca D.",
     "Tran_NamL": "Kaplan"
   },
@@ -792,13 +792,6 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lamumba, Inc."
-  },
-  {
-    "Filer_ID": "1381183",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-05-13",
     "Tran_NamF": null,
@@ -808,6 +801,13 @@
     "Filer_ID": "1381183",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-06-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lamumba, Inc."
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-29",
     "Tran_NamF": null,
     "Tran_NamL": "Lamumba, Inc."
   },
@@ -856,14 +856,14 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-18",
+    "Tran_Date": "2016-09-19",
     "Tran_NamF": "Jan H.",
     "Tran_NamL": "Lewis"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-19",
+    "Tran_Date": "2016-11-18",
     "Tran_NamF": "Jan H.",
     "Tran_NamL": "Lewis"
   },
@@ -912,14 +912,14 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-19",
+    "Tran_Date": "2016-10-19",
     "Tran_NamF": "Mark",
     "Tran_NamL": "Ludwig"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
+    "Tran_Date": "2016-11-19",
     "Tran_NamF": "Mark",
     "Tran_NamL": "Ludwig"
   },
@@ -1009,13 +1009,6 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "National Union of Healthcare Workers Candidate Committee for Quality Patient Care and Union Democracy"
-  },
-  {
-    "Filer_ID": "1381183",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-06-06",
     "Tran_NamF": null,
@@ -1023,15 +1016,22 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Kathy",
-    "Tran_NamL": "Neal"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "National Union of Healthcare Workers Candidate Committee for Quality Patient Care and Union Democracy"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 120.0,
     "Tran_Date": "2016-04-28",
+    "Tran_NamF": "Kathy",
+    "Tran_NamL": "Neal"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-31",
     "Tran_NamF": "Kathy",
     "Tran_NamL": "Neal"
   },
@@ -1065,6 +1065,13 @@
   },
   {
     "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-13",
+    "Tran_NamF": "Jennie Y.",
+    "Tran_NamL": "Ong"
+  },
+  {
+    "Filer_ID": "1381183",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "Jennie Y.",
@@ -1079,13 +1086,6 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-13",
-    "Tran_NamF": "Jennie Y.",
-    "Tran_NamL": "Ong"
-  },
-  {
-    "Filer_ID": "1381183",
     "Tran_Amt1": 1400.0,
     "Tran_Date": "2016-06-06",
     "Tran_NamF": null,
@@ -1093,14 +1093,14 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
+    "Tran_Amt1": 60.0,
     "Tran_Date": "2016-10-31",
     "Tran_NamF": "Elizabeth",
     "Tran_NamL": "Pallatto"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-31",
     "Tran_NamF": "Elizabeth",
     "Tran_NamL": "Pallatto"
@@ -1171,14 +1171,14 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-27",
+    "Tran_Date": "2016-06-06",
     "Tran_NamF": "William E.",
     "Tran_NamL": "Purcell"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-06",
+    "Tran_Date": "2016-06-27",
     "Tran_NamF": "William E.",
     "Tran_NamL": "Purcell"
   },
@@ -1338,9 +1338,9 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 240.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Daniel M.",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Paul",
     "Tran_NamL": "Siegel"
   },
   {
@@ -1352,9 +1352,9 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Paul",
+    "Tran_Amt1": 240.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Daniel M.",
     "Tran_NamL": "Siegel"
   },
   {
@@ -1443,8 +1443,8 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-30",
     "Tran_NamF": "Sandre R.",
     "Tran_NamL": "Swanson"
   },
@@ -1457,8 +1457,8 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-30",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
     "Tran_NamF": "Sandre R.",
     "Tran_NamL": "Swanson"
   },
@@ -1548,15 +1548,22 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-26",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
     "Tran_NamF": "Mary",
     "Tran_NamL": "Vail"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Vail"
+  },
+  {
+    "Filer_ID": "1381183",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-26",
     "Tran_NamF": "Mary",
     "Tran_NamL": "Vail"
   },
@@ -1571,13 +1578,6 @@
     "Filer_ID": "1381183",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-12-21",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Vail"
-  },
-  {
-    "Filer_ID": "1381183",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-19",
     "Tran_NamF": "Mary",
     "Tran_NamL": "Vail"
   },
@@ -1605,14 +1605,14 @@
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-19",
+    "Tran_Date": "2016-05-13",
     "Tran_NamF": "Robert Z.",
     "Tran_NamL": "Wasserman"
   },
   {
     "Filer_ID": "1381183",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-13",
+    "Tran_Date": "2016-09-19",
     "Tran_NamF": "Robert Z.",
     "Tran_NamL": "Wasserman"
   },
@@ -1639,15 +1639,15 @@
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-09-24",
+    "Tran_Amt1": 46.0,
+    "Tran_Date": "2016-09-05",
     "Tran_NamF": "John",
     "Tran_NamL": "Winters"
   },
   {
     "Filer_ID": "1381183",
-    "Tran_Amt1": 46.0,
-    "Tran_Date": "2016-09-05",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "John",
     "Tran_NamL": "Winters"
   },

--- a/build/committee/1382408/contributions/index.json
+++ b/build/committee/1382408/contributions/index.json
@@ -1,997 +1,10 @@
 [
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "57th Avenue LLC"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "AJE Partners"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Abel"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Abrams"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Jon",
-    "Tran_NamL": "Adams"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Jon",
-    "Tran_NamL": "Adams"
-  },
-  {
-    "Filer_ID": "1382408",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-02-24",
     "Tran_NamF": "Hatzune",
     "Tran_NamL": "Aguilar"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Alpha Design & Construction"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Ronald",
-    "Tran_NamL": "Alterman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Luis",
-    "Tran_NamL": "Amezcua"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 65.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Luis",
-    "Tran_NamL": "Amezcua"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-09",
-    "Tran_NamF": "Tim",
-    "Tran_NamL": "Anderson"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Jasmin",
-    "Tran_NamL": "Ansar"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Anthony"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Evan",
-    "Tran_NamL": "Arteaga"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "BBI Construction"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Brett",
-    "Tran_NamL": "Badelle"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Mia",
-    "Tran_NamL": "Baldwin"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": "Brandon",
-    "Tran_NamL": "Baranco"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 57.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Bass"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bay Area Citizens PAC - All Purpose Account"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 35.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Judy",
-    "Tran_NamL": "Belcher"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Benson"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-21",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Berg"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-04-28",
-    "Tran_NamF": "Steve",
-    "Tran_NamL": "Berley"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "Anthony",
-    "Tran_NamL": "Bernhardt"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "Anthony",
-    "Tran_NamL": "Bernhardt"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bliss"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "Helen",
-    "Tran_NamL": "Bloch"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-25",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Bonta"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Fred",
-    "Tran_NamL": "Booker"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Fred",
-    "Tran_NamL": "Booker"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Bowden"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Boyd"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Roland",
-    "Tran_NamL": "Brandel"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Craig",
-    "Tran_NamL": "Brandt"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bricklayers and Allied Craftworkers Local No. 3 Political Action Committee"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Shelagh",
-    "Tran_NamL": "Broderson"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Shelagh",
-    "Tran_NamL": "Broderson"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-24",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Brothers"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Elize",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-07-03",
-    "Tran_NamF": "Gloria",
-    "Tran_NamL": "Bruce"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-05-19",
-    "Tran_NamF": "Pamela",
-    "Tran_NamL": "Burdman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Larry",
-    "Tran_NamL": "Bush"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Jerome",
-    "Tran_NamL": "Buttrick"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Real Estate Political Action Committee - California Association of Realtors"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Brooke",
-    "Tran_NamL": "Carpenter"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Cassidy"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": "Gregory",
-    "Tran_NamL": "Chan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Sanford",
-    "Tran_NamL": "Chan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Chen"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-26",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Chessin"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Chessin"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Chia"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Ener",
-    "Tran_NamL": "Chiu"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-22",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Cohen"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "Construction & General Laborers Local Union 304 PAC"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Marsha",
-    "Tran_NamL": "Converse"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Sharon",
-    "Tran_NamL": "Cornu-Toney"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Judith",
-    "Tran_NamL": "Cox"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Janet",
-    "Tran_NamL": "Cox"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Judith",
-    "Tran_NamL": "Cox"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-02",
-    "Tran_NamF": "Francesca",
-    "Tran_NamL": "Cunningham"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Cunningham"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Glen",
-    "Tran_NamL": "Dahlbacka"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Nara",
-    "Tran_NamL": "Dahlbacka"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Dolores",
-    "Tran_NamL": "Dalton"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-01",
-    "Tran_NamF": "Gia",
-    "Tran_NamL": "Daniller"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "David Wedding Dress"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "DeVico"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Deangelo"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Andrew",
-    "Tran_NamL": "Deangelo"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Delaney"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Francisco",
-    "Tran_NamL": "Devries"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-21",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Dockendorf"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Dockendorf"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Diane",
-    "Tran_NamL": "Doucette"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Drury"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Echols"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Julie",
-    "Tran_NamL": "Edwards"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Nico",
-    "Tran_NamL": "Enea"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Bob",
-    "Tran_NamL": "Epstein"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-05-22",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Fickes"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Debbie",
-    "Tran_NamL": "Fischer"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-08",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Fishman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Stuart",
-    "Tran_NamL": "Flashman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Lora Jo",
-    "Tran_NamL": "Foo"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Friedman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Danielle",
-    "Tran_NamL": "Fugere"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Eugene",
-    "Tran_NamL": "Gardner"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Gerry",
-    "Tran_NamL": "Garzon"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Ed",
-    "Tran_NamL": "Gerber"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Ed",
-    "Tran_NamL": "Gerber"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Dale",
-    "Tran_NamL": "Gieringer"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Dale",
-    "Tran_NamL": "Gieringer"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Ernest",
-    "Tran_NamL": "Goitein"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Gold Coast Health, Inc."
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Golden Gate Gen"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Gooding"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Grace"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Green Rush Consulting"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Greenberg"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-02-25",
-    "Tran_NamF": "Allen",
-    "Tran_NamL": "Grodsky"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Allen",
-    "Tran_NamL": "Grodsky"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Tracy",
-    "Tran_NamL": "Grubbs"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Abel",
-    "Tran_NamL": "Guillen"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Andy",
-    "Tran_NamL": "Gunther"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-05",
-    "Tran_NamF": "Sophie",
-    "Tran_NamL": "Hahn"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Sophie",
-    "Tran_NamL": "Hahn"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "Earl",
-    "Tran_NamL": "Hamlin"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Alan",
-    "Tran_NamL": "Harper"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-02",
-    "Tran_NamF": "Ann",
-    "Tran_NamL": "Harvey"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Arthur",
-    "Tran_NamL": "Haubenstock"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Paula",
-    "Tran_NamL": "Hawthorn"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "C. J.",
-    "Tran_NamL": "Hirschfield"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Hochschild"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Hofer"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Mallory",
-    "Tran_NamL": "Holt"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-05",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Hood"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 420.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Houts"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-01",
-    "Tran_NamF": "Lisa",
-    "Tran_NamL": "Hoyos"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Hsu"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Sean",
-    "Tran_NamL": "Hung"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "IAFF, Local 55 Political Action Committee"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-07-20",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Ingram"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-07-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Brotherhood of Electrical Workers Local 595 PAC"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-09",
-    "Tran_NamF": "Lisa",
-    "Tran_NamL": "Jaicks"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Lisa",
-    "Tran_NamL": "Jaicks"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-02-25",
-    "Tran_NamF": "Roger",
-    "Tran_NamL": "Janeway"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Marc",
-    "Tran_NamL": "Janowitz"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-24",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Jenner"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Jetty Marketing"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Jewett"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Jones"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Laniece",
-    "Tran_NamL": "Jones"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Sheila",
-    "Tran_NamL": "Jordan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Wayne",
-    "Tran_NamL": "Jordan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Nicholas",
-    "Tran_NamL": "Josefowitz"
   },
   {
     "Filer_ID": "1382408",
@@ -1002,356 +15,6 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-02-25",
-    "Tran_NamF": "Noah",
-    "Tran_NamL": "Kalb"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-14",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Kalb"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Valarie",
-    "Tran_NamL": "Kalb"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Kalb"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Kalb"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-25",
-    "Tran_NamF": "Ann",
-    "Tran_NamL": "Kalb-Kip"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Ann",
-    "Tran_NamL": "Kalb-Kip"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Ann",
-    "Tran_NamL": "Kalb-Kip"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Leslie",
-    "Tran_NamL": "Katz"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Katz"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Kaufman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Keenan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Keenan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Andy",
-    "Tran_NamL": "Kelley"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Alex",
-    "Tran_NamL": "Kelley"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Kernighan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Clinton",
-    "Tran_NamL": "Killian"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Steve",
-    "Tran_NamL": "Kolm"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Earl",
-    "Tran_NamL": "Koteen"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "Earl",
-    "Tran_NamL": "Koteen"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 600.0,
-    "Tran_Date": "2016-12-31",
-    "Tran_NamF": "Janet",
-    "Tran_NamL": "Kranzberg"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 136.0,
-    "Tran_Date": "2016-05-22",
-    "Tran_NamF": "George",
-    "Tran_NamL": "Krevsky"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Jack",
-    "Tran_NamL": "Kurzweil"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Sara",
-    "Tran_NamL": "Kwan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Norman",
-    "Tran_NamL": "La Force"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Sam",
-    "Tran_NamL": "Lauter"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Carter",
-    "Tran_NamL": "Lavin"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Lawson"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "League of Conservation Voters"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Leno"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-19",
-    "Tran_NamF": "Shira",
-    "Tran_NamL": "Levine"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Claire",
-    "Tran_NamL": "Levine"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Henry",
-    "Tran_NamL": "Levy"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Kent",
-    "Tran_NamL": "Lewandowski"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Jiao",
-    "Tran_NamL": "Li"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Moses",
-    "Tran_NamL": "Libitzky"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lighthouse Public Affairs, LLC"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Gordon",
-    "Tran_NamL": "Link"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Gordon",
-    "Tran_NamL": "Link"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Spencer",
-    "Tran_NamL": "Liolios"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "Little"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Lowe"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Rafael",
-    "Tran_NamL": "Mandelman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Francisco",
-    "Tran_NamL": "Mariscal"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Melvyn",
-    "Tran_NamL": "Mark"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Honey",
-    "Tran_NamL": "Mark"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-24",
-    "Tran_NamF": "Esther",
-    "Tran_NamL": "Marks"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Marks"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Marsteller"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 136.0,
-    "Tran_Date": "2016-06-04",
-    "Tran_NamF": "Suzanne",
-    "Tran_NamL": "Mason"
-  },
-  {
-    "Filer_ID": "1382408",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-02-24",
     "Tran_NamF": "Richard",
@@ -1359,10 +22,136 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-05-05",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "McCarthy"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-02-25",
+    "Tran_NamF": "Allen",
+    "Tran_NamL": "Grodsky"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-02-25",
+    "Tran_NamF": "Roger",
+    "Tran_NamL": "Janeway"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-02-25",
+    "Tran_NamF": "Noah",
+    "Tran_NamL": "Kalb"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-25",
+    "Tran_NamF": "Ann",
+    "Tran_NamL": "Kalb-Kip"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-02-28",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Woo"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-03",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sidley"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-17",
+    "Tran_NamF": "Cheri",
+    "Tran_NamL": "Shankar"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-18",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Stephens"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-24",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Brothers"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-24",
+    "Tran_NamF": "Michele",
+    "Tran_NamL": "Townsend"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-31",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Piper"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-21",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Berg"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-04-21",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Dockendorf"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-04-25",
+    "Tran_NamF": "Roland",
+    "Tran_NamL": "Washington"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-04-28",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Berley"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-28",
+    "Tran_NamF": "Harmon",
+    "Tran_NamL": "Schragge"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California Carpenters Regional Council Small Contributor Committee"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-01",
+    "Tran_NamF": "Gia",
+    "Tran_NamL": "Daniller"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-01",
+    "Tran_NamF": "Lisa",
+    "Tran_NamL": "Hoyos"
   },
   {
     "Filer_ID": "1382408",
@@ -1373,10 +162,52 @@
   },
   {
     "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-01",
+    "Tran_NamF": "Rebecca",
+    "Tran_NamL": "Prozan"
+  },
+  {
+    "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "R.B.",
-    "Tran_NamL": "Mendelson"
+    "Tran_Date": "2016-05-01",
+    "Tran_NamF": "Debra",
+    "Tran_NamL": "Walker"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-04",
+    "Tran_NamF": "Jane",
+    "Tran_NamL": "Morrison"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-05-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "Operating Engineers Local Union No. 3, District 20 PAC"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-05",
+    "Tran_NamF": "Sophie",
+    "Tran_NamL": "Hahn"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-05",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Hood"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-05",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "McCarthy"
   },
   {
     "Filer_ID": "1382408",
@@ -1388,331 +219,16 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Mills"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Clint",
-    "Tran_NamL": "Mitchell"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-19",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Mixon"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 99.0,
-    "Tran_Date": "2016-09-03",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Mixon"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Montauk"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-04",
-    "Tran_NamF": "Jane",
-    "Tran_NamL": "Morrison"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Kenny",
-    "Tran_NamL": "Morrison"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Adhitya",
-    "Tran_NamL": "Nagraj"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "National Union of Healthcare Workers Candidate Committee for Quality Patient Care and Union Democracy"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 257.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Nautilus Group"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Christine",
-    "Tran_NamL": "Nguyen"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Lan",
-    "Tran_NamL": "Nguyen"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Ortrun",
-    "Tran_NamL": "Niesar"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-07",
-    "Tran_NamF": "Bruce",
-    "Tran_NamL": "Nilles"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Bruce",
-    "Tran_NamL": "Nilles"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Hao",
-    "Tran_NamL": "Ninh"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Janet",
-    "Tran_NamL": "Noble"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Northern California Carpenters Regional Council Small Contributor Committee"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Jody",
-    "Tran_NamL": "Nunez"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Bruce",
-    "Tran_NamL": "Nye"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "CJ",
-    "Tran_NamL": "Omara"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-05-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Operating Engineers Local Union No. 3, District 20 PAC"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Oram"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "PMACC dba Harborside Health Center"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Patterson"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Pepper"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "Maureen",
-    "Tran_NamL": "Perata"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Howie",
-    "Tran_NamL": "Perlin"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Adam",
-    "Tran_NamL": "Peterson"
+    "Tran_Date": "2016-05-09",
+    "Tran_NamF": "Lisa",
+    "Tran_NamL": "Jaicks"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Shiloh",
-    "Tran_NamL": "Phillips"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Barry",
-    "Tran_NamL": "Pilger"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-31",
-    "Tran_NamF": "Sue",
-    "Tran_NamL": "Piper"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": "Sue",
-    "Tran_NamL": "Piper"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Sue",
-    "Tran_NamL": "Piper"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Jessica",
-    "Tran_NamL": "Pitt"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Planthold"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 136.0,
-    "Tran_Date": "2016-05-22",
-    "Tran_NamF": "Janis",
-    "Tran_NamL": "Plotkin"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Janis",
-    "Tran_NamL": "Plotkin"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-01",
-    "Tran_NamF": "Rebecca",
-    "Tran_NamL": "Prozan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Purcell"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Purcell"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Jean",
-    "Tran_NamL": "Quan"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Raburn"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Wilma",
-    "Tran_NamL": "Rader"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Radulovich"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Raich"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Clifford",
-    "Tran_NamL": "Rechtschaffen"
+    "Tran_Date": "2016-05-19",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Burdman"
   },
   {
     "Filer_ID": "1382408",
@@ -1724,37 +240,30 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Sue",
-    "Tran_NamL": "Reinhold"
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Cohen"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Shari",
-    "Tran_NamL": "Ressler"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Fickes"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Rhine"
+    "Tran_Amt1": 136.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Krevsky"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Travis",
-    "Tran_NamL": "Ritchie"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Roots for Health, Inc."
+    "Tran_Amt1": 136.0,
+    "Tran_Date": "2016-05-22",
+    "Tran_NamF": "Janis",
+    "Tran_NamL": "Plotkin"
   },
   {
     "Filer_ID": "1382408",
@@ -1762,237 +271,6 @@
     "Tran_Date": "2016-05-22",
     "Tran_NamF": "Adolph",
     "Tran_NamL": "Rosekrans"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Adolph",
-    "Tran_NamL": "Rosekrans"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Emily",
-    "Tran_NamL": "Rosenberg"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Rossoff"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Frank",
-    "Tran_NamL": "Russo"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-26",
-    "Tran_NamF": "Rebecca",
-    "Tran_NamL": "Saltzman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 57.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Rebecca",
-    "Tran_NamL": "Saltzman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Rebecca",
-    "Tran_NamL": "Saltzman"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-24",
-    "Tran_NamF": "Libby",
-    "Tran_NamL": "Schaaf"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-06",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Schiller"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Schiller"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Schlichtmann"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 58.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Schlichtmann"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Schmier"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-28",
-    "Tran_NamF": "Harmon",
-    "Tran_NamL": "Schragge"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Emily",
-    "Tran_NamL": "Schreuder"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Samuel",
-    "Tran_NamL": "Schuchat"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Lynda",
-    "Tran_NamL": "Schwartz"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Schwartz"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Semler"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-11-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021, Candidate PAC, Small Contributors Committee"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "B. Reid",
-    "Tran_NamL": "Settlemier"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-17",
-    "Tran_NamF": "Cheri",
-    "Tran_NamL": "Shankar"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Renee",
-    "Tran_NamL": "Sharp"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Shawl"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Shawl"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sheet Metal Workers International Association Local No. 104 Political Action Committee"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Neal",
-    "Tran_NamL": "Shorstein"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Harmon",
-    "Tran_NamL": "Shragge"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-03",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sidley"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Janna",
-    "Tran_NamL": "Sidley"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sight Glass Management"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sign Pictorial & Display (L.U. No. 510)"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Silver"
   },
   {
     "Filer_ID": "1382408",
@@ -2011,58 +289,37 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Skinner"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "Bernard",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "Bernard",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Bernard",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Bernard",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Kyle",
-    "Tran_NamL": "Specht"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-05-22",
     "Tran_NamF": "Richard",
     "Tran_NamL": "Speiglman"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Speiglman"
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "Brandon",
+    "Tran_NamL": "Baranco"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Schlichtmann"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-26",
+    "Tran_NamF": "Alice",
+    "Tran_NamL": "Webber"
   },
   {
     "Filer_ID": "1382408",
@@ -2073,59 +330,262 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Marianna",
-    "Tran_NamL": "Stark"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-18",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Stephens"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Stephenson"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Stephenson"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": "Kathryn",
-    "Tran_NamL": "Sterbenc"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Kathryn",
-    "Tran_NamL": "Sterbenc"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Kathryn",
-    "Tran_NamL": "Sterbenc"
+    "Tran_Amt1": 136.0,
+    "Tran_Date": "2016-06-04",
+    "Tran_NamF": "Suzanne",
+    "Tran_NamL": "Mason"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Stevens"
+    "Tran_Date": "2016-06-09",
+    "Tran_NamF": "Tim",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sign Pictorial & Display (L.U. No. 510)"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-11",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Zebrack"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-14",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Kalb"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bay Area Citizens PAC - All Purpose Account"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "Earl",
+    "Tran_NamL": "Hamlin"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "Rivka",
+    "Tran_NamL": "Yerushalmi"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "PMACC dba Harborside Health Center"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-16",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Piper"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": "Gregory",
+    "Tran_NamL": "Chan"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Anthony"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Bass"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Benson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Ener",
+    "Tran_NamL": "Chiu"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Judith",
+    "Tran_NamL": "Cox"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Glen",
+    "Tran_NamL": "Dahlbacka"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Gordon",
+    "Tran_NamL": "Link"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Jean",
+    "Tran_NamL": "Quan"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Skinner"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Weinstein"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-19",
+    "Tran_NamF": "Shira",
+    "Tran_NamL": "Levine"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Lawson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Jasmin",
+    "Tran_NamL": "Ansar"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Roland",
+    "Tran_NamL": "Brandel"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Marsha",
+    "Tran_NamL": "Converse"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Bob",
+    "Tran_NamL": "Epstein"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Paula",
+    "Tran_NamL": "Hawthorn"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "C. J.",
+    "Tran_NamL": "Hirschfield"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Leslie",
+    "Tran_NamL": "Katz"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Earl",
+    "Tran_NamL": "Koteen"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Jody",
+    "Tran_NamL": "Nunez"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Purcell"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Raich"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Shawl"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Andrew",
+    "Tran_NamL": "Young"
   },
   {
     "Filer_ID": "1382408",
@@ -2137,23 +597,121 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Stout"
+    "Tran_Date": "2016-06-26",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Chessin"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Taylor",
-    "Tran_NamL": "Sublett"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-26",
+    "Tran_NamF": "Rebecca",
+    "Tran_NamL": "Saltzman"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Sutter"
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Honey",
+    "Tran_NamL": "Mark"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Melvyn",
+    "Tran_NamL": "Mark"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Patterson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Stephenson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "Cox"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Sophie",
+    "Tran_NamL": "Hahn"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Ann",
+    "Tran_NamL": "Kalb-Kip"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Lynda",
+    "Tran_NamL": "Schwartz"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Shelagh",
+    "Tran_NamL": "Broderson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Cassidy"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Danielle",
+    "Tran_NamL": "Fugere"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Abel",
+    "Tran_NamL": "Guillen"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Valarie",
+    "Tran_NamL": "Kalb"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Claire",
+    "Tran_NamL": "Levine"
   },
   {
     "Filer_ID": "1382408",
@@ -2164,6 +722,419 @@
   },
   {
     "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Bernhardt"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "Bernard",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-02",
+    "Tran_NamF": "Francesca",
+    "Tran_NamL": "Cunningham"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-02",
+    "Tran_NamF": "Ann",
+    "Tran_NamL": "Harvey"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-07-02",
+    "Tran_NamF": "Forest",
+    "Tran_NamL": "Weld"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-07-03",
+    "Tran_NamF": "Gloria",
+    "Tran_NamL": "Bruce"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-07",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Nilles"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-19",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Mixon"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-07-20",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Ingram"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-07-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lighthouse Public Affairs, LLC"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Johanna",
+    "Tran_NamL": "Wald"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-24",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Jenner"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-24",
+    "Tran_NamF": "Libby",
+    "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-25",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Bonta"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-07-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Brotherhood of Electrical Workers Local 595 PAC"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sheet Metal Workers International Association Local No. 104 Political Action Committee"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Marsteller"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Planthold"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-28",
+    "Tran_NamF": "Andrew",
+    "Tran_NamL": "Wiener"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Chessin"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Clifford",
+    "Tran_NamL": "Rechtschaffen"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Howie",
+    "Tran_NamL": "Perlin"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Warwick"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Debbie",
+    "Tran_NamL": "Fischer"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Montauk"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Wisland"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-06",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Schiller"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Nicholas",
+    "Tran_NamL": "Josefowitz"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Brett",
+    "Tran_NamL": "Badelle"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Buttrick"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Janna",
+    "Tran_NamL": "Sidley"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 58.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Schlichtmann"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 57.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 257.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Nautilus Group"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "Bernard",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Alterman"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Luis",
+    "Tran_NamL": "Amezcua"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Ed",
+    "Tran_NamL": "Gerber"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Dale",
+    "Tran_NamL": "Gieringer"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Sheila",
+    "Tran_NamL": "Jordan"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Jack",
+    "Tran_NamL": "Kurzweil"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Nye"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 57.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Rebecca",
+    "Tran_NamL": "Saltzman"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Speiglman"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Taylor",
+    "Tran_NamL": "Sublett"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 114.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Carol",
+    "Tran_NamL": "Tolbert"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Stan",
+    "Tran_NamL": "Weisner"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-16",
+    "Tran_NamF": "Kathryn",
+    "Tran_NamL": "Sterbenc"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Fred",
+    "Tran_NamL": "Booker"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Bernhardt"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "U.A. Local 342 P.A.C. Fund"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Drury"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Esther",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Katz"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Laurie",
+    "Tran_NamL": "Umeh"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Elize",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Clinton",
+    "Tran_NamL": "Killian"
+  },
+  {
+    "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "Paul",
@@ -2171,10 +1142,1109 @@
   },
   {
     "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "BBI Construction"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Hochschild"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Sam",
+    "Tran_NamL": "Lauter"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Barry",
+    "Tran_NamL": "Pilger"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 99.0,
+    "Tran_Date": "2016-09-03",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Mixon"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-05",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Zebrack"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "CJ",
+    "Tran_NamL": "Omara"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Alan",
+    "Tran_NamL": "Harper"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Pepper"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bricklayers and Allied Craftworkers Local No. 3 Political Action Committee"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Vose"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "National Union of Healthcare Workers Candidate Committee for Quality Patient Care and Union Democracy"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Moses",
+    "Tran_NamL": "Libitzky"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Francisco",
+    "Tran_NamL": "Devries"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Kernighan"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Leno"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Rafael",
+    "Tran_NamL": "Mandelman"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "R.B.",
+    "Tran_NamL": "Mendelson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Echols"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Jewett"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Renee",
+    "Tran_NamL": "Sharp"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Rossoff"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Stout"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Al",
+    "Tran_NamL": "Weinrub"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Marguerite",
+    "Tran_NamL": "Young"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Sanford",
+    "Tran_NamL": "Chan"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 80.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Wisland"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Howard",
+    "Tran_NamL": "Wenger"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Judith",
+    "Tran_NamL": "Williams"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Wooley"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 65.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Luis",
+    "Tran_NamL": "Amezcua"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Fred",
+    "Tran_NamL": "Booker"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "DeVico"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Stuart",
+    "Tran_NamL": "Flashman"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Lora Jo",
+    "Tran_NamL": "Foo"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Andy",
+    "Tran_NamL": "Kelley"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Carter",
+    "Tran_NamL": "Lavin"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Nilles"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Frank",
+    "Tran_NamL": "Russo"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Schiller"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Samuel",
+    "Tran_NamL": "Schuchat"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Stephenson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "AJE Partners"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Greenberg"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hofer"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Lisa",
+    "Tran_NamL": "Jaicks"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Kalb"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Keenan"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Mills"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Raburn"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Radulovich"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Adolph",
+    "Tran_NamL": "Rosekrans"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Rebecca",
+    "Tran_NamL": "Saltzman"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Schmier"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Bernard",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Kathryn",
+    "Tran_NamL": "Sterbenc"
+  },
+  {
+    "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-23",
     "Tran_NamF": "Delia",
     "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Ubell"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Zac",
+    "Tran_NamL": "Unger"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Arthur",
+    "Tran_NamL": "Haubenstock"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Ann",
+    "Tran_NamL": "Kalb-Kip"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Gordon",
+    "Tran_NamL": "Link"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Ortrun",
+    "Tran_NamL": "Niesar"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Purcell"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Reinhold"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Forest",
+    "Tran_NamL": "Weld"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Abel"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "IAFF, Local 55 Political Action Committee"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Kalb"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Norman",
+    "Tran_NamL": "La Force"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "League of Conservation Voters"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Little"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Francisco",
+    "Tran_NamL": "Mariscal"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Zebrack"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "Construction & General Laborers Local Union 304 PAC"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Schwartz"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Sutter"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Sharon",
+    "Tran_NamL": "Cornu-Toney"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Adhitya",
+    "Tran_NamL": "Nagraj"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Chia"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Wayne",
+    "Tran_NamL": "Jordan"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Shari",
+    "Tran_NamL": "Ressler"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Delaney"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Allen",
+    "Tran_NamL": "Grodsky"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Andy",
+    "Tran_NamL": "Gunther"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Kolm"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Jon",
+    "Tran_NamL": "Adams"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Kent",
+    "Tran_NamL": "Lewandowski"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-08",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Fishman"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Grubbs"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Doucette"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Transport Oakland"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Travis",
+    "Tran_NamL": "Ritchie"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "B. Reid",
+    "Tran_NamL": "Settlemier"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Jon",
+    "Tran_NamL": "Adams"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Boyd"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Shelagh",
+    "Tran_NamL": "Broderson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Julie",
+    "Tran_NamL": "Edwards"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Ed",
+    "Tran_NamL": "Gerber"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Ernest",
+    "Tran_NamL": "Goitein"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "Noble"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Piper"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Wilma",
+    "Tran_NamL": "Rader"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Emily",
+    "Tran_NamL": "Rosenberg"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Semler"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Neal",
+    "Tran_NamL": "Shorstein"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Harmon",
+    "Tran_NamL": "Shragge"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Bernard",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Marianna",
+    "Tran_NamL": "Stark"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Kathryn",
+    "Tran_NamL": "Sterbenc"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Teigland"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Forest",
+    "Tran_NamL": "Weld"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Marguerite",
+    "Tran_NamL": "Young"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Abrams"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "Helen",
+    "Tran_NamL": "Bloch"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "Earl",
+    "Tran_NamL": "Koteen"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "Maureen",
+    "Tran_NamL": "Perata"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Gerry",
+    "Tran_NamL": "Garzon"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 420.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Houts"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Jessica",
+    "Tran_NamL": "Pitt"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Dockendorf"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Kelley"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Stevens"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Nicky",
+    "Tran_NamL": "Yuen"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "57th Avenue LLC"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Mia",
+    "Tran_NamL": "Baldwin"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Real Estate Political Action Committee - California Association of Realtors"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Chen"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Nara",
+    "Tran_NamL": "Dahlbacka"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Andrew",
+    "Tran_NamL": "Deangelo"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Deangelo"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Nico",
+    "Tran_NamL": "Enea"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Gardner"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Dale",
+    "Tran_NamL": "Gieringer"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Gold Coast Health, Inc."
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Grace"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Green Rush Consulting"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Mallory",
+    "Tran_NamL": "Holt"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hsu"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Sean",
+    "Tran_NamL": "Hung"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Jetty Marketing"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Sara",
+    "Tran_NamL": "Kwan"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Henry",
+    "Tran_NamL": "Levy"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Spencer",
+    "Tran_NamL": "Liolios"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Clint",
+    "Tran_NamL": "Mitchell"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Hao",
+    "Tran_NamL": "Ninh"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Oram"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Peterson"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Shiloh",
+    "Tran_NamL": "Phillips"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Janis",
+    "Tran_NamL": "Plotkin"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Roots for Health, Inc."
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Emily",
+    "Tran_NamL": "Schreuder"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sight Glass Management"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Kyle",
+    "Tran_NamL": "Specht"
   },
   {
     "Filer_ID": "1382408",
@@ -2186,37 +2256,93 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Teamac Imports"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Teigland"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-19",
     "Tran_NamF": null,
     "Tran_NamL": "The Milo Group of CA Inc."
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 114.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Carol",
-    "Tran_NamL": "Tolbert"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Andrea",
+    "Tran_NamL": "Unsworth"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-24",
-    "Tran_NamF": "Michele",
-    "Tran_NamL": "Townsend"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "White"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Jeongeui",
+    "Tran_NamL": "Yoo"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Zebrack"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Alpha Design & Construction"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Evan",
+    "Tran_NamL": "Arteaga"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Brooke",
+    "Tran_NamL": "Carpenter"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Golden Gate Gen"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Jiao",
+    "Tran_NamL": "Li"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Christine",
+    "Tran_NamL": "Nguyen"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Lan",
+    "Tran_NamL": "Nguyen"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Teamac Imports"
   },
   {
     "Filer_ID": "1382408",
@@ -2234,164 +2360,24 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Transport Oakland"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Henry",
-    "Tran_NamL": "Trapp"
-  },
-  {
-    "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "U.A. Local 342 P.A.C. Fund"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Ubell"
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Anna",
+    "Tran_NamL": "Wong"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Laurie",
-    "Tran_NamL": "Umeh"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Zac",
-    "Tran_NamL": "Unger"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Unite Here TIP State & Local Fund"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Andrea",
-    "Tran_NamL": "Unsworth"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Ruth",
-    "Tran_NamL": "Vose"
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Rhine"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Johanna",
-    "Tran_NamL": "Wald"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-01",
-    "Tran_NamF": "Debra",
-    "Tran_NamL": "Walker"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Warwick"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-04-25",
-    "Tran_NamF": "Roland",
-    "Tran_NamL": "Washington"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-26",
-    "Tran_NamF": "Alice",
-    "Tran_NamL": "Webber"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Al",
-    "Tran_NamL": "Weinrub"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Weinstein"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Stan",
-    "Tran_NamL": "Weisner"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-07-02",
-    "Tran_NamF": "Forest",
-    "Tran_NamL": "Weld"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Forest",
-    "Tran_NamL": "Weld"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Forest",
-    "Tran_NamL": "Weld"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Forest",
-    "Tran_NamL": "Weld"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Howard",
-    "Tran_NamL": "Wenger"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Janet",
-    "Tran_NamL": "White"
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Shawl"
   },
   {
     "Filer_ID": "1382408",
@@ -2402,31 +2388,10 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-28",
-    "Tran_NamF": "Andrew",
-    "Tran_NamL": "Wiener"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Judith",
-    "Tran_NamL": "Williams"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Wisland"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Wisland"
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Laniece",
+    "Tran_NamL": "Jones"
   },
   {
     "Filer_ID": "1382408",
@@ -2437,93 +2402,128 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Anna",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-02-28",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Woo"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Wooley"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "Rivka",
-    "Tran_NamL": "Yerushalmi"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Jeongeui",
-    "Tran_NamL": "Yoo"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Andrew",
-    "Tran_NamL": "Young"
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Marc",
+    "Tran_NamL": "Janowitz"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Marguerite",
-    "Tran_NamL": "Young"
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Henry",
+    "Tran_NamL": "Trapp"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Marguerite",
-    "Tran_NamL": "Young"
+    "Tran_Amt1": 35.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Judy",
+    "Tran_NamL": "Belcher"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Bowden"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Craig",
+    "Tran_NamL": "Brandt"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Judith",
+    "Tran_NamL": "Cox"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Cunningham"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Dolores",
+    "Tran_NamL": "Dalton"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "David Wedding Dress"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Gooding"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Keenan"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Lowe"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Unite Here TIP State & Local Fund"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Forest",
+    "Tran_NamL": "Weld"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Nicky",
-    "Tran_NamL": "Yuen"
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Larry",
+    "Tran_NamL": "Bush"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-11",
-    "Tran_NamF": "Bradley",
-    "Tran_NamL": "Zebrack"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Kenny",
+    "Tran_NamL": "Morrison"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-05",
-    "Tran_NamF": "Bradley",
-    "Tran_NamL": "Zebrack"
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-11-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021, Candidate PAC, Small Contributors Committee"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Bradley",
-    "Tran_NamL": "Zebrack"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Bradley",
-    "Tran_NamL": "Zebrack"
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-12-31",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "Kranzberg"
   }
 ]

--- a/build/committee/1382408/contributions/index.json
+++ b/build/committee/1382408/contributions/index.json
@@ -29,15 +29,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-15",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-06",
     "Tran_NamF": "Jon",
     "Tran_NamL": "Adams"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-06",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-15",
     "Tran_NamF": "Jon",
     "Tran_NamL": "Adams"
   },
@@ -64,15 +64,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 65.0,
-    "Tran_Date": "2016-09-22",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-08-15",
     "Tran_NamF": "Luis",
     "Tran_NamL": "Amezcua"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-08-15",
+    "Tran_Amt1": 65.0,
+    "Tran_Date": "2016-09-22",
     "Tran_NamF": "Luis",
     "Tran_NamL": "Amezcua"
   },
@@ -134,13 +134,6 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 57.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Barnett"
-  },
-  {
-    "Filer_ID": "1382408",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-06-23",
     "Tran_NamF": "Michael",
@@ -150,6 +143,13 @@
     "Filer_ID": "1382408",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 57.0,
+    "Tran_Date": "2016-08-12",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Barnett"
   },
@@ -198,14 +198,14 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-22",
+    "Tran_Date": "2016-07-01",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Bernhardt"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-01",
+    "Tran_Date": "2016-08-22",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Bernhardt"
   },
@@ -233,14 +233,14 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-22",
+    "Tran_Date": "2016-08-17",
     "Tran_NamF": "Fred",
     "Tran_NamL": "Booker"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-17",
+    "Tran_Date": "2016-09-22",
     "Tran_NamF": "Fred",
     "Tran_NamL": "Booker"
   },
@@ -365,16 +365,16 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Sanford",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": "Gregory",
     "Tran_NamL": "Chan"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": "Gregory",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Sanford",
     "Tran_NamL": "Chan"
   },
   {
@@ -386,15 +386,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-31",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-26",
     "Tran_NamF": "Stephen",
     "Tran_NamL": "Chessin"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-26",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-07-31",
     "Tran_NamF": "Stephen",
     "Tran_NamL": "Chessin"
   },
@@ -442,13 +442,6 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Judith",
-    "Tran_NamL": "Cox"
-  },
-  {
-    "Filer_ID": "1382408",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-06-18",
     "Tran_NamF": "Judith",
@@ -463,16 +456,23 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 40.0,
+    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Cunningham"
+    "Tran_NamF": "Judith",
+    "Tran_NamL": "Cox"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-07-02",
     "Tran_NamF": "Francesca",
+    "Tran_NamL": "Cunningham"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Margaret",
     "Tran_NamL": "Cunningham"
   },
   {
@@ -521,14 +521,14 @@
     "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Andrew",
+    "Tran_NamF": "Stephen",
     "Tran_NamL": "Deangelo"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Stephen",
+    "Tran_NamF": "Andrew",
     "Tran_NamL": "Deangelo"
   },
   {
@@ -666,13 +666,6 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Ed",
-    "Tran_NamL": "Gerber"
-  },
-  {
-    "Filer_ID": "1382408",
     "Tran_Amt1": 300.0,
     "Tran_Date": "2016-08-15",
     "Tran_NamF": "Ed",
@@ -680,15 +673,22 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Dale",
-    "Tran_NamL": "Gieringer"
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Ed",
+    "Tran_NamL": "Gerber"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Dale",
+    "Tran_NamL": "Gieringer"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-19",
     "Tran_NamF": "Dale",
     "Tran_NamL": "Gieringer"
   },
@@ -743,15 +743,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-05",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-02-25",
     "Tran_NamF": "Allen",
     "Tran_NamL": "Grodsky"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-02-25",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
     "Tran_NamF": "Allen",
     "Tran_NamL": "Grodsky"
   },
@@ -779,14 +779,14 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-29",
+    "Tran_Date": "2016-05-05",
     "Tran_NamF": "Sophie",
     "Tran_NamL": "Hahn"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-05",
+    "Tran_Date": "2016-06-29",
     "Tran_NamF": "Sophie",
     "Tran_NamL": "Hahn"
   },
@@ -911,15 +911,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-23",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-05-09",
     "Tran_NamF": "Lisa",
     "Tran_NamL": "Jaicks"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-09",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-23",
     "Tran_NamF": "Lisa",
     "Tran_NamL": "Jaicks"
   },
@@ -974,16 +974,16 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Wayne",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Sheila",
     "Tran_NamL": "Jordan"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Sheila",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Wayne",
     "Tran_NamL": "Jordan"
   },
   {
@@ -995,9 +995,30 @@
   },
   {
     "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-02-24",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Kalb"
+  },
+  {
+    "Filer_ID": "1382408",
     "Tran_Amt1": 125.0,
     "Tran_Date": "2016-02-25",
     "Tran_NamF": "Noah",
+    "Tran_NamL": "Kalb"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-14",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Kalb"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Valarie",
     "Tran_NamL": "Kalb"
   },
   {
@@ -1010,42 +1031,21 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-02-24",
-    "Tran_NamF": "Scott",
-    "Tran_NamL": "Kalb"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Valarie",
-    "Tran_NamL": "Kalb"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-14",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Kalb"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-25",
     "Tran_NamF": "David",
     "Tran_NamL": "Kalb"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-06-29",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-25",
     "Tran_NamF": "Ann",
     "Tran_NamL": "Kalb-Kip"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-25",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-06-29",
     "Tran_NamF": "Ann",
     "Tran_NamL": "Kalb-Kip"
   },
@@ -1059,15 +1059,15 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Robert",
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Leslie",
     "Tran_NamL": "Katz"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Leslie",
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Robert",
     "Tran_NamL": "Katz"
   },
   {
@@ -1080,14 +1080,14 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-27",
+    "Tran_Date": "2016-09-23",
     "Tran_NamF": "David",
     "Tran_NamL": "Keenan"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-23",
+    "Tran_Date": "2016-10-27",
     "Tran_NamF": "David",
     "Tran_NamL": "Keenan"
   },
@@ -1128,15 +1128,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-16",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-23",
     "Tran_NamF": "Earl",
     "Tran_NamL": "Koteen"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-23",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-16",
     "Tran_NamF": "Earl",
     "Tran_NamL": "Koteen"
   },
@@ -1212,16 +1212,16 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Claire",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-19",
+    "Tran_NamF": "Shira",
     "Tran_NamL": "Levine"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-19",
-    "Tran_NamF": "Shira",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Claire",
     "Tran_NamL": "Levine"
   },
   {
@@ -1261,15 +1261,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-18",
     "Tran_NamF": "Gordon",
     "Tran_NamL": "Link"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-18",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Gordon",
     "Tran_NamL": "Link"
   },
@@ -1312,28 +1312,28 @@
     "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Honey",
+    "Tran_NamF": "Melvyn",
     "Tran_NamL": "Mark"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Melvyn",
+    "Tran_NamF": "Honey",
     "Tran_NamL": "Mark"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Marks"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-24",
     "Tran_NamF": "Esther",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Anne",
     "Tran_NamL": "Marks"
   },
   {
@@ -1459,14 +1459,14 @@
     "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Lan",
+    "Tran_NamF": "Christine",
     "Tran_NamL": "Nguyen"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Christine",
+    "Tran_NamF": "Lan",
     "Tran_NamL": "Nguyen"
   },
   {
@@ -1604,6 +1604,13 @@
   },
   {
     "Filer_ID": "1382408",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-31",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Piper"
+  },
+  {
+    "Filer_ID": "1382408",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-06-16",
     "Tran_NamF": "Sue",
@@ -1613,13 +1620,6 @@
     "Filer_ID": "1382408",
     "Tran_Amt1": 125.0,
     "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Sue",
-    "Tran_NamL": "Piper"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-31",
     "Tran_NamF": "Sue",
     "Tran_NamL": "Piper"
   },
@@ -1639,15 +1639,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
+    "Tran_Amt1": 136.0,
+    "Tran_Date": "2016-05-22",
     "Tran_NamF": "Janis",
     "Tran_NamL": "Plotkin"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 136.0,
-    "Tran_Date": "2016-05-22",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-19",
     "Tran_NamF": "Janis",
     "Tran_NamL": "Plotkin"
   },
@@ -1716,15 +1716,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-24",
+    "Tran_Amt1": 318.0,
+    "Tran_Date": "2016-05-19",
     "Tran_NamF": "Sue",
     "Tran_NamL": "Reinhold"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 318.0,
-    "Tran_Date": "2016-05-19",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Sue",
     "Tran_NamL": "Reinhold"
   },
@@ -1821,13 +1821,6 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Schiller"
-  },
-  {
-    "Filer_ID": "1382408",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-08-06",
     "Tran_NamF": "Steven",
@@ -1835,15 +1828,22 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 58.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Schlichtmann"
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Schiller"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-05-26",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Schlichtmann"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 58.0,
+    "Tran_Date": "2016-08-10",
     "Tran_NamF": "Laura",
     "Tran_NamL": "Schlichtmann"
   },
@@ -1877,16 +1877,16 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Mark",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Lynda",
     "Tran_NamL": "Schwartz"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Lynda",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Mark",
     "Tran_NamL": "Schwartz"
   },
   {
@@ -1926,15 +1926,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-22",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Shawl"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-22",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Shawl"
   },
@@ -1961,16 +1961,16 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Janna",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-03",
+    "Tran_NamF": "Michael",
     "Tran_NamL": "Sidley"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-03",
-    "Tran_NamF": "Michael",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Janna",
     "Tran_NamL": "Sidley"
   },
   {
@@ -2004,14 +2004,14 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-18",
+    "Tran_Date": "2016-05-22",
     "Tran_NamF": "Nancy",
     "Tran_NamL": "Skinner"
   },
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-05-22",
+    "Tran_Date": "2016-06-18",
     "Tran_NamF": "Nancy",
     "Tran_NamL": "Skinner"
   },
@@ -2360,8 +2360,8 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-11-05",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Forest",
     "Tran_NamL": "Weld"
   },
@@ -2374,8 +2374,8 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-24",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-11-05",
     "Tran_NamF": "Forest",
     "Tran_NamL": "Weld"
   },
@@ -2416,15 +2416,15 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 80.0,
-    "Tran_Date": "2016-09-20",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-05",
     "Tran_NamF": "Laura",
     "Tran_NamL": "Wisland"
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-05",
+    "Tran_Amt1": 80.0,
+    "Tran_Date": "2016-09-20",
     "Tran_NamF": "Laura",
     "Tran_NamL": "Wisland"
   },
@@ -2472,9 +2472,9 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Marguerite",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-23",
+    "Tran_NamF": "Andrew",
     "Tran_NamL": "Young"
   },
   {
@@ -2486,9 +2486,9 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-23",
-    "Tran_NamF": "Andrew",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Marguerite",
     "Tran_NamL": "Young"
   },
   {
@@ -2500,8 +2500,15 @@
   },
   {
     "Filer_ID": "1382408",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-11",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Zebrack"
+  },
+  {
+    "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
+    "Tran_Date": "2016-09-05",
     "Tran_NamF": "Bradley",
     "Tran_NamL": "Zebrack"
   },
@@ -2515,14 +2522,7 @@
   {
     "Filer_ID": "1382408",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-05",
-    "Tran_NamF": "Bradley",
-    "Tran_NamL": "Zebrack"
-  },
-  {
-    "Filer_ID": "1382408",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-11",
+    "Tran_Date": "2016-10-19",
     "Tran_NamF": "Bradley",
     "Tran_NamL": "Zebrack"
   }

--- a/build/committee/1382679/contributions/index.json
+++ b/build/committee/1382679/contributions/index.json
@@ -2,331 +2,16 @@
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Adams"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Gayle",
-    "Tran_NamL": "Akins"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-03",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Alexander"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Almsteier"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-03-04",
-    "Tran_NamF": "Claude",
-    "Tran_NamL": "Ames"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-02-04",
     "Tran_NamF": "Herb",
     "Tran_NamL": "Anderson"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-02",
-    "Tran_NamF": "Tamsen",
-    "Tran_NamL": "Anderson"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Saundra",
-    "Tran_NamL": "Andrews"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-13",
-    "Tran_NamF": "Sharon",
-    "Tran_NamL": "Ball"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-16",
-    "Tran_NamF": "Anna",
-    "Tran_NamL": "Banks"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": "Anthony",
-    "Tran_NamL": "Batarse Jr."
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-30",
-    "Tran_NamF": "Alice",
-    "Tran_NamL": "Beasley"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-02",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Diana L.",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-30",
-    "Tran_NamF": "Loraine",
-    "Tran_NamL": "Binion"
-  },
-  {
-    "Filer_ID": "1382679",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bliss"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-03-13",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Bloch"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Blomfield Lee"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Blum Oakland"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "Carl",
-    "Tran_NamL": "Blumenstein"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-02",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Boggan Jr"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-11",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bricklayers and Allied Craftworkers Local No. 3 PAC#1244975"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-22",
-    "Tran_NamF": "Farimah",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-24",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Cheryl",
-    "Tran_NamL": "Burris"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Alberta",
-    "Tran_NamL": "Caldwell"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-07",
-    "Tran_NamF": "Cynthia",
-    "Tran_NamL": "Cannady"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-12",
-    "Tran_NamF": "Ray",
-    "Tran_NamL": "Carlisle"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-06",
-    "Tran_NamF": "Melissa",
-    "Tran_NamL": "Cowan"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Daily"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-06",
-    "Tran_NamF": "Douglas",
-    "Tran_NamL": "Dal Cielo"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Dang"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-13",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "Dasilva"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Timothy",
-    "Tran_NamL": "Davis"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Claude",
-    "Tran_NamL": "Dawson"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Dean"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "M. Quinn",
-    "Tran_NamL": "Delaney"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Diamond"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "District Council of Ironworkers"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Noel",
-    "Tran_NamL": "Edlin"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 175.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Reverend D. Jacquelyn",
-    "Tran_NamL": "Edwards"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Alice",
-    "Tran_NamL": "Edwards"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Katharine",
-    "Tran_NamL": "Ennix"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Barry",
-    "Tran_NamL": "Epstein"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "FLRISH, INC."
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Rocio",
-    "Tran_NamL": "Fierro"
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "Jayne",
+    "Tran_NamL": "Williams"
   },
   {
     "Filer_ID": "1382679",
@@ -338,58 +23,149 @@
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Flowers"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-05",
-    "Tran_NamF": "Loritta E.",
-    "Tran_NamL": "Ford"
+    "Tran_Date": "2016-03-02",
+    "Tran_NamF": "Tamsen",
+    "Tran_NamL": "Anderson"
   },
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Foster"
+    "Tran_Date": "2016-03-02",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-02",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Boggan Jr"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-03",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Alexander"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-03-04",
+    "Tran_NamF": "Claude",
+    "Tran_NamL": "Ames"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-05",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Scates"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-07",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Cannady"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-09",
+    "Tran_NamF": "Gwendolyn",
+    "Tran_NamL": "Williams"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-10",
+    "Tran_NamF": "Pelayo",
+    "Tran_NamL": "Llamas"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-10",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Omura"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-11",
+    "Tran_NamF": "Joyce",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-11",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Montes"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-11",
+    "Tran_NamF": "Nikole",
+    "Tran_NamL": "Richardson"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-12",
+    "Tran_NamF": "Ray",
+    "Tran_NamL": "Carlisle"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-12",
+    "Tran_NamF": "Jack",
+    "Tran_NamL": "Lipton"
   },
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Henry",
-    "Tran_NamL": "Gardner"
+    "Tran_Date": "2016-03-12",
+    "Tran_NamF": "Benjamin",
+    "Tran_NamL": "Stock"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Gooding"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-03-12",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Tribble"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Veronica",
-    "Tran_NamL": "Gray"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-03-12",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Washington"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Gordon",
-    "Tran_NamL": "Greenwood"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-13",
+    "Tran_NamF": "Sharon",
+    "Tran_NamL": "Ball"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "Elliot",
-    "Tran_NamL": "Halpern"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-03-13",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Bloch"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-13",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Dasilva"
   },
   {
     "Filer_ID": "1382679",
@@ -408,9 +184,135 @@
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-10",
-    "Tran_NamF": "Elihu",
-    "Tran_NamL": "Harris"
+    "Tran_Date": "2016-03-13",
+    "Tran_NamF": "Lynn",
+    "Tran_NamL": "Hutchins"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-13",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Pierik"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-13",
+    "Tran_NamF": "Gerald",
+    "Tran_NamL": "Ramiza"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-13",
+    "Tran_NamF": "Hilliard",
+    "Tran_NamL": "Terry III"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Gayle",
+    "Tran_NamL": "Akins"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Saundra",
+    "Tran_NamL": "Andrews"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Diana L.",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Blomfield Lee"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Cheryl",
+    "Tran_NamL": "Burris"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Daily"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Timothy",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Dean"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "M. Quinn",
+    "Tran_NamL": "Delaney"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 175.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Reverend D. Jacquelyn",
+    "Tran_NamL": "Edwards"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Katharine",
+    "Tran_NamL": "Ennix"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Barry",
+    "Tran_NamL": "Epstein"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Rocio",
+    "Tran_NamL": "Fierro"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Veronica",
+    "Tran_NamL": "Gray"
   },
   {
     "Filer_ID": "1382679",
@@ -429,58 +331,9 @@
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-11",
-    "Tran_NamF": "Joyce",
-    "Tran_NamL": "Hicks"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-08",
-    "Tran_NamF": "Andre",
-    "Tran_NamL": "Hill"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-03-14",
     "Tran_NamF": "Yvonne",
     "Tran_NamL": "Hudson-Harmon"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-13",
-    "Tran_NamF": "Lynn",
-    "Tran_NamL": "Hutchins"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "IBEW Local 595"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Illgen"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Association of Fire Fighters Local 55"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Brotherhood of Electrical Workers Local 595 PAC ID# 1273532"
   },
   {
     "Filer_ID": "1382679",
@@ -505,30 +358,9 @@
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-04-19",
-    "Tran_NamF": "Alex",
-    "Tran_NamL": "Katz"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-07-23",
-    "Tran_NamF": "Alex",
-    "Tran_NamL": "Katz"
-  },
-  {
-    "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-03-14",
     "Tran_NamF": "Michelle",
-    "Tran_NamL": "Kenyon"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "Arianna",
     "Tran_NamL": "Kenyon"
   },
   {
@@ -547,52 +379,10 @@
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Curtis",
-    "Tran_NamL": "Kidder"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-18",
-    "Tran_NamF": "Gary",
-    "Tran_NamL": "Lafayette"
-  },
-  {
-    "Filer_ID": "1382679",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-03-14",
     "Tran_NamF": "Denise",
     "Tran_NamL": "Le Noir"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": "Rep. Barbara",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-07-25",
-    "Tran_NamF": "Jessica",
-    "Tran_NamL": "Levitt"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-12",
-    "Tran_NamF": "Jack",
-    "Tran_NamL": "Lipton"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-10",
-    "Tran_NamF": "Pelayo",
-    "Tran_NamL": "Llamas"
   },
   {
     "Filer_ID": "1382679",
@@ -610,73 +400,10 @@
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "April",
-    "Tran_NamL": "Madison-Ramsey"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-20",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Maguire"
-  },
-  {
-    "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-03-14",
     "Tran_NamF": "Raymond",
     "Tran_NamL": "Marshall"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": "Alistair",
-    "Tran_NamL": "McElwee"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "William",
-    "Tran_NamL": "McNeill"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": "Nate",
-    "Tran_NamL": "Miley"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Robin",
-    "Tran_NamL": "Miller"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Dianne",
-    "Tran_NamL": "Millner"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Jeff",
-    "Tran_NamL": "Millner"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-16",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Mills"
   },
   {
     "Filer_ID": "1382679",
@@ -687,73 +414,10 @@
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-11",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Montes"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Doryanna",
-    "Tran_NamL": "Moreno"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-05",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Morodomi"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Nahass"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Wayne",
-    "Tran_NamL": "Nishioka"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-11",
-    "Tran_NamF": "Christine",
-    "Tran_NamL": "Nomna"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 750.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Northern California Carpenters Regional Council, Small Contribution Committee ID #972104"
-  },
-  {
-    "Filer_ID": "1382679",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-14",
     "Tran_NamF": "Vivian",
     "Tran_NamL": "O'Neal"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-10",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Omura"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-05-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Operating Engineers Local Union No. 3 District 20 PAC ID#91396"
   },
   {
     "Filer_ID": "1382679",
@@ -764,94 +428,10 @@
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "PMACC dba Harborside Health Center"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Parker"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-01",
-    "Tran_NamF": "Josephine",
-    "Tran_NamL": "Parker"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 116.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Savannah",
-    "Tran_NamL": "Parker"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Patterson"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Pereda"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Peterson"
-  },
-  {
-    "Filer_ID": "1382679",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-14",
     "Tran_NamF": "Krishna",
     "Tran_NamL": "Pettitt"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-05-05",
-    "Tran_NamF": "Krishna",
-    "Tran_NamL": "Pettitt"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-13",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Pierik"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-03-31",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Preiss"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Linda",
-    "Tran_NamL": "Purkiss"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-13",
-    "Tran_NamF": "Gerald",
-    "Tran_NamL": "Ramiza"
   },
   {
     "Filer_ID": "1382679",
@@ -863,49 +443,7 @@
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-11",
-    "Tran_NamF": "Nikole",
-    "Tran_NamL": "Richardson"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "Miguel",
-    "Tran_NamL": "Rodriguez"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-05",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Scates"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-14",
-    "Tran_NamF": "Libby",
-    "Tran_NamL": "Schaaf"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-11",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sheet Metal Wokers' International Association Local No. 104 PAC #850381"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Siegel"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-10",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Siegel"
   },
@@ -925,80 +463,45 @@
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-03-12",
-    "Tran_NamF": "Benjamin",
-    "Tran_NamL": "Stock"
-  },
-  {
-    "Filer_ID": "1382679",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Jon",
-    "Tran_NamL": "Sylvester"
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Jain",
+    "Tran_NamL": "Williams"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-01",
-    "Tran_NamF": "Lita",
-    "Tran_NamL": "Tang"
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "Carl",
+    "Tran_NamL": "Blumenstein"
   },
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Taylor"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-13",
-    "Tran_NamF": "Hilliard",
-    "Tran_NamL": "Terry III"
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "Elliot",
+    "Tran_NamL": "Halpern"
   },
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-03-12",
-    "Tran_NamF": "George",
-    "Tran_NamL": "Tribble"
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Parker"
   },
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-05-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "U.A. Local 342 P.A.C. Fund"
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "Arianna",
+    "Tran_NamL": "Kenyon"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-03-23",
-    "Tran_NamF": "Michele",
-    "Tran_NamL": "Vadon"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-04",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Verber"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Booker",
-    "Tran_NamL": "Wade"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-03-12",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Washington"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-16",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Mills"
   },
   {
     "Filer_ID": "1382679",
@@ -1009,31 +512,241 @@
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Evelyn",
-    "Tran_NamL": "Wesley"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-20",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Maguire"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "Jayne",
-    "Tran_NamL": "Williams"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-22",
+    "Tran_NamF": "Farimah",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Batarse Jr."
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "FLRISH, INC."
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Gooding"
   },
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-09",
-    "Tran_NamF": "Gwendolyn",
-    "Tran_NamL": "Williams"
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": "Rep. Barbara",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": "Alistair",
+    "Tran_NamL": "McElwee"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": "Nate",
+    "Tran_NamL": "Miley"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "PMACC dba Harborside Health Center"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-03-23",
+    "Tran_NamF": "Michele",
+    "Tran_NamL": "Vadon"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-24",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-30",
+    "Tran_NamF": "Alice",
+    "Tran_NamL": "Beasley"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-03-30",
+    "Tran_NamF": "Loraine",
+    "Tran_NamL": "Binion"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-03-31",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Preiss"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-01",
+    "Tran_NamF": "Lita",
+    "Tran_NamL": "Tang"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-04",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Verber"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-05",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Morodomi"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-06",
+    "Tran_NamF": "Melissa",
+    "Tran_NamL": "Cowan"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-04-06",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Dal Cielo"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-06",
+    "Tran_NamF": "H. James",
+    "Tran_NamL": "Wulfsberg"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-10",
+    "Tran_NamF": "Elihu",
+    "Tran_NamL": "Harris"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-11",
+    "Tran_NamF": "Christine",
+    "Tran_NamL": "Nomna"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-14",
+    "Tran_NamF": "Libby",
+    "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-16",
+    "Tran_NamF": "Anna",
+    "Tran_NamL": "Banks"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-04-18",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Lafayette"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-04-19",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Katz"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-05-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "Operating Engineers Local Union No. 3 District 20 PAC ID#91396"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-05",
+    "Tran_NamF": "Loritta E.",
+    "Tran_NamL": "Ford"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Brotherhood of Electrical Workers Local 595 PAC ID# 1273532"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-05-05",
+    "Tran_NamF": "Krishna",
+    "Tran_NamL": "Pettitt"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-08",
+    "Tran_NamF": "Andre",
+    "Tran_NamL": "Hill"
   },
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Jain",
-    "Tran_NamL": "Williams"
+    "Tran_Date": "2016-05-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "District Council of Ironworkers"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-05-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "IBEW Local 595"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-05-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "U.A. Local 342 P.A.C. Fund"
   },
   {
     "Filer_ID": "1382679",
@@ -1045,8 +758,295 @@
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-04-06",
-    "Tran_NamF": "H. James",
-    "Tran_NamL": "Wulfsberg"
+    "Tran_Date": "2016-06-01",
+    "Tran_NamF": "Josephine",
+    "Tran_NamL": "Parker"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Alberta",
+    "Tran_NamL": "Caldwell"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Noel",
+    "Tran_NamL": "Edlin"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Foster"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Dianne",
+    "Tran_NamL": "Millner"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Jeff",
+    "Tran_NamL": "Millner"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Patterson"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Jon",
+    "Tran_NamL": "Sylvester"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Booker",
+    "Tran_NamL": "Wade"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Blum Oakland"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Alice",
+    "Tran_NamL": "Edwards"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Gordon",
+    "Tran_NamL": "Greenwood"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Nahass"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Peterson"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Almsteier"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Pereda"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Diamond"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "William",
+    "Tran_NamL": "McNeill"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Robin",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 116.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Savannah",
+    "Tran_NamL": "Parker"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Adams"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "April",
+    "Tran_NamL": "Madison-Ramsey"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Doryanna",
+    "Tran_NamL": "Moreno"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Wayne",
+    "Tran_NamL": "Nishioka"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Purkiss"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Dang"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Association of Fire Fighters Local 55"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Rodriguez"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bricklayers and Allied Craftworkers Local No. 3 PAC#1244975"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sheet Metal Wokers' International Association Local No. 104 PAC #850381"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-07-23",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Katz"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-07-25",
+    "Tran_NamF": "Jessica",
+    "Tran_NamL": "Levitt"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Henry",
+    "Tran_NamL": "Gardner"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Flowers"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 750.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California Carpenters Regional Council, Small Contribution Committee ID #972104"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Curtis",
+    "Tran_NamL": "Kidder"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Claude",
+    "Tran_NamL": "Dawson"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Siegel"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Evelyn",
+    "Tran_NamL": "Wesley"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Illgen"
   }
 ]

--- a/build/committee/1382679/contributions/index.json
+++ b/build/committee/1382679/contributions/index.json
@@ -37,15 +37,15 @@
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-02",
-    "Tran_NamF": "Tamsen",
+    "Tran_Date": "2016-02-04",
+    "Tran_NamF": "Herb",
     "Tran_NamL": "Anderson"
   },
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-02-04",
-    "Tran_NamF": "Herb",
+    "Tran_Date": "2016-03-02",
+    "Tran_NamF": "Tamsen",
     "Tran_NamL": "Anderson"
   },
   {
@@ -86,15 +86,15 @@
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Diana L.",
+    "Tran_Date": "2016-03-02",
+    "Tran_NamF": "Jennifer",
     "Tran_NamL": "Bell"
   },
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-02",
-    "Tran_NamF": "Jennifer",
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Diana L.",
     "Tran_NamL": "Bell"
   },
   {
@@ -156,13 +156,6 @@
   {
     "Filer_ID": "1382679",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-31",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-03-22",
     "Tran_NamF": "Farimah",
     "Tran_NamL": "Brown"
@@ -172,6 +165,13 @@
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-24",
     "Tran_NamF": "Thomas",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1382679",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-31",
+    "Tran_NamF": "Matthew",
     "Tran_NamL": "Brown"
   },
   {
@@ -288,16 +288,16 @@
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "Alice",
+    "Tran_Amt1": 175.0,
+    "Tran_Date": "2016-03-14",
+    "Tran_NamF": "Reverend D. Jacquelyn",
     "Tran_NamL": "Edwards"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 175.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": "Reverend D. Jacquelyn",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "Alice",
     "Tran_NamL": "Edwards"
   },
   {
@@ -400,16 +400,16 @@
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-04-10",
-    "Tran_NamF": "Elihu",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-13",
+    "Tran_NamF": "Robert",
     "Tran_NamL": "Harris"
   },
   {
     "Filer_ID": "1382679",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-13",
-    "Tran_NamF": "Robert",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-04-10",
+    "Tran_NamF": "Elihu",
     "Tran_NamL": "Harris"
   },
   {
@@ -1016,6 +1016,13 @@
   },
   {
     "Filer_ID": "1382679",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-02-18",
+    "Tran_NamF": "Jayne",
+    "Tran_NamL": "Williams"
+  },
+  {
+    "Filer_ID": "1382679",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-03-09",
     "Tran_NamF": "Gwendolyn",
@@ -1026,13 +1033,6 @@
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-03-14",
     "Tran_NamF": "Jain",
-    "Tran_NamL": "Williams"
-  },
-  {
-    "Filer_ID": "1382679",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-02-18",
-    "Tran_NamF": "Jayne",
     "Tran_NamL": "Williams"
   },
   {

--- a/build/committee/1384267/contributions/index.json
+++ b/build/committee/1384267/contributions/index.json
@@ -57,15 +57,15 @@
   },
   {
     "Filer_ID": "1384267",
-    "Tran_Amt1": -300.0,
-    "Tran_Date": "2016-09-03",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-05-11",
     "Tran_NamF": "Seonghee",
     "Tran_NamL": "Lim"
   },
   {
     "Filer_ID": "1384267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-11",
+    "Tran_Amt1": -300.0,
+    "Tran_Date": "2016-09-03",
     "Tran_NamF": "Seonghee",
     "Tran_NamL": "Lim"
   },

--- a/build/committee/1384267/contributions/index.json
+++ b/build/committee/1384267/contributions/index.json
@@ -2,23 +2,9 @@
   {
     "Filer_ID": "1384267",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-06",
-    "Tran_NamF": "Janet",
-    "Tran_NamL": "Arnold"
-  },
-  {
-    "Filer_ID": "1384267",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "Debra",
-    "Tran_NamL": "Avery"
-  },
-  {
-    "Filer_ID": "1384267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-03",
-    "Tran_NamF": "Suzanne",
-    "Tran_NamL": "Baker-Shoup"
+    "Tran_Date": "2016-05-11",
+    "Tran_NamF": "Seonghee",
+    "Tran_NamL": "Lim"
   },
   {
     "Filer_ID": "1384267",
@@ -29,38 +15,24 @@
   },
   {
     "Filer_ID": "1384267",
-    "Tran_Amt1": -300.0,
-    "Tran_Date": "2016-09-03",
-    "Tran_NamF": "Dale",
-    "Tran_NamL": "Baum"
-  },
-  {
-    "Filer_ID": "1384267",
-    "Tran_Amt1": 180.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Carol",
-    "Tran_NamL": "Delton"
-  },
-  {
-    "Filer_ID": "1384267",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Green Party Of The United States"
+    "Tran_Date": "2016-08-06",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "Arnold"
   },
   {
     "Filer_ID": "1384267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Kaufman"
+    "Tran_Date": "2016-09-03",
+    "Tran_NamF": "Suzanne",
+    "Tran_NamL": "Baker-Shoup"
   },
   {
     "Filer_ID": "1384267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-05-11",
-    "Tran_NamF": "Seonghee",
-    "Tran_NamL": "Lim"
+    "Tran_Amt1": -300.0,
+    "Tran_Date": "2016-09-03",
+    "Tran_NamF": "Dale",
+    "Tran_NamL": "Baum"
   },
   {
     "Filer_ID": "1384267",
@@ -75,20 +47,6 @@
     "Tran_Date": "2016-09-03",
     "Tran_NamF": "Stephen",
     "Tran_NamL": "Lowe"
-  },
-  {
-    "Filer_ID": "1384267",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Education Association P.A.C. PID 1345259"
-  },
-  {
-    "Filer_ID": "1384267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Ritchie"
   },
   {
     "Filer_ID": "1384267",
@@ -107,16 +65,16 @@
   {
     "Filer_ID": "1384267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Rubin"
-  },
-  {
-    "Filer_ID": "1384267",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-03",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Schacher"
+  },
+  {
+    "Filer_ID": "1384267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Green Party Of The United States"
   },
   {
     "Filer_ID": "1384267",
@@ -135,8 +93,50 @@
   {
     "Filer_ID": "1384267",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1384267",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Education Association P.A.C. PID 1345259"
+  },
+  {
+    "Filer_ID": "1384267",
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Carol",
+    "Tran_NamL": "Delton"
+  },
+  {
+    "Filer_ID": "1384267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Ritchie"
+  },
+  {
+    "Filer_ID": "1384267",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-30",
     "Tran_NamF": "Mark",
     "Tran_NamL": "Wieder"
+  },
+  {
+    "Filer_ID": "1384267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Rubin"
+  },
+  {
+    "Filer_ID": "1384267",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "Debra",
+    "Tran_NamL": "Avery"
   }
 ]

--- a/build/committee/1384926/contributions/index.json
+++ b/build/committee/1384926/contributions/index.json
@@ -1,129 +1,10 @@
 [
   {
     "Filer_ID": "1384926",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Marilyn",
-    "Tran_NamL": "Albert"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Ismael",
-    "Tran_NamL": "Armendariz"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "Janet S.",
-    "Tran_NamL": "Arnold"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-11-16",
-    "Tran_NamF": "Debra",
-    "Tran_NamL": "Avery"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Nurses Association PAC Small Contributor Committee (CNA PAC)"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Martian",
-    "Tran_NamL": "Caraves"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-09",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Cervantes"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "William Alan",
-    "Tran_NamL": "Chorneau"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Construction & General Laborers Local 304 PAC"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "Helen Marie",
-    "Tran_NamL": "Duffy"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Emily",
-    "Tran_NamL": "Filloy"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Brian A.",
-    "Tran_NamL": "Foster"
-  },
-  {
-    "Filer_ID": "1384926",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Gerry",
-    "Tran_NamL": "Garzon"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": "Shanthi",
-    "Tran_NamL": "Gonzales"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Gonzales for School Board 2014"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-22",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Gorham"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "Angelica",
-    "Tran_NamL": "Gums"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Sophie",
-    "Tran_NamL": "Hahn"
+    "Tran_Date": "2016-05-24",
+    "Tran_NamF": "Frederick",
+    "Tran_NamL": "Schoeneman"
   },
   {
     "Filer_ID": "1384926",
@@ -135,128 +16,9 @@
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "Marcia",
-    "Tran_NamL": "Henry"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "Dashiel",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Alyssa",
-    "Tran_NamL": "Kang"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Andy",
-    "Tran_NamL": "Katz"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "Michael V.",
-    "Tran_NamL": "Kaufman"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Michael V.",
-    "Tran_NamL": "Kaufman"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "Amrit",
-    "Tran_NamL": "Kohli"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Lawson"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Caren",
-    "Tran_NamL": "Leong"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Mar"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-26",
-    "Tran_NamF": "Alison",
-    "Tran_NamL": "McDonald"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "Bethany",
-    "Tran_NamL": "Meyer"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Bethany",
-    "Tran_NamL": "Meyer"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Bethany",
-    "Tran_NamL": "Meyer"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Cintya I.",
-    "Tran_NamL": "Molina"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "Cintya",
-    "Tran_NamL": "Molina"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "National Union of Healthcare Workers Canidate Committee for Quality Patient Care and Union Democracy"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Barbara A.",
-    "Tran_NamL": "Rhine"
+    "Tran_Date": "2016-06-09",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Cervantes"
   },
   {
     "Filer_ID": "1384926",
@@ -267,66 +29,17 @@
   },
   {
     "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "Christopher Castro",
-    "Tran_NamL": "Rodriquez"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Sal",
-    "Tran_NamL": "Rosselli"
-  },
-  {
-    "Filer_ID": "1384926",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Susan G.",
-    "Tran_NamL": "Schacher"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-05-24",
-    "Tran_NamF": "Frederick",
-    "Tran_NamL": "Schoeneman"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": "Daniel M.",
-    "Tran_NamL": "Siegel"
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "Bethany",
+    "Tran_NamL": "Meyer"
   },
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Akio",
-    "Tran_NamL": "Tanaka"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Bonita",
-    "Tran_NamL": "Trinclisti"
-  },
-  {
-    "Filer_ID": "1384926",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Unity PAC Alameda Labor Council"
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Gorham"
   },
   {
     "Filer_ID": "1384926",
@@ -345,6 +58,69 @@
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "Janet S.",
+    "Tran_NamL": "Arnold"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "Helen Marie",
+    "Tran_NamL": "Duffy"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Gonzales for School Board 2014"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "Michael V.",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "Amrit",
+    "Tran_NamL": "Kohli"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "Christopher Castro",
+    "Tran_NamL": "Rodriquez"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": "Daniel M.",
+    "Tran_NamL": "Siegel"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Unity PAC Alameda Labor Council"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-26",
+    "Tran_NamF": "Alison",
+    "Tran_NamL": "McDonald"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-06-29",
     "Tran_NamF": "Phyllis",
     "Tran_NamL": "Willett"
@@ -352,8 +128,232 @@
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Ismael",
+    "Tran_NamL": "Armendariz"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Andy",
+    "Tran_NamL": "Katz"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Caren",
+    "Tran_NamL": "Leong"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Bethany",
+    "Tran_NamL": "Meyer"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Cintya I.",
+    "Tran_NamL": "Molina"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "Angelica",
+    "Tran_NamL": "Gums"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Sophie",
+    "Tran_NamL": "Hahn"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-20",
     "Tran_NamF": "Jerry",
     "Tran_NamL": "Wolfe"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Construction & General Laborers Local 304 PAC"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "National Union of Healthcare Workers Canidate Committee for Quality Patient Care and Union Democracy"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Marilyn",
+    "Tran_NamL": "Albert"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Martian",
+    "Tran_NamL": "Caraves"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "William Alan",
+    "Tran_NamL": "Chorneau"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Brian A.",
+    "Tran_NamL": "Foster"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Gerry",
+    "Tran_NamL": "Garzon"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Lawson"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Barbara A.",
+    "Tran_NamL": "Rhine"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Sal",
+    "Tran_NamL": "Rosselli"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Susan G.",
+    "Tran_NamL": "Schacher"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Akio",
+    "Tran_NamL": "Tanaka"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Bonita",
+    "Tran_NamL": "Trinclisti"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Marcia",
+    "Tran_NamL": "Henry"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "Dashiel",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Bethany",
+    "Tran_NamL": "Meyer"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Emily",
+    "Tran_NamL": "Filloy"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Nurses Association PAC Small Contributor Committee (CNA PAC)"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Michael V.",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Mar"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": "Shanthi",
+    "Tran_NamL": "Gonzales"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "Cintya",
+    "Tran_NamL": "Molina"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Alyssa",
+    "Tran_NamL": "Kang"
+  },
+  {
+    "Filer_ID": "1384926",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-11-16",
+    "Tran_NamF": "Debra",
+    "Tran_NamL": "Avery"
   }
 ]

--- a/build/committee/1384926/contributions/index.json
+++ b/build/committee/1384926/contributions/index.json
@@ -128,14 +128,14 @@
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-13",
+    "Tran_Date": "2016-06-08",
     "Tran_NamF": "Marcia",
     "Tran_NamL": "Henry"
   },
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-08",
+    "Tran_Date": "2016-10-13",
     "Tran_NamF": "Marcia",
     "Tran_NamL": "Henry"
   },
@@ -163,14 +163,14 @@
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-27",
+    "Tran_Date": "2016-06-24",
     "Tran_NamF": "Michael V.",
     "Tran_NamL": "Kaufman"
   },
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-24",
+    "Tran_Date": "2016-10-27",
     "Tran_NamF": "Michael V.",
     "Tran_NamL": "Kaufman"
   },
@@ -233,15 +233,15 @@
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "Cintya",
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Cintya I.",
     "Tran_NamL": "Molina"
   },
   {
     "Filer_ID": "1384926",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Cintya I.",
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "Cintya",
     "Tran_NamL": "Molina"
   },
   {

--- a/build/committee/1385180/contributions/index.json
+++ b/build/committee/1385180/contributions/index.json
@@ -99,10 +99,24 @@
   },
   {
     "Filer_ID": "1385180",
+    "Tran_Amt1": 2200.6,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "THE COCA-COLA COMPANY"
+  },
+  {
+    "Filer_ID": "1385180",
     "Tran_Amt1": 1500000.0,
     "Tran_Date": "2016-10-26",
     "Tran_NamF": null,
     "Tran_NamL": "AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC (NON-PROFIT 501(C)(6))"
+  },
+  {
+    "Filer_ID": "1385180",
+    "Tran_Amt1": 5191.31,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "THE COCA-COLA COMPANY"
   },
   {
     "Filer_ID": "1385180",
@@ -117,19 +131,5 @@
     "Tran_Date": "2016-11-07",
     "Tran_NamF": null,
     "Tran_NamL": "D.R.I.V.E. - DEMOCRAT, REPUBLICAN, INDEPENDENT VOTER EDUCATION"
-  },
-  {
-    "Filer_ID": "1385180",
-    "Tran_Amt1": 2200.6,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "THE COCA-COLA COMPANY"
-  },
-  {
-    "Filer_ID": "1385180",
-    "Tran_Amt1": 5191.31,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "THE COCA-COLA COMPANY"
   }
 ]

--- a/build/committee/1385180/contributions/index.json
+++ b/build/committee/1385180/contributions/index.json
@@ -120,15 +120,15 @@
   },
   {
     "Filer_ID": "1385180",
-    "Tran_Amt1": 5191.31,
-    "Tran_Date": "2016-10-27",
+    "Tran_Amt1": 2200.6,
+    "Tran_Date": "2016-10-22",
     "Tran_NamF": null,
     "Tran_NamL": "THE COCA-COLA COMPANY"
   },
   {
     "Filer_ID": "1385180",
-    "Tran_Amt1": 2200.6,
-    "Tran_Date": "2016-10-22",
+    "Tran_Amt1": 5191.31,
+    "Tran_Date": "2016-10-27",
     "Tran_NamF": null,
     "Tran_NamL": "THE COCA-COLA COMPANY"
   }

--- a/build/committee/1385949/contributions/index.json
+++ b/build/committee/1385949/contributions/index.json
@@ -1,10 +1,10 @@
 [
   {
     "Filer_ID": "1385949",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "Jose",
-    "Tran_NamL": "Arias"
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-01-18",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Moore"
   },
   {
     "Filer_ID": "1385949",
@@ -16,9 +16,9 @@
   {
     "Filer_ID": "1385949",
     "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "Felicia",
-    "Tran_NamL": "Gustin"
+    "Tran_Date": "2016-04-01",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Renik"
   },
   {
     "Filer_ID": "1385949",
@@ -26,13 +26,6 @@
     "Tran_Date": "2016-07-12",
     "Tran_NamF": "Anne",
     "Tran_NamL": "MacDougald"
-  },
-  {
-    "Filer_ID": "1385949",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-01-18",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Moore"
   },
   {
     "Filer_ID": "1385949",
@@ -44,9 +37,16 @@
   {
     "Filer_ID": "1385949",
     "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-04-01",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Renik"
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "Jose",
+    "Tran_NamL": "Arias"
+  },
+  {
+    "Filer_ID": "1385949",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "Felicia",
+    "Tran_NamL": "Gustin"
   },
   {
     "Filer_ID": "1385949",

--- a/build/committee/1386081/contributions/index.json
+++ b/build/committee/1386081/contributions/index.json
@@ -1,262 +1,87 @@
 [
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Jeanette P.",
-    "Tran_NamL": "Aguilar"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Mary A.",
-    "Tran_NamL": "Ahern"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-06",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Allen"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Andrew J. Maxwell, M.D., Inc."
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Arellano"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Balco Properties"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Peter J.",
-    "Tran_NamL": "Ballew"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Zaccaria",
-    "Tran_NamL": "Barbieri"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Tim",
-    "Tran_NamL": "Beresky"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Berg"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Matthew A.",
-    "Tran_NamL": "Bernstein"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Peter",
-    "Tran_NamL": "Boero"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Luigi A.",
-    "Tran_NamL": "Bonacini"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-06-20",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Brackett"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Rebecca",
-    "Tran_NamL": "Breska"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Beverly Avery",
-    "Tran_NamL": "Broussard"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Suzanne M.",
-    "Tran_NamL": "Brunel"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Mary Louise",
-    "Tran_NamL": "Bucher"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "F.L.",
-    "Tran_NamL": "Burnett"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "CWP Property Management, Inc."
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Real Estate PAC (CREPAC)- California Association of Realtors"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "David E.",
-    "Tran_NamL": "Cannon"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Mitchell",
-    "Tran_NamL": "Capor"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Ross F.",
-    "Tran_NamL": "Catanzarite"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Celine O'Driscoll dba O'Driscoll Plastering"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Chadwick"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Angie M.",
-    "Tran_NamL": "Chakalian"
+    "Tran_Date": "2016-06-10",
+    "Tran_NamF": "Gerald T.",
+    "Tran_NamL": "Dunn"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Jeffery T.",
-    "Tran_NamL": "Corbett"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Eveleen R.",
-    "Tran_NamL": "Corbett"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Pamela K.",
-    "Tran_NamL": "Corbett"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": -300.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Pamela K.",
-    "Tran_NamL": "Corbett"
+    "Tran_Date": "2016-06-11",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Knutson"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Kelly",
-    "Tran_NamL": "Coulombe"
+    "Tran_Date": "2016-06-11",
+    "Tran_NamF": "William C.",
+    "Tran_NamL": "Levins"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-11",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Palia"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-12",
+    "Tran_NamF": "Regina",
+    "Tran_NamL": "Kolhede"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Stephen M.",
-    "Tran_NamL": "Crosetti"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Marie A.",
-    "Tran_NamL": "Cumming"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Cunniffe"
+    "Tran_Date": "2016-06-12",
+    "Tran_NamF": "Eileen",
+    "Tran_NamL": "McCullough"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Robert J.",
-    "Tran_NamL": "Dailey"
+    "Tran_Date": "2016-06-12",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "O'Shea"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-13",
+    "Tran_NamF": "Velma",
+    "Tran_NamL": "Magnani"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-13",
+    "Tran_NamF": "Susan H.",
+    "Tran_NamL": "Reisz"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "Jeffrey M.",
+    "Tran_NamL": "Jorgensen"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-15",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Lange"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "James G.",
-    "Tran_NamL": "Daly"
+    "Tran_Date": "2016-06-16",
+    "Tran_NamF": "Paul D.",
+    "Tran_NamL": "O'Driscoll"
   },
   {
     "Filer_ID": "1386081",
@@ -268,16 +93,65 @@
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Jerome B.",
-    "Tran_NamL": "Deck Jr."
+    "Tran_Date": "2016-06-18",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Skiles"
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 700.0,
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-06-20",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Brackett"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "CWP Property Management, Inc."
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
     "Tran_Date": "2016-06-28",
-    "Tran_NamF": "James A.",
-    "Tran_NamL": "Diamantine"
+    "Tran_NamF": "Peter J.",
+    "Tran_NamL": "Ballew"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Tim",
+    "Tran_NamL": "Beresky"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Matthew A.",
+    "Tran_NamL": "Bernstein"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Rebecca",
+    "Tran_NamL": "Breska"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Celine O'Driscoll dba O'Driscoll Plastering"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Robert J.",
+    "Tran_NamL": "Dailey"
   },
   {
     "Filer_ID": "1386081",
@@ -288,17 +162,10 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "George",
-    "Tran_NamL": "Donovan"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-10",
-    "Tran_NamF": "Gerald T.",
-    "Tran_NamL": "Dunn"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "James A.",
+    "Tran_NamL": "Diamantine"
   },
   {
     "Filer_ID": "1386081",
@@ -313,27 +180,6 @@
     "Tran_Date": "2016-06-28",
     "Tran_NamF": "Janice M.",
     "Tran_NamL": "Dwyer"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Eisenberg"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Paula",
-    "Tran_NamL": "Eisenberg"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "F.M. Construction Company"
   },
   {
     "Filer_ID": "1386081",
@@ -366,6 +212,342 @@
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Terese",
+    "Tran_NamL": "Geniella"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Charles R.",
+    "Tran_NamL": "Henry"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Mary Ellen",
+    "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "George E.",
+    "Tran_NamL": "Krueger"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Todd",
+    "Tran_NamL": "Lloyd"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Mary J.",
+    "Tran_NamL": "Mahoney"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Mitchell"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Walter E.",
+    "Tran_NamL": "Moresi"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Lisa",
+    "Tran_NamL": "Moscaret-Burr"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "John F.",
+    "Tran_NamL": "Murphy"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Michael B.",
+    "Tran_NamL": "Murphy"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "David J.",
+    "Tran_NamL": "Newacheck"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "Onken"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Pacific Underground Construction, Inc."
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Edith E.",
+    "Tran_NamL": "Parrott"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Nina M.",
+    "Tran_NamL": "Patane"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Karen G.",
+    "Tran_NamL": "Queen"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Quigley"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Karen L.",
+    "Tran_NamL": "Raven"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Heather Keith",
+    "Tran_NamL": "Spellman"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "The Haley Law Offices A Professional Corporation"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Maria G.",
+    "Tran_NamL": "Trodella"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Valva"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Anita J.",
+    "Tran_NamL": "Waldron"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Bernadette",
+    "Tran_NamL": "Willoughby"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Balco Properties"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Eisenberg"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Paula",
+    "Tran_NamL": "Eisenberg"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Mitchell",
+    "Tran_NamL": "Capor"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Eveleen R.",
+    "Tran_NamL": "Corbett"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Jeffery T.",
+    "Tran_NamL": "Corbett"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "F.M. Construction Company"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "Greer"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Kellogg"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Karen I.",
+    "Tran_NamL": "McInerney"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Michael Tanzillo & Company Commercial Real Estate Brokerage General Account"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Anjeannette",
+    "Tran_NamL": "Schnetz"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Susan M.",
+    "Tran_NamL": "Scott"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Angie C.",
+    "Tran_NamL": "Sinnott"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-06-30",
+    "Tran_NamF": "Margaret A.",
+    "Tran_NamL": "Zimmerman"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Wallace"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-06",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Allen"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": -500.0,
+    "Tran_Date": "2016-07-14",
+    "Tran_NamF": "Nina M.",
+    "Tran_NamL": "Patane"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Arellano"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Peter",
+    "Tran_NamL": "Boero"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Beverly Avery",
+    "Tran_NamL": "Broussard"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Marie A.",
+    "Tran_NamL": "Cumming"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "James G.",
+    "Tran_NamL": "Daly"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
     "Tran_Date": "2016-07-22",
     "Tran_NamF": "Cormac",
     "Tran_NamL": "Gath"
@@ -379,80 +561,10 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Terese",
-    "Tran_NamL": "Geniella"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-07-22",
     "Tran_NamF": "Stephen F.",
     "Tran_NamL": "Ghiglieri"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Richard D.",
-    "Tran_NamL": "Goslee"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Janet",
-    "Tran_NamL": "Greer"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Gregory F.",
-    "Tran_NamL": "Gress"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Katherine",
-    "Tran_NamL": "Guelder"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Rodrigo",
-    "Tran_NamL": "Gutierrez"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Charles R.",
-    "Tran_NamL": "Henry"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Douglas J.",
-    "Tran_NamL": "Herman"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Robert M.",
-    "Tran_NamL": "Hittle"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Todd",
-    "Tran_NamL": "Hoekstra"
   },
   {
     "Filer_ID": "1386081",
@@ -463,94 +575,10 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Debra",
-    "Tran_NamL": "Honcik"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Alan",
-    "Tran_NamL": "Horwitz"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Lora Margherita",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "Jeffrey M.",
-    "Tran_NamL": "Jorgensen"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Theresa",
-    "Tran_NamL": "Joyce"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Kellogg"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-07-22",
     "Tran_NamF": "Danielle M.",
     "Tran_NamL": "Kenealey"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Kilty"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Mary Ellen",
-    "Tran_NamL": "King"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "Klindt"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-11",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Knutson"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-12",
-    "Tran_NamF": "Regina",
-    "Tran_NamL": "Kolhede"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "George E.",
-    "Tran_NamL": "Krueger"
   },
   {
     "Filer_ID": "1386081",
@@ -562,65 +590,9 @@
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-15",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Lange"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-07-22",
     "Tran_NamF": null,
     "Tran_NamL": "Law Offices of Daniel A. Presher"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": null,
-    "Tran_NamL": "Law Offices of Lynn K. Cadwalader"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Law Offices of W. G. Watson, Jr."
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-11",
-    "Tran_NamF": "William C.",
-    "Tran_NamL": "Levins"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Jan",
-    "Tran_NamL": "Lewis"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Luanne F.",
-    "Tran_NamL": "Livermore"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Todd",
-    "Tran_NamL": "Lloyd"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Linda M.",
-    "Tran_NamL": "Lonay"
   },
   {
     "Filer_ID": "1386081",
@@ -628,6 +600,216 @@
     "Tran_Date": "2016-07-22",
     "Tran_NamF": "Thomas V.",
     "Tran_NamL": "Loran III"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Edward E.",
+    "Tran_NamL": "Madigan"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "John H.",
+    "Tran_NamL": "McCroy"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Mimi",
+    "Tran_NamL": "Moloney"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Morris Distributing, Inc."
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Sean W.",
+    "Tran_NamL": "Morrisroe"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Garry A.",
+    "Tran_NamL": "Offenberg"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Christine M.",
+    "Tran_NamL": "Olofson"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Lorrie C.",
+    "Tran_NamL": "Owens"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Mariann C.",
+    "Tran_NamL": "Sanford"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Maria T.",
+    "Tran_NamL": "Tanzillo"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Geraldine",
+    "Tran_NamL": "Tong"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Kathleen C.",
+    "Tran_NamL": "Toomey"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Rodrigo",
+    "Tran_NamL": "Gutierrez"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "John Hanna",
+    "Tran_NamL": "Valva"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Chadwick"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Jeanette P.",
+    "Tran_NamL": "Aguilar"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Mary A.",
+    "Tran_NamL": "Ahern"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Zaccaria",
+    "Tran_NamL": "Barbieri"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Luigi A.",
+    "Tran_NamL": "Bonacini"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Suzanne M.",
+    "Tran_NamL": "Brunel"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "David E.",
+    "Tran_NamL": "Cannon"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Kelly",
+    "Tran_NamL": "Coulombe"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Jerome B.",
+    "Tran_NamL": "Deck Jr."
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Richard D.",
+    "Tran_NamL": "Goslee"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Douglas J.",
+    "Tran_NamL": "Herman"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Todd",
+    "Tran_NamL": "Hoekstra"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Lora Margherita",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Kilty"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Klindt"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Law Offices of W. G. Watson, Jr."
   },
   {
     "Filer_ID": "1386081",
@@ -652,73 +834,10 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Edward E.",
-    "Tran_NamL": "Madigan"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Edward E.",
-    "Tran_NamL": "Madigan"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-13",
-    "Tran_NamF": "Velma",
-    "Tran_NamL": "Magnani"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Mary J.",
-    "Tran_NamL": "Mahoney"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-25",
     "Tran_NamF": "Lisa",
     "Tran_NamL": "Mahoney"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Mary Corbett",
-    "Tran_NamL": "Matoza"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Ryan",
-    "Tran_NamL": "McCorvie"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "John H.",
-    "Tran_NamL": "McCroy"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-06-12",
-    "Tran_NamF": "Eileen",
-    "Tran_NamL": "McCullough"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Karen I.",
-    "Tran_NamL": "McInerney"
   },
   {
     "Filer_ID": "1386081",
@@ -729,66 +848,10 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Michael Tanzillo & Company Commercial Real Estate Brokerage General Account"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Mikula Enterprises, Inc. dba Auto Doctor of San Leandro"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Mitchell"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Mimi",
-    "Tran_NamL": "Moloney"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-25",
     "Tran_NamF": null,
     "Tran_NamL": "Montclair Land Surveying, Inc."
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Walter E.",
-    "Tran_NamL": "Moresi"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Morris Distributing, Inc."
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Sean W.",
-    "Tran_NamL": "Morrisroe"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Lisa",
-    "Tran_NamL": "Moscaret-Burr"
   },
   {
     "Filer_ID": "1386081",
@@ -799,38 +862,10 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "John F.",
-    "Tran_NamL": "Murphy"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Michael B.",
-    "Tran_NamL": "Murphy"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 300.0,
     "Tran_Date": "2016-08-25",
     "Tran_NamF": "Alexandra",
     "Tran_NamL": "Murphy"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Alfred J.",
-    "Tran_NamL": "Musante Sr."
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "David J.",
-    "Tran_NamL": "Newacheck"
   },
   {
     "Filer_ID": "1386081",
@@ -841,143 +876,10 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Carol V.",
-    "Tran_NamL": "Nitz"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": "Paul D.",
-    "Tran_NamL": "O'Driscoll"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-12",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "O'Shea"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Garry A.",
-    "Tran_NamL": "Offenberg"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Julia",
-    "Tran_NamL": "Okeeffe"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Christine M.",
-    "Tran_NamL": "Olofson"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Greg",
-    "Tran_NamL": "Onken"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Lorrie C.",
-    "Tran_NamL": "Owens"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Pacific Underground Construction, Inc."
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-11",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Palia"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Edith E.",
-    "Tran_NamL": "Parrott"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Nina M.",
-    "Tran_NamL": "Patane"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": -500.0,
-    "Tran_Date": "2016-07-14",
-    "Tran_NamF": "Nina M.",
-    "Tran_NamL": "Patane"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-08-25",
     "Tran_NamF": "Marnie",
     "Tran_NamL": "Pinsker"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Michele M.",
-    "Tran_NamL": "Pla"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Karen G.",
-    "Tran_NamL": "Queen"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Maureen",
-    "Tran_NamL": "Querio"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Quigley"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Karen L.",
-    "Tran_NamL": "Raven"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-13",
-    "Tran_NamF": "Susan H.",
-    "Tran_NamL": "Reisz"
   },
   {
     "Filer_ID": "1386081",
@@ -1016,34 +918,6 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Mariann C.",
-    "Tran_NamL": "Sanford"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Daniel J.",
-    "Tran_NamL": "Schneider"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Anjeannette",
-    "Tran_NamL": "Schnetz"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Susan M.",
-    "Tran_NamL": "Scott"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-08-25",
     "Tran_NamF": "Lisa O.",
@@ -1058,80 +932,10 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Angie C.",
-    "Tran_NamL": "Sinnott"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-18",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Skiles"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Patricia A.",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Niki L.",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 225.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Allen C.",
-    "Tran_NamL": "Speare"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Heather Keith",
-    "Tran_NamL": "Spellman"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-25",
     "Tran_NamF": "Thomas J.",
     "Tran_NamL": "Sullivan"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Maria T.",
-    "Tran_NamL": "Tanzillo"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "The Haley Law Offices A Professional Corporation"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Geraldine",
-    "Tran_NamL": "Tong"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Kathleen C.",
-    "Tran_NamL": "Toomey"
   },
   {
     "Filer_ID": "1386081",
@@ -1143,57 +947,253 @@
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Maria G.",
-    "Tran_NamL": "Trodella"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "Valva"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "John Hanna",
-    "Tran_NamL": "Valva"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-25",
     "Tran_NamF": "Bernard R.",
     "Tran_NamL": "Wade"
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Anita J.",
-    "Tran_NamL": "Waldron"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Wallace"
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Alfred J.",
+    "Tran_NamL": "Musante Sr."
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Bernadette",
-    "Tran_NamL": "Willoughby"
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Julia",
+    "Tran_NamL": "Okeeffe"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Berg"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Mary Louise",
+    "Tran_NamL": "Bucher"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Angie M.",
+    "Tran_NamL": "Chakalian"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": null,
+    "Tran_NamL": "Law Offices of Lynn K. Cadwalader"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Carol V.",
+    "Tran_NamL": "Nitz"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Michele M.",
+    "Tran_NamL": "Pla"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Daniel J.",
+    "Tran_NamL": "Schneider"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Patricia A.",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Alan",
+    "Tran_NamL": "Horwitz"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-06-30",
-    "Tran_NamF": "Margaret A.",
-    "Tran_NamL": "Zimmerman"
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Katherine",
+    "Tran_NamL": "Guelder"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Jan",
+    "Tran_NamL": "Lewis"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Andrew J. Maxwell, M.D., Inc."
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Stephen M.",
+    "Tran_NamL": "Crosetti"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Theresa",
+    "Tran_NamL": "Joyce"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Luanne F.",
+    "Tran_NamL": "Livermore"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Linda M.",
+    "Tran_NamL": "Lonay"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Edward E.",
+    "Tran_NamL": "Madigan"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Maureen",
+    "Tran_NamL": "Querio"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Gregory F.",
+    "Tran_NamL": "Gress"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Pamela K.",
+    "Tran_NamL": "Corbett"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Ross F.",
+    "Tran_NamL": "Catanzarite"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Cunniffe"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Robert M.",
+    "Tran_NamL": "Hittle"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 225.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Allen C.",
+    "Tran_NamL": "Speare"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Donovan"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": -300.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Pamela K.",
+    "Tran_NamL": "Corbett"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Real Estate PAC (CREPAC)- California Association of Realtors"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Mary Corbett",
+    "Tran_NamL": "Matoza"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mikula Enterprises, Inc. dba Auto Doctor of San Leandro"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Ryan",
+    "Tran_NamL": "McCorvie"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Debra",
+    "Tran_NamL": "Honcik"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "F.L.",
+    "Tran_NamL": "Burnett"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Niki L.",
+    "Tran_NamL": "Smith"
   }
 ]

--- a/build/committee/1386081/contributions/index.json
+++ b/build/committee/1386081/contributions/index.json
@@ -190,20 +190,6 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Pamela K.",
-    "Tran_NamL": "Corbett"
-  },
-  {
-    "Filer_ID": "1386081",
-    "Tran_Amt1": -300.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Pamela K.",
-    "Tran_NamL": "Corbett"
-  },
-  {
-    "Filer_ID": "1386081",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "Jeffery T.",
@@ -214,6 +200,20 @@
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-06-30",
     "Tran_NamF": "Eveleen R.",
+    "Tran_NamL": "Corbett"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Pamela K.",
+    "Tran_NamL": "Corbett"
+  },
+  {
+    "Filer_ID": "1386081",
+    "Tran_Amt1": -300.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Pamela K.",
     "Tran_NamL": "Corbett"
   },
   {
@@ -276,14 +276,14 @@
     "Filer_ID": "1386081",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Darcy",
+    "Tran_NamF": "James A.",
     "Tran_NamL": "Diamantine"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-06-28",
-    "Tran_NamF": "James A.",
+    "Tran_NamF": "Darcy",
     "Tran_NamL": "Diamantine"
   },
   {
@@ -653,14 +653,14 @@
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
+    "Tran_Date": "2016-07-22",
     "Tran_NamF": "Edward E.",
     "Tran_NamL": "Madigan"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-22",
+    "Tran_Date": "2016-09-23",
     "Tran_NamF": "Edward E.",
     "Tran_NamL": "Madigan"
   },
@@ -806,16 +806,16 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Alexandra",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Michael B.",
     "Tran_NamL": "Murphy"
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Michael B.",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Alexandra",
     "Tran_NamL": "Murphy"
   },
   {
@@ -918,15 +918,15 @@
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": -500.0,
-    "Tran_Date": "2016-07-14",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
     "Tran_NamF": "Nina M.",
     "Tran_NamL": "Patane"
   },
   {
     "Filer_ID": "1386081",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
+    "Tran_Amt1": -500.0,
+    "Tran_Date": "2016-07-14",
     "Tran_NamF": "Nina M.",
     "Tran_NamL": "Patane"
   },
@@ -1073,15 +1073,15 @@
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Niki L.",
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Patricia A.",
     "Tran_NamL": "Smith"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Patricia A.",
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Niki L.",
     "Tran_NamL": "Smith"
   },
   {
@@ -1129,15 +1129,15 @@
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Claudia E.",
+    "Tran_Date": "2016-07-22",
+    "Tran_NamF": "Kathleen C.",
     "Tran_NamL": "Toomey"
   },
   {
     "Filer_ID": "1386081",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-22",
-    "Tran_NamF": "Kathleen C.",
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Claudia E.",
     "Tran_NamL": "Toomey"
   },
   {

--- a/build/committee/1386145/contributions/index.json
+++ b/build/committee/1386145/contributions/index.json
@@ -9,14 +9,14 @@
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-21",
+    "Tran_Date": "2016-04-17",
     "Tran_NamF": "Barbara",
     "Tran_NamL": "Attard"
   },
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-17",
+    "Tran_Date": "2016-09-21",
     "Tran_NamF": "Barbara",
     "Tran_NamL": "Attard"
   },
@@ -29,15 +29,15 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-28",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-05-04",
     "Tran_NamF": "Ginny",
     "Tran_NamL": "Berson"
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-05-04",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-28",
     "Tran_NamF": "Ginny",
     "Tran_NamL": "Berson"
   },
@@ -134,15 +134,15 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-15",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-23",
     "Tran_NamF": "Gay",
     "Tran_NamL": "Cobb"
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-23",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-15",
     "Tran_NamF": "Gay",
     "Tran_NamL": "Cobb"
   },
@@ -204,15 +204,15 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-10",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-14",
     "Tran_NamF": null,
     "Tran_NamL": "Dan Kalb City Council Officeholder Committee"
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-14",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-10",
     "Tran_NamF": null,
     "Tran_NamL": "Dan Kalb City Council Officeholder Committee"
   },
@@ -246,15 +246,15 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-24",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-21",
     "Tran_NamF": "Pamela",
     "Tran_NamL": "Drake"
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-21",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": "Pamela",
     "Tran_NamL": "Drake"
   },
@@ -288,15 +288,15 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-12",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-01-25",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Ferro"
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-01-25",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-12",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Ferro"
   },
@@ -372,6 +372,13 @@
   },
   {
     "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hofer"
+  },
+  {
+    "Filer_ID": "1386145",
     "Tran_Amt1": 25.0,
     "Tran_Date": "2016-10-24",
     "Tran_NamF": "Marcia and Ricardo",
@@ -380,21 +387,14 @@
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Hofer"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-24",
+    "Tran_Date": "2016-08-17",
     "Tran_NamF": "Julie",
     "Tran_NamL": "Humphrey"
   },
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-17",
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": "Julie",
     "Tran_NamL": "Humphrey"
   },
@@ -561,15 +561,15 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 280.0,
-    "Tran_Date": "2016-10-24",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-20",
     "Tran_NamF": "Michael",
     "Tran_NamL": "McAfee"
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-20",
+    "Tran_Amt1": 280.0,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": "Michael",
     "Tran_NamL": "McAfee"
   },
@@ -701,20 +701,6 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 600.0,
-    "Tran_Date": "2016-03-29",
-    "Tran_NamF": "Len",
-    "Tran_NamL": "Raphael"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-11",
-    "Tran_NamF": "Len",
-    "Tran_NamL": "Raphael"
-  },
-  {
-    "Filer_ID": "1386145",
     "Tran_Amt1": 2.85,
     "Tran_Date": "2016-01-26",
     "Tran_NamF": "Len",
@@ -731,6 +717,20 @@
     "Filer_ID": "1386145",
     "Tran_Amt1": 1.0,
     "Tran_Date": "2016-02-01",
+    "Tran_NamF": "Len",
+    "Tran_NamL": "Raphael"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-11",
+    "Tran_NamF": "Len",
+    "Tran_NamL": "Raphael"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-03-29",
     "Tran_NamF": "Len",
     "Tran_NamL": "Raphael"
   },
@@ -772,14 +772,14 @@
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
+    "Tran_Date": "2016-09-22",
     "Tran_NamF": "Sharon",
     "Tran_NamL": "Rose"
   },
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-22",
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": "Sharon",
     "Tran_NamL": "Rose"
   },
@@ -841,6 +841,13 @@
   },
   {
     "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-19",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Shawl"
+  },
+  {
+    "Filer_ID": "1386145",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-08-23",
     "Tran_NamF": "Susan",
@@ -850,13 +857,6 @@
     "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Shawl"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-19",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Shawl"
   },
@@ -925,8 +925,8 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-25",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-19",
     "Tran_NamF": "Bonnie",
     "Tran_NamL": "Steinbock"
   },
@@ -939,8 +939,8 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-19",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-25",
     "Tran_NamF": "Bonnie",
     "Tran_NamL": "Steinbock"
   },
@@ -1009,20 +1009,6 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-11-19",
-    "Tran_NamF": "Allene",
-    "Tran_NamL": "Warren"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Allene",
-    "Tran_NamL": "Warren"
-  },
-  {
-    "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-04-21",
     "Tran_NamF": "Allene",
@@ -1037,8 +1023,22 @@
   },
   {
     "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Allene",
+    "Tran_NamL": "Warren"
+  },
+  {
+    "Filer_ID": "1386145",
     "Tran_Amt1": 125.0,
     "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Allene",
+    "Tran_NamL": "Warren"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-11-19",
     "Tran_NamF": "Allene",
     "Tran_NamL": "Warren"
   },
@@ -1073,15 +1073,15 @@
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "E. Jane",
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Larry",
     "Tran_NamL": "White"
   },
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Larry",
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "E. Jane",
     "Tran_NamL": "White"
   },
   {
@@ -1090,6 +1090,13 @@
     "Tran_Date": "2016-09-21",
     "Tran_NamF": "Valerie",
     "Tran_NamL": "Winemiller"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 1.0,
+    "Tran_Date": "2016-01-26",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Wrobel"
   },
   {
     "Filer_ID": "1386145",
@@ -1102,13 +1109,6 @@
     "Filer_ID": "1386145",
     "Tran_Amt1": 20.0,
     "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Wrobel"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 1.0,
-    "Tran_Date": "2016-01-26",
     "Tran_NamF": "Jonathan",
     "Tran_NamL": "Wrobel"
   },

--- a/build/committee/1386145/contributions/index.json
+++ b/build/committee/1386145/contributions/index.json
@@ -1,10 +1,115 @@
 [
   {
     "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-01-22",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Magnani"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-23",
+    "Tran_NamF": "Gay",
+    "Tran_NamL": "Cobb"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-01-25",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Ferro"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 1.65,
+    "Tran_Date": "2016-01-26",
+    "Tran_NamF": "Len",
+    "Tran_NamL": "Raphael"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 2.85,
+    "Tran_Date": "2016-01-26",
+    "Tran_NamF": "Len",
+    "Tran_NamL": "Raphael"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 1.0,
+    "Tran_Date": "2016-01-26",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Wrobel"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 1.0,
+    "Tran_Date": "2016-02-01",
+    "Tran_NamF": "Len",
+    "Tran_NamL": "Raphael"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-02-04",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Shawl"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Dewart"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-03-11",
+    "Tran_NamF": "Len",
+    "Tran_NamL": "Raphael"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-19",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Shawl"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-20",
+    "Tran_NamF": "Beverley",
+    "Tran_NamL": "Smrha"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-03-29",
+    "Tran_NamF": "Len",
+    "Tran_NamL": "Raphael"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-03-31",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Tasic"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-04-04",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Janks"
+  },
+  {
+    "Filer_ID": "1386145",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-27",
+    "Tran_Date": "2016-04-15",
     "Tran_NamF": null,
-    "Tran_NamL": "American Civil Liberties Union"
+    "Tran_NamL": "Wellstone Democratic Club"
   },
   {
     "Filer_ID": "1386145",
@@ -16,16 +121,9 @@
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Attard"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Pieter",
-    "Tran_NamL": "Bach"
+    "Tran_Date": "2016-04-21",
+    "Tran_NamF": "Allene",
+    "Tran_NamL": "Warren"
   },
   {
     "Filer_ID": "1386145",
@@ -36,269 +134,10 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 40.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "Ginny",
-    "Tran_NamL": "Berson"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Bluestein"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Victor",
-    "Tran_NamL": "Bonfilio"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Lorelei",
-    "Tran_NamL": "Bosserman"
-  },
-  {
-    "Filer_ID": "1386145",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Rofiah",
-    "Tran_NamL": "Breen"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Annise",
-    "Tran_NamL": "Brokstein"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Bruckman"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Lisa",
-    "Tran_NamL": "Buchberg"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 750.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Burris"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "Francis",
-    "Tran_NamL": "Calpotura"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Francis",
-    "Tran_NamL": "Calpotura"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Chorneau"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Cilley"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-23",
-    "Tran_NamF": "Gay",
-    "Tran_NamL": "Cobb"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Gay",
-    "Tran_NamL": "Cobb"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Toni",
-    "Tran_NamL": "Cook"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Cowan"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Adam",
-    "Tran_NamL": "Cozzette"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Cunningham"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Cunningham"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Mime",
-    "Tran_NamL": "Cuvalo"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Rajesh",
-    "Tran_NamL": "Daftary"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Emma",
-    "Tran_NamL": "Daftary"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "Dan Kalb City Council Officeholder Committee"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Dan Kalb City Council Officeholder Committee"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Mary Quinn",
-    "Tran_NamL": "Delaney"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Jackie",
-    "Tran_NamL": "Dennis"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 180.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "Nathaniel",
-    "Tran_NamL": "Dewart"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Nathaniel",
-    "Tran_NamL": "Dewart"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Pamela",
-    "Tran_NamL": "Drake"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Pamela",
-    "Tran_NamL": "Drake"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Laurie",
-    "Tran_NamL": "Earp"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Elect McElhaney for City Council 2016"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "Kathrun",
-    "Tran_NamL": "Epstein"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Dina",
-    "Tran_NamL": "Ezzedine"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-01-25",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Ferro"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Ferro"
+    "Tran_Date": "2016-06-14",
+    "Tran_NamF": "Torger",
+    "Tran_NamL": "Johnson"
   },
   {
     "Filer_ID": "1386145",
@@ -309,80 +148,10 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Annette",
-    "Tran_NamL": "Floystrup"
-  },
-  {
-    "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Kelly",
-    "Tran_NamL": "Garrison"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Ed",
-    "Tran_NamL": "Gerber"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Gillman"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Rashidah",
-    "Tran_NamL": "Grinage"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Hamid",
-    "Tran_NamL": "Grinage"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Erin",
-    "Tran_NamL": "Hagan"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Paula",
-    "Tran_NamL": "Hawthorn"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Hershey"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Hofer"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Marcia and Ricardo",
-    "Tran_NamL": "Hofer"
+    "Tran_Date": "2016-07-07",
+    "Tran_NamF": "Ver",
+    "Tran_NamL": "Ronja"
   },
   {
     "Filer_ID": "1386145",
@@ -393,535 +162,10 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Julie",
-    "Tran_NamL": "Humphrey"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Federation of Professional and Technical Engineers Local 21 Issues PAC Fund"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Jacobs"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-04-04",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Janks"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Sandhya",
-    "Tran_NamL": "Jha"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-14",
-    "Tran_NamF": "Torger",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Laniece",
-    "Tran_NamL": "Jones"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Saied",
-    "Tran_NamL": "Karamooz"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 540.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Alexander",
-    "Tran_NamL": "Kelter"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Kevess"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Knight"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Kogler"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Leah",
-    "Tran_NamL": "Korican"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-11",
-    "Tran_NamF": "Kurt",
-    "Tran_NamL": "Kuhwald"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Jack",
-    "Tran_NamL": "Kurzweil"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Jack",
-    "Tran_NamL": "Kurzweil"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 54.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Landau"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Lavelle"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Nate",
-    "Tran_NamL": "Lawson"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Joan",
-    "Tran_NamL": "Lichterman"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Alexandra",
-    "Tran_NamL": "Lubomirsky"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-01-22",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Magnani"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Make Oakland Better Now"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Mayor Libby Schaaf 2014 Officeholder Committee"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "McAfee"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 280.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "McAfee"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Merriam"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Alexandra",
-    "Tran_NamL": "Mobley"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Martin",
-    "Tran_NamL": "Monica"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Muhammad"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Munro"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Cytron",
-    "Tran_NamL": "Naomi"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Oakland",
-    "Tran_NamL": "Neighbors for Racial Justice"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Noble"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Northern California District Council, International Longshore and Warehouse Union"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Maura",
-    "Tran_NamL": "O'Brien"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Education Association PAC"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Connie",
-    "Tran_NamL": "Perry"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Jason",
-    "Tran_NamL": "Pfeifle"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Joe",
-    "Tran_NamL": "Pfeifle"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Shikira",
-    "Tran_NamL": "Porter"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Prados"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Art",
-    "Tran_NamL": "Ramsey"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Art",
-    "Tran_NamL": "Ramsey"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 2.85,
-    "Tran_Date": "2016-01-26",
-    "Tran_NamF": "Len",
-    "Tran_NamL": "Raphael"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 1.65,
-    "Tran_Date": "2016-01-26",
-    "Tran_NamF": "Len",
-    "Tran_NamL": "Raphael"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 1.0,
-    "Tran_Date": "2016-02-01",
-    "Tran_NamF": "Len",
-    "Tran_NamL": "Raphael"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-03-11",
-    "Tran_NamF": "Len",
-    "Tran_NamL": "Raphael"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 600.0,
-    "Tran_Date": "2016-03-29",
-    "Tran_NamF": "Len",
-    "Tran_NamL": "Raphael"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Lyles",
-    "Tran_NamL": "Reginald"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Adrienne",
-    "Tran_NamL": "Ricardo"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Rachel",
-    "Tran_NamL": "Richman"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Walter",
-    "Tran_NamL": "Riley"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-07-07",
-    "Tran_NamF": "Ver",
-    "Tran_NamL": "Ronja"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Sharon",
-    "Tran_NamL": "Rose"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Sharon",
-    "Tran_NamL": "Rose"
-  },
-  {
-    "Filer_ID": "1386145",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-18",
     "Tran_NamF": "Jessica",
     "Tran_NamL": "Rothhaar"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Rubin"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Constance",
-    "Tran_NamL": "Ryan"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Naomi",
-    "Tran_NamL": "Schiff"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Naomi",
-    "Tran_NamL": "Schiff"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Schlosberg"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Issues PAC"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-02-04",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Shawl"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-19",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Shawl"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Shawl"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Shawl"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Jan",
-    "Tran_NamL": "Simon"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Anita",
-    "Tran_NamL": "Singha"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-20",
-    "Tran_NamF": "Beverley",
-    "Tran_NamL": "Smrha"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-10",
-    "Tran_NamF": "Beverley",
-    "Tran_NamL": "Smrha"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Alanya",
-    "Tran_NamL": "Snyder"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Vicki",
-    "Tran_NamL": "Solomon"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Samson",
-    "Tran_NamL": "Sprouse"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Judith",
-    "Tran_NamL": "Stacey"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 35.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": "Ruby",
-    "Tran_NamL": "Stein"
   },
   {
     "Filer_ID": "1386145",
@@ -939,17 +183,311 @@
   },
   {
     "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Allene",
+    "Tran_NamL": "Warren"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Chorneau"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Ed",
+    "Tran_NamL": "Gerber"
+  },
+  {
+    "Filer_ID": "1386145",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Bonnie",
-    "Tran_NamL": "Steinbock"
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Rashidah",
+    "Tran_NamL": "Grinage"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Paula",
+    "Tran_NamL": "Hawthorn"
   },
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Anand",
-    "Tran_NamL": "Subramanian"
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Oakland",
+    "Tran_NamL": "Neighbors for Racial Justice"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Shawl"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 40.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "Ginny",
+    "Tran_NamL": "Berson"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Jackie",
+    "Tran_NamL": "Dennis"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Noble"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Martin",
+    "Tran_NamL": "Monica"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Alexandra",
+    "Tran_NamL": "Mobley"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Krista",
+    "Tran_NamL": "Yu"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Beverley",
+    "Tran_NamL": "Smrha"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-11",
+    "Tran_NamF": "Kurt",
+    "Tran_NamL": "Kuhwald"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Rofiah",
+    "Tran_NamL": "Breen"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Ferro"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Laurie",
+    "Tran_NamL": "Earp"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Cunningham"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "Dan Kalb City Council Officeholder Committee"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Lorelei",
+    "Tran_NamL": "Bosserman"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Gay",
+    "Tran_NamL": "Cobb"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Anita",
+    "Tran_NamL": "Singha"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Dewart"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Kogler"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Prados"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Larry",
+    "Tran_NamL": "White"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 540.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Alexander",
+    "Tran_NamL": "Kelter"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Pfeifle"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Nicholas",
+    "Tran_NamL": "Vigilante"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Cytron",
+    "Tran_NamL": "Naomi"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Art",
+    "Tran_NamL": "Ramsey"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Mary",
+    "Tran_NamL": "Vail"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 750.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Burris"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Hershey"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "McAfee"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Attard"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Drake"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Kelly",
+    "Tran_NamL": "Garrison"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Sandhya",
+    "Tran_NamL": "Jha"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Saied",
+    "Tran_NamL": "Karamooz"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Jack",
+    "Tran_NamL": "Kurzweil"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Maura",
+    "Tran_NamL": "O'Brien"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Adrienne",
+    "Tran_NamL": "Ricardo"
   },
   {
     "Filer_ID": "1386145",
@@ -960,10 +498,255 @@
   },
   {
     "Filer_ID": "1386145",
+    "Tran_Amt1": 35.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Valerie",
+    "Tran_NamL": "Winemiller"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Victor",
+    "Tran_NamL": "Bonfilio"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Sharon",
+    "Tran_NamL": "Rose"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Naomi",
+    "Tran_NamL": "Schiff"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Lisa",
+    "Tran_NamL": "Buchberg"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Laniece",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Lyles",
+    "Tran_NamL": "Reginald"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Emily",
+    "Tran_NamL": "Weinstein"
+  },
+  {
+    "Filer_ID": "1386145",
     "Tran_Amt1": 25.0,
-    "Tran_Date": "2016-03-31",
-    "Tran_NamF": "Sandra",
-    "Tran_NamL": "Tasic"
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Bluestein"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Leah",
+    "Tran_NamL": "Korican"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Merriam"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Bonnie",
+    "Tran_NamL": "Steinbock"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Bruckman"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Cilley"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Rajesh",
+    "Tran_NamL": "Daftary"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 5.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Joel",
+    "Tran_NamL": "Weber"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Make Oakland Better Now"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Walter",
+    "Tran_NamL": "Riley"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Pieter",
+    "Tran_NamL": "Bach"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Toni",
+    "Tran_NamL": "Cook"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Munro"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Shikira",
+    "Tran_NamL": "Porter"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Issues PAC"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "Francis",
+    "Tran_NamL": "Calpotura"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "Kathrun",
+    "Tran_NamL": "Epstein"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Alanya",
+    "Tran_NamL": "Snyder"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Annise",
+    "Tran_NamL": "Brokstein"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Dina",
+    "Tran_NamL": "Ezzedine"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Gillman"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Lichterman"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Annette",
+    "Tran_NamL": "Floystrup"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Lavelle"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Connie",
+    "Tran_NamL": "Perry"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Vicki",
+    "Tran_NamL": "Solomon"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Whalen"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 54.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Landau"
   },
   {
     "Filer_ID": "1386145",
@@ -971,6 +754,76 @@
     "Tran_Date": "2016-10-07",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Tigges"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Dan Kalb City Council Officeholder Committee"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Mary Quinn",
+    "Tran_NamL": "Delaney"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Muhammad"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Elect McElhaney for City Council 2016"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California District Council, International Longshore and Warehouse Union"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Rachel",
+    "Tran_NamL": "Richman"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Jan",
+    "Tran_NamL": "Simon"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "E. Jane",
+    "Tran_NamL": "White"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hofer"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Alexandra",
+    "Tran_NamL": "Lubomirsky"
   },
   {
     "Filer_ID": "1386145",
@@ -982,16 +835,191 @@
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Harrison",
-    "Tran_NamL": "Touw"
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Cowan"
   },
   {
     "Filer_ID": "1386145",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Mary",
-    "Tran_NamL": "Vail"
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Nate",
+    "Tran_NamL": "Lawson"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Mime",
+    "Tran_NamL": "Cuvalo"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Kevess"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 35.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Ruby",
+    "Tran_NamL": "Stein"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Francis",
+    "Tran_NamL": "Calpotura"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Cozzette"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Cunningham"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Emma",
+    "Tran_NamL": "Daftary"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Drake"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Erin",
+    "Tran_NamL": "Hagan"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Marcia and Ricardo",
+    "Tran_NamL": "Hofer"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Julie",
+    "Tran_NamL": "Humphrey"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Jacobs"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Knight"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Jack",
+    "Tran_NamL": "Kurzweil"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 280.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "McAfee"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Education Association PAC"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Art",
+    "Tran_NamL": "Ramsey"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Sharon",
+    "Tran_NamL": "Rose"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Rubin"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Shawl"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Samson",
+    "Tran_NamL": "Sprouse"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Judith",
+    "Tran_NamL": "Stacey"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Anand",
+    "Tran_NamL": "Subramanian"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Harrison",
+    "Tran_NamL": "Touw"
   },
   {
     "Filer_ID": "1386145",
@@ -1002,22 +1030,8 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Nicholas",
-    "Tran_NamL": "Vigilante"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-04-21",
-    "Tran_NamF": "Allene",
-    "Tran_NamL": "Warren"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-22",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": "Allene",
     "Tran_NamL": "Warren"
   },
@@ -1027,76 +1041,6 @@
     "Tran_Date": "2016-10-24",
     "Tran_NamF": "Allene",
     "Tran_NamL": "Warren"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Allene",
-    "Tran_NamL": "Warren"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-11-19",
-    "Tran_NamF": "Allene",
-    "Tran_NamL": "Warren"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 5.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Joel",
-    "Tran_NamL": "Weber"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Emily",
-    "Tran_NamL": "Weinstein"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-04-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Wellstone Democratic Club"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Whalen"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Larry",
-    "Tran_NamL": "White"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "E. Jane",
-    "Tran_NamL": "White"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 35.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Valerie",
-    "Tran_NamL": "Winemiller"
-  },
-  {
-    "Filer_ID": "1386145",
-    "Tran_Amt1": 1.0,
-    "Tran_Date": "2016-01-26",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Wrobel"
   },
   {
     "Filer_ID": "1386145",
@@ -1114,16 +1058,72 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Krista",
-    "Tran_NamL": "Yu"
-  },
-  {
-    "Filer_ID": "1386145",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-10-24",
     "Tran_NamF": "Barry",
     "Tran_NamL": "Zuckerman"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Naomi",
+    "Tran_NamL": "Schiff"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "American Civil Liberties Union"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Joe",
+    "Tran_NamL": "Pfeifle"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Hamid",
+    "Tran_NamL": "Grinage"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mayor Libby Schaaf 2014 Officeholder Committee"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 25.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Constance",
+    "Tran_NamL": "Ryan"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Federation of Professional and Technical Engineers Local 21 Issues PAC Fund"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Schlosberg"
+  },
+  {
+    "Filer_ID": "1386145",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-11-19",
+    "Tran_NamF": "Allene",
+    "Tran_NamL": "Warren"
   }
 ]

--- a/build/committee/1386145/contributions/index.json
+++ b/build/committee/1386145/contributions/index.json
@@ -1030,14 +1030,14 @@
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 125.0,
+    "Tran_Amt1": 25.0,
     "Tran_Date": "2016-10-24",
     "Tran_NamF": "Allene",
     "Tran_NamL": "Warren"
   },
   {
     "Filer_ID": "1386145",
-    "Tran_Amt1": 25.0,
+    "Tran_Amt1": 125.0,
     "Tran_Date": "2016-10-24",
     "Tran_NamF": "Allene",
     "Tran_NamL": "Warren"

--- a/build/committee/1386416/contributions/index.json
+++ b/build/committee/1386416/contributions/index.json
@@ -1,24 +1,24 @@
 [
   {
     "Filer_ID": "1386416",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-15",
+    "Tran_NamF": "jan",
+    "Tran_NamL": "herbert"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": -712.0,
+    "Tran_Date": "2016-04-04",
+    "Tran_NamF": "jan",
+    "Tran_NamL": "herbert"
+  },
+  {
+    "Filer_ID": "1386416",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-06-27",
     "Tran_NamF": "Dan",
     "Tran_NamL": "Bellino"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-24",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Bellino"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Courtney",
-    "Tran_NamL": "Benoist"
   },
   {
     "Filer_ID": "1386416",
@@ -30,16 +30,30 @@
   {
     "Filer_ID": "1386416",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Brown"
+    "Tran_Date": "2016-06-27",
+    "Tran_NamF": "michael",
+    "Tran_NamL": "deflorimonte"
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "Carol",
-    "Tran_NamL": "Burton"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Skankar",
+    "Tran_NamL": "Krishna"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-29",
+    "Tran_NamF": "Akil",
+    "Tran_NamL": "Manley"
   },
   {
     "Filer_ID": "1386416",
@@ -51,16 +65,30 @@
   {
     "Filer_ID": "1386416",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-05",
+    "Tran_NamF": "Kelun",
+    "Tran_NamL": "Zhang"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-14",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Walsh"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-19",
     "Tran_NamF": "Dan",
     "Tran_NamL": "Cohen"
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-12-02",
-    "Tran_NamF": "Chuck",
-    "Tran_NamL": "Daggs"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Bellino"
   },
   {
     "Filer_ID": "1386416",
@@ -71,10 +99,17 @@
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "JEAN",
-    "Tran_NamL": "Driscoll"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Amana",
+    "Tran_NamL": "Harris"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Dirk",
+    "Tran_NamL": "Tillotson"
   },
   {
     "Filer_ID": "1386416",
@@ -85,10 +120,17 @@
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-12-17",
-    "Tran_NamF": "Lauren",
-    "Tran_NamL": "Dutton"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Beth",
+    "Tran_NamL": "Thompson"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Laurene",
+    "Tran_NamL": "Powell Jobs"
   },
   {
     "Filer_ID": "1386416",
@@ -96,83 +138,6 @@
     "Tran_Date": "2016-09-26",
     "Tran_NamF": null,
     "Tran_NamL": "Families and Educators for Public Edducation"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "JASON",
-    "Tran_NamL": "Fish"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Abe",
-    "Tran_NamL": "Friedman"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Hardin"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Amana",
-    "Tran_NamL": "Harris"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Florence",
-    "Tran_NamL": "Kong"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Isaac",
-    "Tran_NamL": "Kos-Read"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Skankar",
-    "Tran_NamL": "Krishna"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Raymond",
-    "Tran_NamL": "Lankford"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Lowe"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-29",
-    "Tran_NamF": "Akil",
-    "Tran_NamL": "Manley"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Woods-Cadiz",
-    "Tran_NamL": "Maya"
   },
   {
     "Filer_ID": "1386416",
@@ -191,72 +156,9 @@
   {
     "Filer_ID": "1386416",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Laurene",
-    "Tran_NamL": "Powell Jobs"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-28",
     "Tran_NamF": "David",
     "Tran_NamL": "Rangel"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Riley"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": -300.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Tracy",
-    "Tran_NamL": "Session"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Melanie",
-    "Tran_NamL": "Shelby"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Sorr"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-30",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sorrell"
   },
   {
     "Filer_ID": "1386416",
@@ -267,24 +169,115 @@
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Beth",
-    "Tran_NamL": "Thompson"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Riley"
   },
   {
     "Filer_ID": "1386416",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Dirk",
-    "Tran_NamL": "Tillotson"
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "Carol",
+    "Tran_NamL": "Burton"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "JEAN",
+    "Tran_NamL": "Driscoll"
   },
   {
     "Filer_ID": "1386416",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-14",
-    "Tran_NamF": "Patrick",
-    "Tran_NamL": "Walsh"
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Sorr"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Hardin"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Florence",
+    "Tran_NamL": "Kong"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Woods-Cadiz",
+    "Tran_NamL": "Maya"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Raymond",
+    "Tran_NamL": "Lankford"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Melanie",
+    "Tran_NamL": "Shelby"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Courtney",
+    "Tran_NamL": "Benoist"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "JASON",
+    "Tran_NamL": "Fish"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": -300.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Abe",
+    "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Isaac",
+    "Tran_NamL": "Kos-Read"
   },
   {
     "Filer_ID": "1386416",
@@ -295,30 +288,37 @@
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-05",
-    "Tran_NamF": "Kelun",
-    "Tran_NamL": "Zhang"
-  },
-  {
-    "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-27",
-    "Tran_NamF": "michael",
-    "Tran_NamL": "deflorimonte"
-  },
-  {
-    "Filer_ID": "1386416",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-15",
-    "Tran_NamF": "jan",
-    "Tran_NamL": "herbert"
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Lowe"
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": -712.0,
-    "Tran_Date": "2016-04-04",
-    "Tran_NamF": "jan",
-    "Tran_NamL": "herbert"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Session"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sorrell"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-12-02",
+    "Tran_NamF": "Chuck",
+    "Tran_NamL": "Daggs"
+  },
+  {
+    "Filer_ID": "1386416",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-12-17",
+    "Tran_NamF": "Lauren",
+    "Tran_NamL": "Dutton"
   }
 ]

--- a/build/committee/1386416/contributions/index.json
+++ b/build/committee/1386416/contributions/index.json
@@ -1,15 +1,15 @@
 [
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-24",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-06-27",
     "Tran_NamF": "Dan",
     "Tran_NamL": "Bellino"
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-06-27",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-24",
     "Tran_NamF": "Dan",
     "Tran_NamL": "Bellino"
   },
@@ -212,14 +212,14 @@
   {
     "Filer_ID": "1386416",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-15",
+    "Tran_Date": "2016-06-28",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Rogers"
   },
   {
     "Filer_ID": "1386416",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-06-28",
+    "Tran_Date": "2016-10-15",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Rogers"
   },
@@ -281,15 +281,15 @@
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-27",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-14",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Walsh"
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-14",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-27",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Walsh"
   },
@@ -309,15 +309,15 @@
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": -712.0,
-    "Tran_Date": "2016-04-04",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-03-15",
     "Tran_NamF": "jan",
     "Tran_NamL": "herbert"
   },
   {
     "Filer_ID": "1386416",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-03-15",
+    "Tran_Amt1": -712.0,
+    "Tran_Date": "2016-04-04",
     "Tran_NamF": "jan",
     "Tran_NamL": "herbert"
   }

--- a/build/committee/1386749/contributions/index.json
+++ b/build/committee/1386749/contributions/index.json
@@ -107,14 +107,14 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-27",
+    "Tran_Date": "2016-08-06",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Jimenez"
   },
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-06",
+    "Tran_Date": "2016-09-27",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Jimenez"
   },
@@ -149,14 +149,14 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-30",
+    "Tran_Date": "2016-08-06",
     "Tran_NamF": "Carmen",
     "Tran_NamL": "Morales"
   },
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-06",
+    "Tran_Date": "2016-09-30",
     "Tran_NamF": "Carmen",
     "Tran_NamL": "Morales"
   },
@@ -184,13 +184,6 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Salvador",
-    "Tran_NamL": "Ortiz"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "Angelica",
     "Tran_NamL": "Ortiz"
@@ -200,6 +193,13 @@
     "Tran_Amt1": 350.0,
     "Tran_Date": "2016-09-03",
     "Tran_NamF": "Freddy",
+    "Tran_NamL": "Ortiz"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Salvador",
     "Tran_NamL": "Ortiz"
   },
   {
@@ -240,13 +240,6 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "T. Gary",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-16",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Rogers"
@@ -256,6 +249,13 @@
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-16",
     "Tran_NamF": "Kathrine",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "T. Gary",
     "Tran_NamL": "Rogers"
   },
   {
@@ -323,16 +323,16 @@
   },
   {
     "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Parker",
+    "Tran_Amt1": 313.31,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Hae-Sin",
     "Tran_NamL": "Thomas"
   },
   {
     "Filer_ID": "1386749",
-    "Tran_Amt1": 313.31,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Hae-Sin",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Parker",
     "Tran_NamL": "Thomas"
   },
   {
@@ -345,15 +345,15 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "Maricela",
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "Adelina",
     "Tran_NamL": "Trenado"
   },
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "Adelina",
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Maricela",
     "Tran_NamL": "Trenado"
   },
   {
@@ -386,15 +386,15 @@
   },
   {
     "Filer_ID": "1386749",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-20",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-27",
     "Tran_NamF": "Jean",
     "Tran_NamL": "Wing"
   },
   {
     "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-27",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-20",
     "Tran_NamF": "Jean",
     "Tran_NamL": "Wing"
   },

--- a/build/committee/1386749/contributions/index.json
+++ b/build/committee/1386749/contributions/index.json
@@ -1,31 +1,24 @@
 [
   {
     "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-13",
+    "Tran_NamF": "Huber",
+    "Tran_NamL": "Trenado"
+  },
+  {
+    "Filer_ID": "1386749",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "Larissa",
-    "Tran_NamL": "Adam"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Elena",
-    "Tran_NamL": "Aguilar"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-01",
-    "Tran_NamF": "Legratta",
-    "Tran_NamL": "Banks"
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Cruz",
+    "Tran_NamL": "Trenado Ortiz"
   },
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Courtney",
-    "Tran_NamL": "Benoist"
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Libby",
+    "Tran_NamL": "Schaaf"
   },
   {
     "Filer_ID": "1386749",
@@ -37,72 +30,16 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Bromley"
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "Eduardo",
+    "Tran_NamL": "Martinez"
   },
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "Santiago",
-    "Tran_NamL": "Campos"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "Josephine",
-    "Tran_NamL": "Chu"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Cohen"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Danner"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "Families and Educators for Public Education FPPC #1331137"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Jason",
-    "Tran_NamL": "Fish"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "Crystal",
-    "Tran_NamL": "Fisher"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Abe",
-    "Tran_NamL": "Friedman"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Christina",
-    "Tran_NamL": "Greenberg"
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "Adelina",
+    "Tran_NamL": "Trenado"
   },
   {
     "Filer_ID": "1386749",
@@ -114,9 +51,16 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Jimenez"
+    "Tran_Date": "2016-08-06",
+    "Tran_NamF": "Carmen",
+    "Tran_NamL": "Morales"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "Larissa",
+    "Tran_NamL": "Adam"
   },
   {
     "Filer_ID": "1386749",
@@ -128,37 +72,23 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Koelling"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "Leadership for Educational Equity"
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Bromley"
   },
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "Eduardo",
-    "Tran_NamL": "Martinez"
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Josephine",
+    "Tran_NamL": "Chu"
   },
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-06",
-    "Tran_NamF": "Carmen",
-    "Tran_NamL": "Morales"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Carmen",
-    "Tran_NamL": "Morales"
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Crystal",
+    "Tran_NamL": "Fisher"
   },
   {
     "Filer_ID": "1386749",
@@ -166,13 +96,6 @@
     "Tran_Date": "2016-08-11",
     "Tran_NamF": "Carlos",
     "Tran_NamL": "Moreno"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Morrill"
   },
   {
     "Filer_ID": "1386749",
@@ -184,9 +107,79 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Lihi",
+    "Tran_NamL": "Rosenthal"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Jessica",
+    "Tran_NamL": "Stewart"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Maricela",
+    "Tran_NamL": "Trenado"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Gamaliel",
+    "Tran_NamL": "Piedra"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Koelling"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Jean",
+    "Tran_NamL": "Wing"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Elena",
+    "Tran_NamL": "Aguilar"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "Angelica",
     "Tran_NamL": "Ortiz"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "Families and Educators for Public Education FPPC #1331137"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Stein"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 313.31,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Hae-Sin",
+    "Tran_NamL": "Thomas"
   },
   {
     "Filer_ID": "1386749",
@@ -197,10 +190,150 @@
   },
   {
     "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Arthur",
+    "Tran_NamL": "Rock"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Cohen"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Walsh"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Danner"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Jenna",
+    "Tran_NamL": "Stauffer"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Lauren",
+    "Tran_NamL": "Westreich"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Kathrine",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-17",
     "Tran_NamF": "Salvador",
     "Tran_NamL": "Ortiz"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Morrill"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Parker",
+    "Tran_NamL": "Thomas"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Kathleen",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "T. Gary",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Jimenez"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Carmen",
+    "Tran_NamL": "Morales"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Adelina",
+    "Tran_NamL": "Trenado"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-01",
+    "Tran_NamF": "Legratta",
+    "Tran_NamL": "Banks"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "Santiago",
+    "Tran_NamL": "Campos"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Julie",
+    "Tran_NamL": "Wright"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Christina",
+    "Tran_NamL": "Greenberg"
   },
   {
     "Filer_ID": "1386749",
@@ -219,58 +352,23 @@
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Gamaliel",
-    "Tran_NamL": "Piedra"
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Silver"
   },
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Laurene",
-    "Tran_NamL": "Powell Jobs"
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Courtney",
+    "Tran_NamL": "Benoist"
   },
   {
     "Filer_ID": "1386749",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Arthur",
-    "Tran_NamL": "Rock"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Kathrine",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "T. Gary",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Kathleen",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "Lihi",
-    "Tran_NamL": "Rosenthal"
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Fish"
   },
   {
     "Filer_ID": "1386749",
@@ -281,118 +379,6 @@
   },
   {
     "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Libby",
-    "Tran_NamL": "Schaaf"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Silver"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Adam",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Jenna",
-    "Tran_NamL": "Stauffer"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Stein"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "Jessica",
-    "Tran_NamL": "Stewart"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 313.31,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Hae-Sin",
-    "Tran_NamL": "Thomas"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Parker",
-    "Tran_NamL": "Thomas"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-13",
-    "Tran_NamF": "Huber",
-    "Tran_NamL": "Trenado"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "Adelina",
-    "Tran_NamL": "Trenado"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "Maricela",
-    "Tran_NamL": "Trenado"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Adelina",
-    "Tran_NamL": "Trenado"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Cruz",
-    "Tran_NamL": "Trenado Ortiz"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Patrick",
-    "Tran_NamL": "Walsh"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Lauren",
-    "Tran_NamL": "Westreich"
-  },
-  {
-    "Filer_ID": "1386749",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Jean",
-    "Tran_NamL": "Wing"
-  },
-  {
-    "Filer_ID": "1386749",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-10-20",
     "Tran_NamF": "Jean",
@@ -400,9 +386,23 @@
   },
   {
     "Filer_ID": "1386749",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Julie",
-    "Tran_NamL": "Wright"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Abe",
+    "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Laurene",
+    "Tran_NamL": "Powell Jobs"
+  },
+  {
+    "Filer_ID": "1386749",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "Leadership for Educational Equity"
   }
 ]

--- a/build/committee/1386922/contributions/index.json
+++ b/build/committee/1386922/contributions/index.json
@@ -1,24 +1,17 @@
 [
   {
     "Filer_ID": "1386922",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": null,
-    "Tran_NamL": "Alameda Labor Council"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Tulani",
+    "Tran_NamL": "Henderson"
   },
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Janet",
-    "Tran_NamL": "Arnold"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "Debra",
-    "Tran_NamL": "Avery"
+    "Tran_Date": "2016-08-13",
+    "Tran_NamF": "Willie",
+    "Tran_NamL": "Jackson"
   },
   {
     "Filer_ID": "1386922",
@@ -30,16 +23,9 @@
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-08",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Berniker"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 650.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Cavallari"
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Weills"
   },
   {
     "Filer_ID": "1386922",
@@ -47,34 +33,6 @@
     "Tran_Date": "2016-08-26",
     "Tran_NamF": "William",
     "Tran_NamL": "Chorneau"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Chorneau"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Decker"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Kit",
-    "Tran_NamL": "Decker"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Decker"
   },
   {
     "Filer_ID": "1386922",
@@ -86,16 +44,37 @@
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Haja",
-    "Tran_NamL": "Dumbuya"
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Chorneau"
   },
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Kitty",
-    "Tran_NamL": "Epstein"
+    "Tran_Date": "2016-09-04",
+    "Tran_NamF": "Kristen",
+    "Tran_NamL": "Loomis"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "Arnold"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Tyron",
+    "Tran_NamL": "Jordan"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Omar",
+    "Tran_NamL": "Smith"
   },
   {
     "Filer_ID": "1386922",
@@ -114,30 +93,37 @@
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Siegel"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Session"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Aurelio",
+    "Tran_NamL": "Valentine"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Haja",
+    "Tran_NamL": "Dumbuya"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-14",
     "Tran_NamF": "Nicholas",
     "Tran_NamL": "Gilbert"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Tulani",
-    "Tran_NamL": "Henderson"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-13",
-    "Tran_NamF": "Willie",
-    "Tran_NamL": "Jackson"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Tyron",
-    "Tran_NamL": "Jordan"
   },
   {
     "Filer_ID": "1386922",
@@ -156,23 +142,37 @@
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-04",
-    "Tran_NamF": "Kristen",
-    "Tran_NamL": "Loomis"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-16",
     "Tran_NamF": "Nzinga",
     "Tran_NamL": "Moore"
   },
   {
     "Filer_ID": "1386922",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "Nzinga",
-    "Tran_NamL": "Moore"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Caroline",
+    "Tran_NamL": "Stanley"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 650.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Cavallari"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Decker"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kit",
+    "Tran_NamL": "Decker"
   },
   {
     "Filer_ID": "1386922",
@@ -180,6 +180,41 @@
     "Tran_Date": "2016-10-07",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Schacher"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-08",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Berniker"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Decker"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Victoria",
+    "Tran_NamL": "Valentine"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "Alameda Labor Council"
+  },
+  {
+    "Filer_ID": "1386922",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Nzinga",
+    "Tran_NamL": "Moore"
   },
   {
     "Filer_ID": "1386922",
@@ -191,50 +226,15 @@
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Session"
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Kitty",
+    "Tran_NamL": "Epstein"
   },
   {
     "Filer_ID": "1386922",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Siegel"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Omar",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Caroline",
-    "Tran_NamL": "Stanley"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Aurelio",
-    "Tran_NamL": "Valentine"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Victoria",
-    "Tran_NamL": "Valentine"
-  },
-  {
-    "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Weills"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "Debra",
+    "Tran_NamL": "Avery"
   }
 ]

--- a/build/committee/1386922/contributions/index.json
+++ b/build/committee/1386922/contributions/index.json
@@ -44,14 +44,14 @@
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-29",
+    "Tran_Date": "2016-08-26",
     "Tran_NamF": "William",
     "Tran_NamL": "Chorneau"
   },
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
+    "Tran_Date": "2016-08-29",
     "Tran_NamF": "William",
     "Tran_NamL": "Chorneau"
   },
@@ -64,16 +64,16 @@
   },
   {
     "Filer_ID": "1386922",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Christopher",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kit",
     "Tran_NamL": "Decker"
   },
   {
     "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Kit",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Christopher",
     "Tran_NamL": "Decker"
   },
   {
@@ -107,15 +107,15 @@
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Nicholas",
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Stephen",
     "Tran_NamL": "Gilbert"
   },
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Stephen",
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Nicholas",
     "Tran_NamL": "Gilbert"
   },
   {
@@ -162,15 +162,15 @@
   },
   {
     "Filer_ID": "1386922",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-10-13",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
     "Tran_NamF": "Nzinga",
     "Tran_NamL": "Moore"
   },
   {
     "Filer_ID": "1386922",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-10-13",
     "Tran_NamF": "Nzinga",
     "Tran_NamL": "Moore"
   },
@@ -219,15 +219,15 @@
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Victoria",
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Aurelio",
     "Tran_NamL": "Valentine"
   },
   {
     "Filer_ID": "1386922",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Aurelio",
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Victoria",
     "Tran_NamL": "Valentine"
   },
   {

--- a/build/committee/1386929/contributions/index.json
+++ b/build/committee/1386929/contributions/index.json
@@ -2,9 +2,37 @@
   {
     "Filer_ID": "1386929",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Ismael",
-    "Tran_NamL": "Armendariz"
+    "Tran_Date": "2016-07-16",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Derias"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Hazel",
+    "Tran_NamL": "Terry-Wesson"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-11",
+    "Tran_NamF": "Devin",
+    "Tran_NamL": "Elizondo"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-11",
+    "Tran_NamF": "Faye",
+    "Tran_NamL": "McFall"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Sharrana",
+    "Tran_NamL": "Richardson"
   },
   {
     "Filer_ID": "1386929",
@@ -23,30 +51,9 @@
   {
     "Filer_ID": "1386929",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Leigh",
-    "Tran_NamL": "Davenport"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-16",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Derias"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Helen",
     "Tran_NamL": "Duffy"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-11",
-    "Tran_NamF": "Devin",
-    "Tran_NamL": "Elizondo"
   },
   {
     "Filer_ID": "1386929",
@@ -57,73 +64,10 @@
   },
   {
     "Filer_ID": "1386929",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-11",
-    "Tran_NamF": "Faye",
-    "Tran_NamL": "McFall"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Justice Coalition"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Justice Coalition"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Alma",
-    "Tran_NamL": "Rahmaan"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 140.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Kameelah",
-    "Tran_NamL": "Rahmaan"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Sharrana",
-    "Tran_NamL": "Richardson"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Sharon",
-    "Tran_NamL": "Rose"
-  },
-  {
-    "Filer_ID": "1386929",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Dan",
     "Tran_NamL": "Siegel"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Hazel",
-    "Tran_NamL": "Terry-Wesson"
-  },
-  {
-    "Filer_ID": "1386929",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-30",
-    "Tran_NamF": "Fredna",
-    "Tran_NamL": "Thomas"
   },
   {
     "Filer_ID": "1386929",
@@ -145,5 +89,61 @@
     "Tran_Date": "2016-10-13",
     "Tran_NamF": null,
     "Tran_NamL": "Unitemized contributions"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Leigh",
+    "Tran_NamL": "Davenport"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Sharon",
+    "Tran_NamL": "Rose"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-30",
+    "Tran_NamF": "Fredna",
+    "Tran_NamL": "Thomas"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Ismael",
+    "Tran_NamL": "Armendariz"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Alma",
+    "Tran_NamL": "Rahmaan"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Justice Coalition"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 140.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Kameelah",
+    "Tran_NamL": "Rahmaan"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Justice Coalition"
   }
 ]

--- a/build/committee/1386929/contributions/index.json
+++ b/build/committee/1386929/contributions/index.json
@@ -64,13 +64,6 @@
   },
   {
     "Filer_ID": "1386929",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Justice Coalition"
-  },
-  {
-    "Filer_ID": "1386929",
     "Tran_Amt1": 300.0,
     "Tran_Date": "2016-11-04",
     "Tran_NamF": null,
@@ -78,16 +71,23 @@
   },
   {
     "Filer_ID": "1386929",
-    "Tran_Amt1": 140.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Kameelah",
-    "Tran_NamL": "Rahmaan"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Justice Coalition"
   },
   {
     "Filer_ID": "1386929",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-11-01",
     "Tran_NamF": "Alma",
+    "Tran_NamL": "Rahmaan"
+  },
+  {
+    "Filer_ID": "1386929",
+    "Tran_Amt1": 140.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Kameelah",
     "Tran_NamL": "Rahmaan"
   },
   {
@@ -134,15 +134,15 @@
   },
   {
     "Filer_ID": "1386929",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-13",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-06",
     "Tran_NamF": null,
     "Tran_NamL": "Unitemized contributions"
   },
   {
     "Filer_ID": "1386929",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-06",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-13",
     "Tran_NamF": null,
     "Tran_NamL": "Unitemized contributions"
   }

--- a/build/committee/1386932/contributions/index.json
+++ b/build/committee/1386932/contributions/index.json
@@ -1,220 +1,17 @@
 [
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Noha",
-    "Tran_NamL": "Aboelata"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "Regina",
-    "Tran_NamL": "Acebo"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Norma A.",
-    "Tran_NamL": "Anderson"
-  },
-  {
-    "Filer_ID": "1386932",
     "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "Ernesto Jose",
-    "Tran_NamL": "Arevalo"
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Michael V.",
+    "Tran_NamL": "Kaufman"
   },
   {
     "Filer_ID": "1386932",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Ernesto Jose",
-    "Tran_NamL": "Arevalo"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Janet S.",
-    "Tran_NamL": "Arnold"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-11-16",
-    "Tran_NamF": "Debra",
-    "Tran_NamL": "Avery"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-16",
-    "Tran_NamF": "Michael Anthony",
-    "Tran_NamL": "Benson Sr."
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": -100.0,
-    "Tran_Date": "2016-11-30",
-    "Tran_NamF": "Michael Anthony",
-    "Tran_NamL": "Benson Sr."
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Moraa",
-    "Tran_NamL": "Bey"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Siri",
-    "Tran_NamL": "Briggsbrown"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Tracy",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Lewis",
-    "Tran_NamL": "Bundy"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Sierra",
-    "Tran_NamL": "Bundy"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Francis S.",
-    "Tran_NamL": "Calpotura"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Arnold",
-    "Tran_NamL": "Chandler"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "William Alan",
-    "Tran_NamL": "Chorneau"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "Sharon",
-    "Tran_NamL": "Cornu-Toney"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "Sandra",
-    "Tran_NamL": "Davis"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Sandra",
-    "Tran_NamL": "Davis"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Mary Quinn",
-    "Tran_NamL": "Delaney"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Alexandra",
-    "Tran_NamL": "Desautels"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Helen Marie",
-    "Tran_NamL": "Duffy"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Fitzgerald"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Shawn",
-    "Tran_NamL": "Ginwright"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Shawn",
-    "Tran_NamL": "Ginwright"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Gordon-Brown"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "Bryon",
-    "Tran_NamL": "Gudiel"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Hailu"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Gregory",
-    "Tran_NamL": "Hodge"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Gregory",
-    "Tran_NamL": "Hodge"
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Sharon A.",
+    "Tran_NamL": "Rice"
   },
   {
     "Filer_ID": "1386932",
@@ -233,37 +30,58 @@
   {
     "Filer_ID": "1386932",
     "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Arnold",
+    "Tran_NamL": "Perkins"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Hailu"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "Ernesto Jose",
+    "Tran_NamL": "Arevalo"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 150.0,
     "Tran_Date": "2016-08-18",
     "Tran_NamF": "Mtafiti",
     "Tran_NamL": "Imara"
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Nia M.",
-    "Tran_NamL": "Imara"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "Pierre M.",
+    "Tran_NamL": "Labossiere"
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Nehanda Z.",
-    "Tran_NamL": "Imara"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Sharon",
+    "Tran_NamL": "Cornu-Toney"
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Kathryn",
-    "Tran_NamL": "Kasch"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Michael V.",
-    "Tran_NamL": "Kaufman"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Gregory",
+    "Tran_NamL": "Hodge"
   },
   {
     "Filer_ID": "1386932",
@@ -271,48 +89,6 @@
     "Tran_Date": "2016-09-08",
     "Tran_NamF": "Michael V.",
     "Tran_NamL": "Kaufman"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Michael V.",
-    "Tran_NamL": "Kaufman"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "Pierre M.",
-    "Tran_NamL": "Labossiere"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Pierre M.",
-    "Tran_NamL": "Labossiere"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Marilyn",
-    "Tran_NamL": "Langlois"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-08",
-    "Tran_NamF": "Shana",
-    "Tran_NamL": "Laze Row"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "League of Conservation Voters of the East Bay"
   },
   {
     "Filer_ID": "1386932",
@@ -323,52 +99,10 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Anna",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Carrie A.",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Anna",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-16",
-    "Tran_NamF": "Kent A.",
-    "Tran_NamL": "Lewandowski"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Nile",
-    "Tran_NamL": "Malloy"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Luke",
-    "Tran_NamL": "Newton"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-30",
-    "Tran_NamF": "Levis",
-    "Tran_NamL": "Owens"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Lewis",
+    "Tran_NamL": "Bundy"
   },
   {
     "Filer_ID": "1386932",
@@ -379,10 +113,101 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-04",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Shiree",
+    "Tran_NamL": "Teng"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Walter",
+    "Tran_NamL": "Riley"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Schacher"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Moraa",
+    "Tran_NamL": "Bey"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Alexandra",
+    "Tran_NamL": "Desautels"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Michael V.",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Zingale"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Ernesto Jose",
+    "Tran_NamL": "Arevalo"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
     "Tran_NamF": "Arnold",
-    "Tran_NamL": "Perkins"
+    "Tran_NamL": "Chandler"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Fitzgerald"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Shawn",
+    "Tran_NamL": "Ginwright"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Kathryn",
+    "Tran_NamL": "Kasch"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Luke",
+    "Tran_NamL": "Newton"
   },
   {
     "Filer_ID": "1386932",
@@ -401,58 +226,30 @@
   {
     "Filer_ID": "1386932",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Barbara A.",
-    "Tran_NamL": "Rhine"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Sharon A.",
-    "Tran_NamL": "Rice"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Walter",
-    "Tran_NamL": "Riley"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-16",
     "Tran_NamF": "Linda",
     "Tran_NamL": "Roman"
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Sal",
-    "Tran_NamL": "Rosselli"
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "Transport Oakland"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Witt"
   },
   {
     "Filer_ID": "1386932",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Roth"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-11",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Roth"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Schacher"
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Anna",
+    "Tran_NamL": "Lee"
   },
   {
     "Filer_ID": "1386932",
@@ -460,6 +257,153 @@
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Rasheed",
     "Tran_NamL": "Shabazz"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sacy",
+    "Tran_NamL": "Thompson"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Nile",
+    "Tran_NamL": "Malloy"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Brenda",
+    "Tran_NamL": "Winston"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Bryon",
+    "Tran_NamL": "Gudiel"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Trimble"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-08",
+    "Tran_NamF": "Shana",
+    "Tran_NamL": "Laze Row"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Nia M.",
+    "Tran_NamL": "Imara"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Marilyn",
+    "Tran_NamL": "Langlois"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Norma A.",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Janet S.",
+    "Tran_NamL": "Arnold"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Siri",
+    "Tran_NamL": "Briggsbrown"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Francis S.",
+    "Tran_NamL": "Calpotura"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "William Alan",
+    "Tran_NamL": "Chorneau"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Mary Quinn",
+    "Tran_NamL": "Delaney"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Helen Marie",
+    "Tran_NamL": "Duffy"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Shawn",
+    "Tran_NamL": "Ginwright"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Nehanda Z.",
+    "Tran_NamL": "Imara"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "League of Conservation Voters of the East Bay"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Carrie A.",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Barbara A.",
+    "Tran_NamL": "Rhine"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Sal",
+    "Tran_NamL": "Rosselli"
   },
   {
     "Filer_ID": "1386932",
@@ -477,34 +421,6 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Shiree",
-    "Tran_NamL": "Teng"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Sacy",
-    "Tran_NamL": "Thompson"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "Transport Oakland"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Trimble"
-  },
-  {
-    "Filer_ID": "1386932",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-12",
     "Tran_NamF": "Bonita",
@@ -512,10 +428,17 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Vanderwarker"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Gordon-Brown"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Gregory",
+    "Tran_NamL": "Hodge"
   },
   {
     "Filer_ID": "1386932",
@@ -526,23 +449,100 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Brenda",
-    "Tran_NamL": "Winston"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Noha",
+    "Tran_NamL": "Aboelata"
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Sandra",
-    "Tran_NamL": "Witt"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Anna",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-30",
+    "Tran_NamF": "Levis",
+    "Tran_NamL": "Owens"
   },
   {
     "Filer_ID": "1386932",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Zingale"
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Pierre M.",
+    "Tran_NamL": "Labossiere"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Roth"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "Regina",
+    "Tran_NamL": "Acebo"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Sierra",
+    "Tran_NamL": "Bundy"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Vanderwarker"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-11",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Roth"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-11-16",
+    "Tran_NamF": "Debra",
+    "Tran_NamL": "Avery"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-16",
+    "Tran_NamF": "Michael Anthony",
+    "Tran_NamL": "Benson Sr."
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-16",
+    "Tran_NamF": "Kent A.",
+    "Tran_NamL": "Lewandowski"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": -100.0,
+    "Tran_Date": "2016-11-30",
+    "Tran_NamF": "Michael Anthony",
+    "Tran_NamL": "Benson Sr."
   }
 ]

--- a/build/committee/1386932/contributions/index.json
+++ b/build/committee/1386932/contributions/index.json
@@ -50,15 +50,15 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": -100.0,
-    "Tran_Date": "2016-11-30",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-16",
     "Tran_NamF": "Michael Anthony",
     "Tran_NamL": "Benson Sr."
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-16",
+    "Tran_Amt1": -100.0,
+    "Tran_Date": "2016-11-30",
     "Tran_NamF": "Michael Anthony",
     "Tran_NamL": "Benson Sr."
   },
@@ -85,16 +85,16 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Sierra",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Lewis",
     "Tran_NamL": "Bundy"
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Lewis",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Sierra",
     "Tran_NamL": "Bundy"
   },
   {
@@ -225,16 +225,9 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-09",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-03",
     "Tran_NamF": "Nia M.",
-    "Tran_NamL": "Imara"
-  },
-  {
-    "Filer_ID": "1386932",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Nehanda Z.",
     "Tran_NamL": "Imara"
   },
   {
@@ -246,9 +239,16 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-03",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-09",
     "Tran_NamF": "Nia M.",
+    "Tran_NamL": "Imara"
+  },
+  {
+    "Filer_ID": "1386932",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Nehanda Z.",
     "Tran_NamL": "Imara"
   },
   {
@@ -323,8 +323,8 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-28",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Anna",
     "Tran_NamL": "Lee"
   },
@@ -337,8 +337,8 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-24",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-28",
     "Tran_NamF": "Anna",
     "Tran_NamL": "Lee"
   },
@@ -435,15 +435,15 @@
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-11",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-02",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Roth"
   },
   {
     "Filer_ID": "1386932",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-02",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-11",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Roth"
   },

--- a/build/committee/1387192/contributions/index.json
+++ b/build/committee/1387192/contributions/index.json
@@ -2,527 +2,9 @@
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "ABC Security Services, Inc"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 206.48,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Claudia",
-    "Tran_NamL": "Albano"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Aida",
-    "Tran_NamL": "Alvarez"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 103.39,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Laura",
-    "Tran_NamL": "Arreola"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Luis",
-    "Tran_NamL": "Arteaga"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Priscilla",
-    "Tran_NamL": "Banks"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Seth",
-    "Tran_NamL": "Barad"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Barad"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Anthony",
-    "Tran_NamL": "Batarse"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Raymond",
-    "Tran_NamL": "Baxter"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Ingrid",
-    "Tran_NamL": "Benedict"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Jamie",
-    "Tran_NamL": "Besaw"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-25",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Betterton"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Bibler"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Cynthia",
-    "Tran_NamL": "Blumgart"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Bolke"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Louis",
-    "Tran_NamL": "Briones"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Jill",
-    "Tran_NamL": "Broadhurst"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Bruno"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 258.03,
-    "Tran_Date": "2016-11-09",
-    "Tran_NamF": "Roxanne",
-    "Tran_NamL": "Caldera"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Real Estate Political Action Committee (CREPAC)California Association of Realtors SCC"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Narciso",
-    "Tran_NamL": "Cano"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 251.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Narciso",
-    "Tran_NamL": "Cano"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Carlson"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Ping Ping",
-    "Tran_NamL": "Chen"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Chesmore"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Cohen"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "Colleen",
-    "Tran_NamL": "Connor"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 155.99,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Corbridge"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": null,
-    "Tran_NamL": "Cres Enterprises, Inc"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Joan",
-    "Tran_NamL": "Crivello"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Donald",
-    "Tran_NamL": "Crowe"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "Celia",
-    "Tran_NamL": "Currin"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Darby"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Ignacio",
-    "Tran_NamL": "De La Fuente"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Dicker"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Raquel",
-    "Tran_NamL": "Donoso"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Christian",
-    "Tran_NamL": "Downer"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Igor",
-    "Tran_NamL": "Drizik"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "El Gato Negro Bar"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Nico",
-    "Tran_NamL": "Enea"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Enea Properties Company LLC"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Wilma",
-    "Tran_NamL": "Espinoza"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Irma",
-    "Tran_NamL": "Flores"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Bettina",
-    "Tran_NamL": "Flores"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "SueAnn",
-    "Tran_NamL": "Freeman"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Frumusa"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Fuentes"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Raymond",
-    "Tran_NamL": "Gallagher"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Herman",
-    "Tran_NamL": "Gallegos"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 129.16,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Maria",
-    "Tran_NamL": "Gallo"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Rocendo",
-    "Tran_NamL": "Gamez"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Christina",
-    "Tran_NamL": "Gandara"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-07-15",
     "Tran_NamF": "Viola",
     "Tran_NamL": "Gonzales"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-05",
-    "Tran_NamF": "Gilda",
-    "Tran_NamL": "Gonzales"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "Juan",
-    "Tran_NamL": "Gonzales"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Viola",
-    "Tran_NamL": "Gonzales"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Viola",
-    "Tran_NamL": "Gonzales"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Christine",
-    "Tran_NamL": "Goodman"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-07-25",
-    "Tran_NamF": "Kerry",
-    "Tran_NamL": "Hamill"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "Kerry",
-    "Tran_NamL": "Hamill"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Elihu",
-    "Tran_NamL": "Harris"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Elihu",
-    "Tran_NamL": "Harris"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-07-21",
-    "Tran_NamF": "Ingrid",
-    "Tran_NamL": "Haubrich"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 51.84,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": "Ingrid",
-    "Tran_NamL": "Haubrich"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 103.39,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Greg",
-    "Tran_NamL": "Hayden"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "Deidre",
-    "Tran_NamL": "Heitman"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Herr"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Herr"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 103.39,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Luis",
-    "Tran_NamL": "Herrera"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Rhonda",
-    "Tran_NamL": "Hirata"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Maria",
-    "Tran_NamL": "Hollands"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": "Peter",
-    "Tran_NamL": "Honisberg"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Lily",
-    "Tran_NamL": "Hu"
   },
   {
     "Filer_ID": "1387192",
@@ -533,185 +15,31 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 103.38,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Iglesias"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "Annie",
-    "Tran_NamL": "Irving"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-07-21",
+    "Tran_NamF": "Ingrid",
+    "Tran_NamL": "Haubrich"
   },
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Alton",
-    "Tran_NamL": "Jelks"
+    "Tran_Date": "2016-07-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "ABC Security Services, Inc"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-25",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Betterton"
   },
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Betty",
-    "Tran_NamL": "Jelks"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "Linton",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 52.2,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "Linton",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Brandon",
-    "Tran_NamL": "Jones"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Sheila",
-    "Tran_NamL": "Jordan"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Samuel",
-    "Tran_NamL": "Kang"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Katzoff"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Kidd"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Kiteas III"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Omar",
-    "Tran_NamL": "Korin"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Koziol"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Eugene",
-    "Tran_NamL": "Larkin"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 325.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Lattimore"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Scott",
-    "Tran_NamL": "Law"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Maurilio",
-    "Tran_NamL": "Leon"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Maurilio",
-    "Tran_NamL": "Leon"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Maurilio",
-    "Tran_NamL": "Leon"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "Abigail",
-    "Tran_NamL": "Leonard"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 103.39,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Abigail",
-    "Tran_NamL": "Leonard"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Rick",
-    "Tran_NamL": "Mariano"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 103.39,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Marks"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 207.88,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Linda Marie",
-    "Tran_NamL": "Marmolejo"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Judith",
-    "Tran_NamL": "Marsh"
+    "Tran_Date": "2016-07-25",
+    "Tran_NamF": "Kerry",
+    "Tran_NamL": "Hamill"
   },
   {
     "Filer_ID": "1387192",
@@ -722,216 +50,6 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 154.93,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": "Jacqueline",
-    "Tran_NamL": "Martinez Garcel"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Danilo",
-    "Tran_NamL": "Mayorga"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Cory",
-    "Tran_NamL": "McCollow"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "John",
-    "Tran_NamL": "McPeak"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-18",
-    "Tran_NamF": "Shahrokh",
-    "Tran_NamL": "Mifaghi"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Esther",
-    "Tran_NamL": "Montoya-Taylor"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Bielle",
-    "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-20",
-    "Tran_NamF": "Michele",
-    "Tran_NamL": "Mork-Ovson"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Marie",
-    "Tran_NamL": "Munson"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": "Sofia",
-    "Tran_NamL": "Navarro"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Charlie",
-    "Tran_NamL": "Ngo"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 103.39,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Noellert"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "OAKPAC, Oakland Metropolitan Chamber of Commerce"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oak Hillside Cleaners"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Police Officer's Association-Political Action Committee"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Oram"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Bryan",
-    "Tran_NamL": "Parker"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Darrin",
-    "Tran_NamL": "Parle"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Peace Officers Research Association of California Political Action Committee(PORAC PAC) SCC"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": "Antonio",
-    "Tran_NamL": "Pelayo"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Ana",
-    "Tran_NamL": "Perez"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Adam",
-    "Tran_NamL": "Peterson"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 259.79,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Porter"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Robles-Mitten"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Perla",
-    "Tran_NamL": "Rodriguez"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Sakai"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 258.03,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Bobbie",
-    "Tran_NamL": "Salgado"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Salinas"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Maria Antonieta",
-    "Tran_NamL": "Sanchez"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Maria",
-    "Tran_NamL": "Sansores"
-  },
-  {
-    "Filer_ID": "1387192",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-07-25",
     "Tran_NamF": "Libby",
@@ -939,24 +57,10 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-09-11",
-    "Tran_NamF": "Sylvia",
-    "Tran_NamL": "Schaffer"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Lupe",
-    "Tran_NamL": "Schoenberger"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Lupe",
-    "Tran_NamL": "Schoenberger"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-05",
+    "Tran_NamF": "Gilda",
+    "Tran_NamL": "Gonzales"
   },
   {
     "Filer_ID": "1387192",
@@ -967,52 +71,115 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 519.25,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Olis",
-    "Tran_NamL": "Simmons"
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Rhonda",
+    "Tran_NamL": "Hirata"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 103.39,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Miye",
-    "Tran_NamL": "Takagi"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Herr"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 103.39,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Olga",
-    "Tran_NamL": "Talamante"
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "Linton",
+    "Tran_NamL": "Johnson"
   },
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "Telegraph Group"
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Katzoff"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Alton",
+    "Tran_NamL": "Jelks"
   },
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Monica",
-    "Tran_NamL": "Tell"
+    "Tran_Date": "2016-08-16",
+    "Tran_NamF": "Peter",
+    "Tran_NamL": "Honisberg"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "R Zachary",
-    "Tran_NamL": "Wassernan"
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-08-16",
+    "Tran_NamF": "Sofia",
+    "Tran_NamL": "Navarro"
   },
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Weltin, Streb & Weltin, LLP"
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Donald",
+    "Tran_NamL": "Crowe"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Larkin"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Maurilio",
+    "Tran_NamL": "Leon"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-20",
+    "Tran_NamF": "Michele",
+    "Tran_NamL": "Mork-Ovson"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Deidre",
+    "Tran_NamL": "Heitman"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Kerry",
+    "Tran_NamL": "Hamill"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 52.2,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Linton",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 259.78,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Abigail",
+    "Tran_NamL": "Leonard"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Christina",
+    "Tran_NamL": "Gandara"
   },
   {
     "Filer_ID": "1387192",
@@ -1023,17 +190,220 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "Roy",
-    "Tran_NamL": "Wilson"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Maria",
+    "Tran_NamL": "Hollands"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Ingrid",
+    "Tran_NamL": "Benedict"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Chesmore"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 259.79,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Porter"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 259.78,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Lupe",
+    "Tran_NamL": "Schoenberger"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Seth",
+    "Tran_NamL": "Barad"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 155.99,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Corbridge"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Irma",
+    "Tran_NamL": "Flores"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Police Officer's Association-Political Action Committee"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "Celia",
+    "Tran_NamL": "Currin"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Herr"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Narciso",
+    "Tran_NamL": "Cano"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Elihu",
+    "Tran_NamL": "Harris"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Alexander",
+    "Tran_NamL": "Young"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Juan",
+    "Tran_NamL": "Gonzales"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Salinas"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Blumgart"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Cohen"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Wilma",
+    "Tran_NamL": "Espinoza"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 325.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Lattimore"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 259.78,
+    "Tran_Date": "2016-09-11",
+    "Tran_NamF": "Sylvia",
+    "Tran_NamL": "Schaffer"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Law"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Rick",
+    "Tran_NamL": "Mariano"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Batarse"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Louis",
+    "Tran_NamL": "Briones"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Carlson"
   },
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Alan",
-    "Tran_NamL": "Wofsy"
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Raquel",
+    "Tran_NamL": "Donoso"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Ana",
+    "Tran_NamL": "Perez"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Robles-Mitten"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Maria Antonieta",
+    "Tran_NamL": "Sanchez"
   },
   {
     "Filer_ID": "1387192",
@@ -1052,9 +422,513 @@
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Alexander",
-    "Tran_NamL": "Young"
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Dicker"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Viola",
+    "Tran_NamL": "Gonzales"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 207.88,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Linda Marie",
+    "Tran_NamL": "Marmolejo"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Peace Officers Research Association of California Political Action Committee(PORAC PAC) SCC"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Sakai"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sheila",
+    "Tran_NamL": "Jordan"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oak Hillside Cleaners"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Maurilio",
+    "Tran_NamL": "Leon"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Oram"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Esther",
+    "Tran_NamL": "Montoya-Taylor"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Peterson"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Perla",
+    "Tran_NamL": "Rodriguez"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Aida",
+    "Tran_NamL": "Alvarez"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Raymond",
+    "Tran_NamL": "Baxter"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Jamie",
+    "Tran_NamL": "Besaw"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Bruno"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Bettina",
+    "Tran_NamL": "Flores"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Cory",
+    "Tran_NamL": "McCollow"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "R Zachary",
+    "Tran_NamL": "Wassernan"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Weltin, Streb & Weltin, LLP"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Fuentes"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Christine",
+    "Tran_NamL": "Goodman"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Alan",
+    "Tran_NamL": "Wofsy"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "Telegraph Group"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 259.78,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Barad"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Rocendo",
+    "Tran_NamL": "Gamez"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Nico",
+    "Tran_NamL": "Enea"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Frumusa"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Brandon",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Darby"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Crivello"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Bryan",
+    "Tran_NamL": "Parker"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 259.78,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Luis",
+    "Tran_NamL": "Arteaga"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bolke"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "SueAnn",
+    "Tran_NamL": "Freeman"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 519.25,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Olis",
+    "Tran_NamL": "Simmons"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Colleen",
+    "Tran_NamL": "Connor"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Annie",
+    "Tran_NamL": "Irving"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Roy",
+    "Tran_NamL": "Wilson"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Priscilla",
+    "Tran_NamL": "Banks"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Bibler"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Elihu",
+    "Tran_NamL": "Harris"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Betty",
+    "Tran_NamL": "Jelks"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Omar",
+    "Tran_NamL": "Korin"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Judith",
+    "Tran_NamL": "Marsh"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Bielle",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Marie",
+    "Tran_NamL": "Munson"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 258.03,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Bobbie",
+    "Tran_NamL": "Salgado"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 259.78,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Lupe",
+    "Tran_NamL": "Schoenberger"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Monica",
+    "Tran_NamL": "Tell"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Real Estate Political Action Committee (CREPAC)California Association of Realtors SCC"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKPAC, Oakland Metropolitan Chamber of Commerce"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 206.48,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Claudia",
+    "Tran_NamL": "Albano"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Samuel",
+    "Tran_NamL": "Kang"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Maria",
+    "Tran_NamL": "Sansores"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 129.16,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Maria",
+    "Tran_NamL": "Gallo"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "John",
+    "Tran_NamL": "McPeak"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Jill",
+    "Tran_NamL": "Broadhurst"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 251.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Narciso",
+    "Tran_NamL": "Cano"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Ignacio",
+    "Tran_NamL": "De La Fuente"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Igor",
+    "Tran_NamL": "Drizik"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Raymond",
+    "Tran_NamL": "Gallagher"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Herman",
+    "Tran_NamL": "Gallegos"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Lily",
+    "Tran_NamL": "Hu"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Kiteas III"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Koziol"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Danilo",
+    "Tran_NamL": "Mayorga"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Darrin",
+    "Tran_NamL": "Parle"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 103.39,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Arreola"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Ping Ping",
+    "Tran_NamL": "Chen"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Christian",
+    "Tran_NamL": "Downer"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Charlie",
+    "Tran_NamL": "Ngo"
   },
   {
     "Filer_ID": "1387192",
@@ -1062,5 +936,131 @@
     "Tran_Date": "2016-10-28",
     "Tran_NamF": "Silvia",
     "Tran_NamL": "Zhang"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Enea Properties Company LLC"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 51.84,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": "Ingrid",
+    "Tran_NamL": "Haubrich"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 103.39,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "Hayden"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 103.39,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Luis",
+    "Tran_NamL": "Herrera"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 103.39,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Abigail",
+    "Tran_NamL": "Leonard"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "El Gato Negro Bar"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Maurilio",
+    "Tran_NamL": "Leon"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": null,
+    "Tran_NamL": "Cres Enterprises, Inc"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 154.93,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": "Jacqueline",
+    "Tran_NamL": "Martinez Garcel"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 103.39,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Miye",
+    "Tran_NamL": "Takagi"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Viola",
+    "Tran_NamL": "Gonzales"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 103.38,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Iglesias"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 103.39,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 103.39,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Noellert"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 103.39,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Olga",
+    "Tran_NamL": "Talamante"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Antonio",
+    "Tran_NamL": "Pelayo"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 258.03,
+    "Tran_Date": "2016-11-09",
+    "Tran_NamF": "Roxanne",
+    "Tran_NamL": "Caldera"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-18",
+    "Tran_NamF": "Shahrokh",
+    "Tran_NamL": "Mifaghi"
   }
 ]

--- a/build/committee/1387192/contributions/index.json
+++ b/build/committee/1387192/contributions/index.json
@@ -43,16 +43,16 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Amy",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Seth",
     "Tran_NamL": "Barad"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Seth",
+    "Tran_Amt1": 259.78,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Amy",
     "Tran_NamL": "Barad"
   },
   {
@@ -379,16 +379,9 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-09-23",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-15",
     "Tran_NamF": "Viola",
-    "Tran_NamL": "Gonzales"
-  },
-  {
-    "Filer_ID": "1387192",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "Juan",
     "Tran_NamL": "Gonzales"
   },
   {
@@ -400,15 +393,22 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-11-07",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Juan",
+    "Tran_NamL": "Gonzales"
+  },
+  {
+    "Filer_ID": "1387192",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-09-23",
     "Tran_NamF": "Viola",
     "Tran_NamL": "Gonzales"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-15",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-11-07",
     "Tran_NamF": "Viola",
     "Tran_NamL": "Gonzales"
   },
@@ -449,15 +449,15 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 51.84,
-    "Tran_Date": "2016-10-29",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-07-21",
     "Tran_NamF": "Ingrid",
     "Tran_NamL": "Haubrich"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-07-21",
+    "Tran_Amt1": 51.84,
+    "Tran_Date": "2016-10-29",
     "Tran_NamF": "Ingrid",
     "Tran_NamL": "Haubrich"
   },
@@ -477,15 +477,15 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-01",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-12",
     "Tran_NamF": "John",
     "Tran_NamL": "Herr"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-12",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-01",
     "Tran_NamF": "John",
     "Tran_NamL": "Herr"
   },
@@ -561,15 +561,15 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 52.2,
-    "Tran_Date": "2016-08-22",
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-08-12",
     "Tran_NamF": "Linton",
     "Tran_NamL": "Johnson"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 104.09,
-    "Tran_Date": "2016-08-12",
+    "Tran_Amt1": 52.2,
+    "Tran_Date": "2016-08-22",
     "Tran_NamF": "Linton",
     "Tran_NamL": "Johnson"
   },
@@ -652,15 +652,15 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-26",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-08-19",
     "Tran_NamF": "Maurilio",
     "Tran_NamL": "Leon"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-08-19",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-26",
     "Tran_NamF": "Maurilio",
     "Tran_NamL": "Leon"
   },
@@ -673,15 +673,15 @@
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 103.39,
-    "Tran_Date": "2016-10-31",
+    "Tran_Amt1": 259.78,
+    "Tran_Date": "2016-08-22",
     "Tran_NamF": "Abigail",
     "Tran_NamL": "Leonard"
   },
   {
     "Filer_ID": "1387192",
-    "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-08-22",
+    "Tran_Amt1": 103.39,
+    "Tran_Date": "2016-10-31",
     "Tran_NamF": "Abigail",
     "Tran_NamL": "Leonard"
   },
@@ -947,14 +947,14 @@
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-10-14",
+    "Tran_Date": "2016-08-29",
     "Tran_NamF": "Lupe",
     "Tran_NamL": "Schoenberger"
   },
   {
     "Filer_ID": "1387192",
     "Tran_Amt1": 259.78,
-    "Tran_Date": "2016-08-29",
+    "Tran_Date": "2016-10-14",
     "Tran_NamF": "Lupe",
     "Tran_NamL": "Schoenberger"
   },

--- a/build/committee/1387267/contributions/index.json
+++ b/build/committee/1387267/contributions/index.json
@@ -155,15 +155,15 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-01",
+    "Tran_Amt1": 1.0,
+    "Tran_Date": "2016-07-31",
     "Tran_NamF": "Peter",
     "Tran_NamL": "Coye"
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 1.0,
-    "Tran_Date": "2016-07-31",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-01",
     "Tran_NamF": "Peter",
     "Tran_NamL": "Coye"
   },
@@ -253,16 +253,16 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Victoria",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Alan",
     "Tran_NamL": "Fong"
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Alan",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Victoria",
     "Tran_NamL": "Fong"
   },
   {
@@ -302,13 +302,6 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Gee"
-  },
-  {
-    "Filer_ID": "1387267",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-09-07",
     "Tran_NamF": "Harry",
@@ -316,16 +309,23 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Victor",
-    "Tran_NamL": "Gong"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Gee"
   },
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-08-03",
     "Tran_NamF": "Fanny",
+    "Tran_NamL": "Gong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Victor",
     "Tran_NamL": "Gong"
   },
   {
@@ -555,15 +555,15 @@
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Patricia",
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Melvin",
     "Tran_NamL": "Quan"
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 30000.0,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": "Bruce",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Patricia",
     "Tran_NamL": "Quan"
   },
   {
@@ -575,9 +575,9 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Melvin",
+    "Tran_Amt1": 30000.0,
+    "Tran_Date": "2016-12-15",
+    "Tran_NamF": "Bruce",
     "Tran_NamL": "Quan"
   },
   {
@@ -729,16 +729,9 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Douglas",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "William",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Karen",
     "Tran_NamL": "Wong"
   },
   {
@@ -750,9 +743,23 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Karen",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "Peter",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Robert",
     "Tran_NamL": "Wong"
   },
   {
@@ -764,9 +771,16 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "Peter",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "William",
     "Tran_NamL": "Wong"
   },
   {
@@ -781,20 +795,6 @@
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-10-28",
     "Tran_NamF": "Douglas",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Robert",
     "Tran_NamL": "Wong"
   },
   {

--- a/build/committee/1387267/contributions/index.json
+++ b/build/committee/1387267/contributions/index.json
@@ -1,24 +1,10 @@
 [
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "AOSEN Group, LLC dba Pho Ao Sen"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Apodaca"
-  },
-  {
-    "Filer_ID": "1387267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "B C Realty"
+    "Tran_Date": "2016-07-25",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Gamboa"
   },
   {
     "Filer_ID": "1387267",
@@ -29,129 +15,10 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Duane",
-    "Tran_NamL": "Baughman"
-  },
-  {
-    "Filer_ID": "1387267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Berring"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Brockett"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Real Estate Political Action Committee - California Associations of Realtors"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Max",
-    "Tran_NamL": "Chacana"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Roger",
-    "Tran_NamL": "Chao"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Theresa",
-    "Tran_NamL": "Chao"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Chavez"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Stewart",
-    "Tran_NamL": "Chen"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Kenny",
-    "Tran_NamL": "Chin"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Ener",
-    "Tran_NamL": "Chiu"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Jarlene",
-    "Tran_NamL": "Choy"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Jack",
-    "Tran_NamL": "Chu"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Judy",
-    "Tran_NamL": "Chu"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Claassen"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Clarke"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Geraldine",
-    "Tran_NamL": "Clarke"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Cowan"
+    "Tran_Date": "2016-07-30",
+    "Tran_NamF": "Arnold",
+    "Tran_NamL": "Mew"
   },
   {
     "Filer_ID": "1387267",
@@ -170,23 +37,93 @@
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "Cuidad De Mexico, Inc"
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Stuart",
+    "Tran_NamL": "Gardiner"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Pressman"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Trachtenberg"
   },
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Ted",
-    "Tran_NamL": "Dang"
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Fanny",
+    "Tran_NamL": "Gong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Ellen",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Layton",
+    "Tran_NamL": "Olson"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Max",
+    "Tran_NamL": "Chacana"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Robin",
+    "Tran_NamL": "Dean"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-06",
+    "Tran_NamF": "Tim",
+    "Tran_NamL": "Hallahan"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "AOSEN Group, LLC dba Pho Ao Sen"
   },
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Dang & Trachuk"
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Apodaca"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Clarke"
   },
   {
     "Filer_ID": "1387267",
@@ -198,128 +135,9 @@
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Robin",
-    "Tran_NamL": "Dean"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Katharine",
-    "Tran_NamL": "Dwyer"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Terrence",
-    "Tran_NamL": "Dwyer"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-07",
     "Tran_NamF": "Merlin",
     "Tran_NamL": "Edwards"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Weylin",
-    "Tran_NamL": "Eng"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Roselyn",
-    "Tran_NamL": "Eng"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Aimee",
-    "Tran_NamL": "Eng"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Falaschi"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Alan",
-    "Tran_NamL": "Fong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Victoria",
-    "Tran_NamL": "Fong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Barry",
-    "Tran_NamL": "Fong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Wenda",
-    "Tran_NamL": "Fong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "Francis Lan Insurance Agency, Inc"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-25",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Gamboa"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Stuart",
-    "Tran_NamL": "Gardiner"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "Harry",
-    "Tran_NamL": "Gee"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Gee"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Fanny",
-    "Tran_NamL": "Gong"
   },
   {
     "Filer_ID": "1387267",
@@ -344,38 +162,10 @@
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "Gordon A Wong,MD,FACP,FCCPChest and Infectious Diseases Consultant"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-06",
-    "Tran_NamF": "Tim",
-    "Tran_NamL": "Hallahan"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Ann",
-    "Tran_NamL": "Hardesty"
-  },
-  {
-    "Filer_ID": "1387267",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-08-07",
     "Tran_NamF": "Larry",
     "Tran_NamL": "Heizel"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Hemphill"
   },
   {
     "Filer_ID": "1387267",
@@ -387,9 +177,65 @@
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-02",
-    "Tran_NamF": "Victor",
-    "Tran_NamL": "Jin"
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lien Nguyen & Associates"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Rachel",
+    "Tran_NamL": "Lowe"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Russell",
+    "Tran_NamL": "Lowe"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Cimberly",
+    "Tran_NamL": "Tamura"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Doan",
+    "Tran_NamL": "Tran"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Them",
+    "Tran_NamL": "Tran"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Ky Vo",
+    "Tran_NamL": "Truong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-07",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Wong"
   },
   {
     "Filer_ID": "1387267",
@@ -401,135 +247,100 @@
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Kernighan"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Kong"
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Sean",
+    "Tran_NamL": "Randolph"
   },
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Jong",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Tatwina",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-14",
-    "Tran_NamF": "Anna Chin",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Ken",
-    "Tran_NamL": "Lem"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lien Nguyen & Associates"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Jorge",
-    "Tran_NamL": "Lopez"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Russell",
-    "Tran_NamL": "Lowe"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Rachel",
-    "Tran_NamL": "Lowe"
+    "Tran_Date": "2016-08-12",
+    "Tran_NamF": "Peter",
+    "Tran_NamL": "Wong"
   },
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Martiniak"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Martiniak"
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Alan",
+    "Tran_NamL": "Fong"
   },
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Mash Petroleum, Inc."
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Ann",
+    "Tran_NamL": "Shenkin"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Budd",
+    "Tran_NamL": "Shenkin"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Tim",
+    "Tran_NamL": "Tosta"
   },
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-30",
-    "Tran_NamF": "Arnold",
-    "Tran_NamL": "Mew"
+    "Tran_Date": "2016-08-16",
+    "Tran_NamF": "Norman",
+    "Tran_NamL": "Ronneberg"
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Ellen",
-    "Tran_NamL": "Miller"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-16",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Vasquez"
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Monson"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Stewart",
+    "Tran_NamL": "Chen"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Ener",
+    "Tran_NamL": "Chiu"
   },
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "John",
-    "Tran_NamL": "O'Toole"
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Jarlene",
+    "Tran_NamL": "Choy"
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Layton",
-    "Tran_NamL": "Olson"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Geraldine",
+    "Tran_NamL": "Clarke"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Roselyn",
+    "Tran_NamL": "Eng"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Weylin",
+    "Tran_NamL": "Eng"
   },
   {
     "Filer_ID": "1387267",
@@ -541,16 +352,51 @@
   {
     "Filer_ID": "1387267",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Dana",
-    "Tran_NamL": "Pong"
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Vogl"
   },
   {
     "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Pressman"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "John",
+    "Tran_NamL": "O'Toole"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "Zackery",
+    "Tran_NamL": "Walton"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Berring"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Katherine",
+    "Tran_NamL": "Strehl"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Sommer"
   },
   {
     "Filer_ID": "1387267",
@@ -561,10 +407,416 @@
   },
   {
     "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Katharine",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Falaschi"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Ann",
+    "Tran_NamL": "Hardesty"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Claassen"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Cowan"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Harry",
+    "Tran_NamL": "Gee"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Ernesto",
+    "Tran_NamL": "Vasquez"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Dana",
+    "Tran_NamL": "Pong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Kernighan"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Roger",
+    "Tran_NamL": "Chao"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "Gordon A Wong,MD,FACP,FCCPChest and Infectious Diseases Consultant"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Jong",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Jack",
+    "Tran_NamL": "Chu"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Barry",
+    "Tran_NamL": "Fong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Victoria",
+    "Tran_NamL": "Fong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Martiniak"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Marsha",
+    "Tran_NamL": "Standish"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Louis",
+    "Tran_NamL": "Weller"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Theresa",
+    "Tran_NamL": "Chao"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Martiniak"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Merrily",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Wenda",
+    "Tran_NamL": "Fong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Kong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Dang & Trachuk"
+  },
+  {
+    "Filer_ID": "1387267",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-09-30",
     "Tran_NamF": "Patricia",
     "Tran_NamL": "Quan"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-02",
+    "Tran_NamF": "Victor",
+    "Tran_NamL": "Jin"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "B C Realty"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Duane",
+    "Tran_NamL": "Baughman"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Judy",
+    "Tran_NamL": "Chu"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Ted",
+    "Tran_NamL": "Dang"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "Francis Lan Insurance Agency, Inc"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Hemphill"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Monson"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Allen",
+    "Tran_NamL": "Sam"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Tsukiyama"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Danny",
+    "Tran_NamL": "Young"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "C C",
+    "Tran_NamL": "Yin"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Kenny",
+    "Tran_NamL": "Chin"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Terrence",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Ken",
+    "Tran_NamL": "Lem"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Toy"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Worth"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Aimee",
+    "Tran_NamL": "Eng"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Brockett"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Gee"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Real Estate Political Action Committee - California Associations of Realtors"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Tatwina",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mash Petroleum, Inc."
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Curtis",
+    "Tran_NamL": "Yew"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Regina",
+    "Tran_NamL": "Yin"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Jorge",
+    "Tran_NamL": "Lopez"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "Cuidad De Mexico, Inc"
+  },
+  {
+    "Filer_ID": "1387267",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-14",
+    "Tran_NamF": "Anna Chin",
+    "Tran_NamL": "Lee"
   },
   {
     "Filer_ID": "1387267",
@@ -579,257 +831,5 @@
     "Tran_Date": "2016-12-15",
     "Tran_NamF": "Bruce",
     "Tran_NamL": "Quan"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Sean",
-    "Tran_NamL": "Randolph"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": "Norman",
-    "Tran_NamL": "Ronneberg"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Allen",
-    "Tran_NamL": "Sam"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Budd",
-    "Tran_NamL": "Shenkin"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Ann",
-    "Tran_NamL": "Shenkin"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "Gary",
-    "Tran_NamL": "Sommer"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Marsha",
-    "Tran_NamL": "Standish"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Katherine",
-    "Tran_NamL": "Strehl"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Cimberly",
-    "Tran_NamL": "Tamura"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Tim",
-    "Tran_NamL": "Tosta"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Toy"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Trachtenberg"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Them",
-    "Tran_NamL": "Tran"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Doan",
-    "Tran_NamL": "Tran"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Ky Vo",
-    "Tran_NamL": "Truong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "Tsukiyama"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Vasquez"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "Ernesto",
-    "Tran_NamL": "Vasquez"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Vogl"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "Zackery",
-    "Tran_NamL": "Walton"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Louis",
-    "Tran_NamL": "Weller"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-07",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-12",
-    "Tran_NamF": "Peter",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Douglas",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Merrily",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Douglas",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Worth"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Curtis",
-    "Tran_NamL": "Yew"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "C C",
-    "Tran_NamL": "Yin"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Regina",
-    "Tran_NamL": "Yin"
-  },
-  {
-    "Filer_ID": "1387267",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Danny",
-    "Tran_NamL": "Young"
   }
 ]

--- a/build/committee/1387803/contributions/index.json
+++ b/build/committee/1387803/contributions/index.json
@@ -22,15 +22,15 @@
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 450.0,
-    "Tran_Date": "2016-10-20",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Rochelle",
     "Tran_NamL": "Benning"
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-10-20",
     "Tran_NamF": "Rochelle",
     "Tran_NamL": "Benning"
   },
@@ -148,15 +148,15 @@
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-10",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-01",
     "Tran_NamF": "James",
     "Tran_NamL": "Harris"
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-01",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-10",
     "Tran_NamF": "James",
     "Tran_NamL": "Harris"
   },
@@ -302,16 +302,16 @@
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "T. Gary",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "Brian",
     "Tran_NamL": "Rogers"
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "Brian",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "T. Gary",
     "Tran_NamL": "Rogers"
   },
   {

--- a/build/committee/1387803/contributions/index.json
+++ b/build/committee/1387803/contributions/index.json
@@ -2,93 +2,16 @@
   {
     "Filer_ID": "1387803",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Al",
-    "Tran_NamL": "Adams"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Michelle",
-    "Tran_NamL": "Beck"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Bellino"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Rochelle",
-    "Tran_NamL": "Benning"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 450.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Rochelle",
-    "Tran_NamL": "Benning"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Courtney",
-    "Tran_NamL": "Benoist"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Aly",
-    "Tran_NamL": "Bonde"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bricklayers And Allied Craftworkers Local No. 3 Political Action Committee"
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Harris"
   },
   {
     "Filer_ID": "1387803",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Oral",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Cohen"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Gregory",
-    "Tran_NamL": "Coxsom"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-06",
-    "Tran_NamF": "Eddie",
-    "Tran_NamL": "Dillard"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Steve",
-    "Tran_NamL": "Dostart"
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Rogers"
   },
   {
     "Filer_ID": "1387803",
@@ -106,52 +29,31 @@
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "Families and Educators for Public Education"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Jason",
-    "Tran_NamL": "Fish"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Abe",
-    "Tran_NamL": "Friedman"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Klein"
   },
   {
     "Filer_ID": "1387803",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-15",
-    "Tran_NamF": "Ed",
-    "Tran_NamL": "Gerber"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Christina",
-    "Tran_NamL": "Greenberg"
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Stein"
   },
   {
     "Filer_ID": "1387803",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Jill",
-    "Tran_NamL": "Habig"
+    "Tran_Date": "2016-08-06",
+    "Tran_NamF": "Eddie",
+    "Tran_NamL": "Dillard"
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Harris"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Libby",
+    "Tran_NamL": "Schaaf"
   },
   {
     "Filer_ID": "1387803",
@@ -162,87 +64,10 @@
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Hassid"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Jabari",
-    "Tran_NamL": "Herbert"
-  },
-  {
-    "Filer_ID": "1387803",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Jason",
-    "Tran_NamL": "Hoffman"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Brotherhood of Electrical Workers Local 595 PAC"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Laurene",
-    "Tran_NamL": "Jobs"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Kakishiba"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Klein"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 301.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": "Shankar",
-    "Tran_NamL": "Krishna"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Alec",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 535.0,
-    "Tran_Date": "2016-09-18",
-    "Tran_NamF": "Ronald",
-    "Tran_NamL": "Lewis"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": "Akil",
-    "Tran_NamL": "Manley"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Greg",
-    "Tran_NamL": "McConnell"
+    "Tran_Date": "2016-08-15",
+    "Tran_NamF": "Ed",
+    "Tran_NamL": "Gerber"
   },
   {
     "Filer_ID": "1387803",
@@ -250,6 +75,48 @@
     "Tran_Date": "2016-08-15",
     "Tran_NamF": "Valerie",
     "Tran_NamL": "Morris"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Bellino"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-27",
+    "Tran_NamF": "Jean",
+    "Tran_NamL": "Wing"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Al",
+    "Tran_NamL": "Adams"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-02",
+    "Tran_NamF": "Glenn",
+    "Tran_NamL": "Shannon"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Hassid"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Kakishiba"
   },
   {
     "Filer_ID": "1387803",
@@ -267,44 +134,58 @@
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Northern California Carpenters Regional Council Small Contributors Committee"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Charter Advocates for Excellent Public Schools"
-  },
-  {
-    "Filer_ID": "1387803",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce (OAKPAC)"
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Olis",
+    "Tran_NamL": "Simmons"
   },
   {
     "Filer_ID": "1387803",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": "Alexis",
-    "Tran_NamL": "Pelosi"
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Rochelle",
+    "Tran_NamL": "Benning"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Hoffman"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "Families and Educators for Public Education"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 301.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "Shankar",
+    "Tran_NamL": "Krishna"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 535.0,
+    "Tran_Date": "2016-09-18",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Lewis"
   },
   {
     "Filer_ID": "1387803",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Riley"
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Cohen"
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": "Brian",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Kathleen",
     "Tran_NamL": "Rogers"
   },
   {
@@ -316,38 +197,87 @@
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Kathleen",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 600.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "Sheryl",
-    "Tran_NamL": "Sandberg"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Libby",
-    "Tran_NamL": "Schaaf"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "Stacy",
-    "Tran_NamL": "Schusterman"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Alec",
+    "Tran_NamL": "Lee"
   },
   {
     "Filer_ID": "1387803",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-02",
-    "Tran_NamF": "Glenn",
-    "Tran_NamL": "Shannon"
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Louise",
+    "Tran_NamL": "Waters"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "U.A. Local 342 P.A.C. Fund"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sprinkler Fitters and Apprentices Local 483 Local PAC"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Simpson"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Gregory",
+    "Tran_NamL": "Coxsom"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Dostart"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Christina",
+    "Tran_NamL": "Greenberg"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce (OAKPAC)"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Zahas"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Jill",
+    "Tran_NamL": "Habig"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bricklayers And Allied Craftworkers Local No. 3 Political Action Committee"
   },
   {
     "Filer_ID": "1387803",
@@ -359,23 +289,93 @@
   {
     "Filer_ID": "1387803",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Riley"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-15",
     "Tran_NamF": "David",
     "Tran_NamL": "Silver"
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Olis",
-    "Tran_NamL": "Simmons"
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "Sheryl",
+    "Tran_NamL": "Sandberg"
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Simpson"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Courtney",
+    "Tran_NamL": "Benoist"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Fish"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": "Akil",
+    "Tran_NamL": "Manley"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Rochelle",
+    "Tran_NamL": "Benning"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Michelle",
+    "Tran_NamL": "Beck"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Jabari",
+    "Tran_NamL": "Herbert"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Abe",
+    "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Oral",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Laurene",
+    "Tran_NamL": "Jobs"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California Carpenters Regional Council Small Contributors Committee"
   },
   {
     "Filer_ID": "1387803",
@@ -383,20 +383,6 @@
     "Tran_Date": "2016-10-28",
     "Tran_NamF": "David",
     "Tran_NamL": "Simpson"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sprinkler Fitters and Apprentices Local 483 Local PAC"
-  },
-  {
-    "Filer_ID": "1387803",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Stein"
   },
   {
     "Filer_ID": "1387803",
@@ -407,13 +393,6 @@
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "U.A. Local 342 P.A.C. Fund"
-  },
-  {
-    "Filer_ID": "1387803",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-10-29",
     "Tran_NamF": "Patrick",
@@ -421,23 +400,44 @@
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Louise",
-    "Tran_NamL": "Waters"
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Charter Advocates for Excellent Public Schools"
   },
   {
     "Filer_ID": "1387803",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-27",
-    "Tran_NamF": "Jean",
-    "Tran_NamL": "Wing"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Brotherhood of Electrical Workers Local 595 PAC"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": "Alexis",
+    "Tran_NamL": "Pelosi"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Aly",
+    "Tran_NamL": "Bonde"
   },
   {
     "Filer_ID": "1387803",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Eugene",
-    "Tran_NamL": "Zahas"
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "McConnell"
+  },
+  {
+    "Filer_ID": "1387803",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "Stacy",
+    "Tran_NamL": "Schusterman"
   }
 ]

--- a/build/committee/1387905/contributions/index.json
+++ b/build/committee/1387905/contributions/index.json
@@ -1,17 +1,38 @@
 [
   {
     "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "12th & 13th Webster St. LLC"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "Niccolo",
+    "Tran_NamL": "Deluca"
   },
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Barney"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Mike",
+    "Tran_NamL": "Yoell"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-29",
     "Tran_NamF": null,
-    "Tran_NamL": "451 Hegenberger Gas, Inc."
+    "Tran_NamL": "WRA, INC"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Ed",
+    "Tran_NamL": "Fitzpatrick"
   },
   {
     "Filer_ID": "1387905",
@@ -23,22 +44,8 @@
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Almsteier"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "Kate",
-    "Tran_NamL": "Arenchild"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Peggy",
     "Tran_NamL": "Arenchild"
   },
   {
@@ -52,36 +59,15 @@
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Peggy",
+    "Tran_NamL": "Arenchild"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
     "Tran_NamF": null,
     "Tran_NamL": "Argent Management"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Auto Plus Towing LLC"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Brandon",
-    "Tran_NamL": "Baranco"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Barney"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bay Stone Depot Inc."
   },
   {
     "Filer_ID": "1387905",
@@ -93,51 +79,9 @@
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "Patel",
-    "Tran_NamL": "Bhumika"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-11-22",
-    "Tran_NamF": "Patel",
-    "Tran_NamL": "Bhumika"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "Stacy",
     "Tran_NamL": "Binh"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bliss"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "A. Freeman",
-    "Tran_NamL": "Bradley"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Rajinder",
-    "Tran_NamL": "Brah"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Brynjolfsson"
   },
   {
     "Filer_ID": "1387905",
@@ -145,34 +89,6 @@
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "John",
     "Tran_NamL": "Burns Patterson"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Real Estate Political Action Committee (CREPAC) - California Association of Realtors"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Gregory",
-    "Tran_NamL": "Caligari"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Carl",
-    "Tran_NamL": "Chan"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Chelstowski"
   },
   {
     "Filer_ID": "1387905",
@@ -184,93 +100,9 @@
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "Construction & General Laborers Local Union No. 304 Political Action Committee"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "Construction Engineering Consulting Group, Inc."
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "Niccolo",
-    "Tran_NamL": "Deluca"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Nyeisha",
-    "Tran_NamL": "Dewitt"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-01",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Doty"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": null,
     "Tran_NamL": "Engeo Inc."
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Essential Aesthetics Inc"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Falaschi"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Ed",
-    "Tran_NamL": "Fitzpatrick"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Fredkin"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Megan",
-    "Tran_NamL": "Gates"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Gates"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "William",
-    "Tran_NamL": "Gates"
   },
   {
     "Filer_ID": "1387905",
@@ -282,92 +114,8 @@
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Gerlach"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Tamar",
-    "Tran_NamL": "Goodfellow"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "J. Stephen",
-    "Tran_NamL": "Goodfellow"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Chad",
-    "Tran_NamL": "Goodfellow"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Shay",
-    "Tran_NamL": "Goodfellow"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Belinda",
-    "Tran_NamL": "Guadarrama"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Denis",
-    "Tran_NamL": "Herrera"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-12-23",
-    "Tran_NamF": "Denis",
-    "Tran_NamL": "Herrera"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Salwa",
-    "Tran_NamL": "Ibrahim"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 530.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Association of Firefighters Local 55 PAC"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "International Federation of Professional and Technical Engineers - Local 21 TJ Anthony PAC Fund"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "Justin Blake",
-    "Tran_NamL": "Johansen"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Shahpar",
     "Tran_NamL": "Johansen"
   },
   {
@@ -379,38 +127,10 @@
   },
   {
     "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Wayne",
-    "Tran_NamL": "Jordan"
-  },
-  {
-    "Filer_ID": "1387905",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "Joanne",
     "Tran_NamL": "Karchmer"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Martin",
-    "Tran_NamL": "Kaufman"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Sam",
-    "Tran_NamL": "Lauter"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lily Hu & Associates"
   },
   {
     "Filer_ID": "1387905",
@@ -436,62 +156,6 @@
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": "P. Scott",
-    "Tran_NamL": "McKibbean"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Randall",
-    "Tran_NamL": "Morrison"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Mudge"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": null,
-    "Tran_NamL": "NNF Grewal Inc"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Nahass"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Fred",
-    "Tran_NamL": "Naranjo"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": null,
-    "Tran_NamL": "National Union Of Healthcare Workers"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Jim",
-    "Tran_NamL": "Nemechek"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "Charlie",
     "Tran_NamL": "Ngo"
@@ -506,72 +170,9 @@
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "OKP Land Holdings LLC"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce (OakPAC)"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Pharmacy"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Jennie",
-    "Tran_NamL": "Ong"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Govind",
-    "Tran_NamL": "Patel"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Sima",
-    "Tran_NamL": "Patel"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Peterson"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": null,
     "Tran_NamL": "Pho Anh Dao Alameda"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Jason",
-    "Tran_NamL": "Post"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Proforma Construction Inc"
   },
   {
     "Filer_ID": "1387905",
@@ -589,45 +190,10 @@
   },
   {
     "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Rosas"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "SEI Development"
-  },
-  {
-    "Filer_ID": "1387905",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "Jamshid",
     "Tran_NamL": "Sagharchi"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": "Yolanda",
-    "Tran_NamL": "Salsedo"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": "Desai",
-    "Tran_NamL": "Sandhya"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-12-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Schnitzer Steel Industries"
   },
   {
     "Filer_ID": "1387905",
@@ -646,34 +212,6 @@
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sebastian Ridley-Thomas for Assembly 2016"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "Service Employees International Union Local 1021 Candidate PAC"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Melanie",
-    "Tran_NamL": "Shelby"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Silver"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "Chris",
     "Tran_NamL": "Taylor"
@@ -687,52 +225,10 @@
   },
   {
     "Filer_ID": "1387905",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "The McConnell Group"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-29",
-    "Tran_NamF": "Michele",
-    "Tran_NamL": "Townsend"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Trilateral LLC"
-  },
-  {
-    "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "Douglas",
     "Tran_NamL": "Turner"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Unity PAC, A Sponsored Committee Of The Alameda Labor Council, AFL-CIO"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Jane",
-    "Tran_NamL": "Vail"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Edward",
-    "Tran_NamL": "Vail"
   },
   {
     "Filer_ID": "1387905",
@@ -744,44 +240,9 @@
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Sudeep",
-    "Tran_NamL": "Virk"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "WRA, INC"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": null,
     "Tran_NamL": "Wildcat LLC"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Wolmark"
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "YHLA Architects Inc."
-  },
-  {
-    "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Mike",
-    "Tran_NamL": "Yoell"
   },
   {
     "Filer_ID": "1387905",
@@ -794,14 +255,553 @@
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Yesica",
+    "Tran_NamF": "Silvia",
     "Tran_NamL": "Zhang"
   },
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Silvia",
+    "Tran_NamF": "Yesica",
     "Tran_NamL": "Zhang"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Almsteier"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Salwa",
+    "Tran_NamL": "Ibrahim"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Jim",
+    "Tran_NamL": "Nemechek"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Peterson"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Nahass"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Sam",
+    "Tran_NamL": "Lauter"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 530.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Association of Firefighters Local 55 PAC"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "451 Hegenberger Gas, Inc."
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Brandon",
+    "Tran_NamL": "Baranco"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Brynjolfsson"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Gregory",
+    "Tran_NamL": "Caligari"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Chelstowski"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Nyeisha",
+    "Tran_NamL": "Dewitt"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Shahpar",
+    "Tran_NamL": "Johansen"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Martin",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Randall",
+    "Tran_NamL": "Morrison"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Mudge"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Fred",
+    "Tran_NamL": "Naranjo"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "OKP Land Holdings LLC"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Govind",
+    "Tran_NamL": "Patel"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sima",
+    "Tran_NamL": "Patel"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Rosas"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-01",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Doty"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Wayne",
+    "Tran_NamL": "Jordan"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce (OakPAC)"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Falaschi"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Construction & General Laborers Local Union No. 304 Political Action Committee"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "NNF Grewal Inc"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "12th & 13th Webster St. LLC"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Carl",
+    "Tran_NamL": "Chan"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Pharmacy"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Jennie",
+    "Tran_NamL": "Ong"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sebastian Ridley-Thomas for Assembly 2016"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "YHLA Architects Inc."
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Auto Plus Towing LLC"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Rajinder",
+    "Tran_NamL": "Brah"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Real Estate Political Action Committee (CREPAC) - California Association of Realtors"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Gerlach"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Denis",
+    "Tran_NamL": "Herrera"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lily Hu & Associates"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Trilateral LLC"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Unity PAC, A Sponsored Committee Of The Alameda Labor Council, AFL-CIO"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Sudeep",
+    "Tran_NamL": "Virk"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Wolmark"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Post"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "A. Freeman",
+    "Tran_NamL": "Bradley"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Essential Aesthetics Inc"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "SEI Development"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": "P. Scott",
+    "Tran_NamL": "McKibbean"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Proforma Construction Inc"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": "Yolanda",
+    "Tran_NamL": "Salsedo"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": "Michele",
+    "Tran_NamL": "Townsend"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Fredkin"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Belinda",
+    "Tran_NamL": "Guadarrama"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "International Federation of Professional and Technical Engineers - Local 21 TJ Anthony PAC Fund"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Vail"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Jane",
+    "Tran_NamL": "Vail"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "Construction Engineering Consulting Group, Inc."
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Melanie",
+    "Tran_NamL": "Shelby"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bay Stone Depot Inc."
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": null,
+    "Tran_NamL": "National Union Of Healthcare Workers"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Gates"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Megan",
+    "Tran_NamL": "Gates"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Gates"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Goodfellow"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "J. Stephen",
+    "Tran_NamL": "Goodfellow"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Shay",
+    "Tran_NamL": "Goodfellow"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Tamar",
+    "Tran_NamL": "Goodfellow"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "Patel",
+    "Tran_NamL": "Bhumika"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": "Desai",
+    "Tran_NamL": "Sandhya"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "The McConnell Group"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021 Candidate PAC"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-11-22",
+    "Tran_NamF": "Patel",
+    "Tran_NamL": "Bhumika"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-12-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Schnitzer Steel Industries"
+  },
+  {
+    "Filer_ID": "1387905",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-12-23",
+    "Tran_NamF": "Denis",
+    "Tran_NamL": "Herrera"
   }
 ]

--- a/build/committee/1387905/contributions/index.json
+++ b/build/committee/1387905/contributions/index.json
@@ -323,15 +323,15 @@
   },
   {
     "Filer_ID": "1387905",
-    "Tran_Amt1": -700.0,
-    "Tran_Date": "2016-12-23",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
     "Tran_NamF": "Denis",
     "Tran_NamL": "Herrera"
   },
   {
     "Filer_ID": "1387905",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
+    "Tran_Amt1": -700.0,
+    "Tran_Date": "2016-12-23",
     "Tran_NamF": "Denis",
     "Tran_NamL": "Herrera"
   },
@@ -359,15 +359,15 @@
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Shahpar",
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Justin Blake",
     "Tran_NamL": "Johansen"
   },
   {
     "Filer_ID": "1387905",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Justin Blake",
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Shahpar",
     "Tran_NamL": "Johansen"
   },
   {

--- a/build/committee/1387983/contributions/index.json
+++ b/build/committee/1387983/contributions/index.json
@@ -212,14 +212,14 @@
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 25000.0,
-    "Tran_Date": "2016-09-27",
+    "Tran_Date": "2016-09-08",
     "Tran_NamF": null,
     "Tran_NamL": "Gallagher & Burk, Inc. Paving & Grading Contractors"
   },
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 25000.0,
-    "Tran_Date": "2016-09-08",
+    "Tran_Date": "2016-09-27",
     "Tran_NamF": null,
     "Tran_NamL": "Gallagher & Burk, Inc. Paving & Grading Contractors"
   },
@@ -330,15 +330,8 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 36075.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": null,
-    "Tran_NamL": "Mayor Libby Schaaf for Oakland"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2518.8,
-    "Tran_Date": "2016-10-19",
+    "Tran_Amt1": 76554.5,
+    "Tran_Date": "2016-09-22",
     "Tran_NamF": null,
     "Tran_NamL": "Mayor Libby Schaaf for Oakland"
   },
@@ -351,8 +344,15 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 76554.5,
-    "Tran_Date": "2016-09-22",
+    "Tran_Amt1": 36075.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mayor Libby Schaaf for Oakland"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2518.8,
+    "Tran_Date": "2016-10-19",
     "Tran_NamF": null,
     "Tran_NamL": "Mayor Libby Schaaf for Oakland"
   },

--- a/build/committee/1387983/contributions/index.json
+++ b/build/committee/1387983/contributions/index.json
@@ -8,122 +8,17 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "AT&T California Employee PAC"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Isaac",
-    "Tran_NamL": "Abid"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Alameda Electrical Distributors"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Altemus"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Argent Materials, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "Franklin",
-    "Tran_NamL": "Arthur"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "BKF Engineers"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bacon"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Beci Electric, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "Shefali",
-    "Tran_NamL": "Billion"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bliss"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bridge Housing Corporation"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "Abbigail",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1387983",
     "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "CDM Smith"
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Whitehouse"
   },
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-06",
+    "Tran_Date": "2016-08-16",
     "Tran_NamF": null,
-    "Tran_NamL": "CP VI Franklin, LLC"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "Cahill"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Alliance For Jobs - Rebuild California Committee"
+    "Tran_NamL": "Townsend Public Affairs, Inc."
   },
   {
     "Filer_ID": "1387983",
@@ -131,6 +26,20 @@
     "Tran_Date": "2016-08-26",
     "Tran_NamF": null,
     "Tran_NamL": "California Conservation Campaign"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Marcone"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
   },
   {
     "Filer_ID": "1387983",
@@ -142,58 +51,58 @@
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Chrisp Company"
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Freiberg"
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Columbia Electric, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "Condon-Johnson And Associates, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 3500.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "D-Line Constructors, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 7500.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "District Council of Ironworkers Political Issues Committee"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Economy Lumber"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Electrical Contractors Trust of Alameda County"
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "Gruendl"
   },
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-09",
-    "Tran_NamF": "Avril",
-    "Tran_NamL": "Fitzgerald"
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Doug",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "AT&T California Employee PAC"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "Abbigail",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "Miye",
+    "Tran_NamL": "Takagi"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-05",
+    "Tran_NamF": "Isaac",
+    "Tran_NamL": "Kos-Read"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-05",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Story"
   },
   {
     "Filer_ID": "1387983",
@@ -205,9 +114,37 @@
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Freiberg"
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": "Ed",
+    "Tran_NamL": "Gerber"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-09-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "United Contractors"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Franklin",
+    "Tran_NamL": "Arthur"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bacon"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Shefali",
+    "Tran_NamL": "Billion"
   },
   {
     "Filer_ID": "1387983",
@@ -215,41 +152,6 @@
     "Tran_Date": "2016-09-08",
     "Tran_NamF": null,
     "Tran_NamL": "Gallagher & Burk, Inc. Paving & Grading Contractors"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 25000.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "Gallagher & Burk, Inc. Paving & Grading Contractors"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": "Ed",
-    "Tran_NamL": "Gerber"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Golden Associates Landscape Architects"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Greg",
-    "Tran_NamL": "Gruendl"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "HNTB Holdings"
   },
   {
     "Filer_ID": "1387983",
@@ -264,34 +166,6 @@
     "Tran_Date": "2016-09-08",
     "Tran_NamF": "Chris",
     "Tran_NamL": "Hwang"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "IFPTE Local 21 Issues PAC Fund"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "J.A. Momaney Services, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "J.R. (Eddie) and Amy Orton, TTEES"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Doug",
-    "Tran_NamL": "Johnson"
   },
   {
     "Filer_ID": "1387983",
@@ -310,23 +184,51 @@
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-05",
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Noguera"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Natasha",
+    "Tran_NamL": "Terk"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-09",
     "Tran_NamF": "Isaac",
-    "Tran_NamL": "Kos-Read"
+    "Tran_NamL": "Abid"
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-10",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Altemus"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-09",
+    "Tran_NamF": "Avril",
+    "Tran_NamL": "Fitzgerald"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 50000.0,
+    "Tran_Date": "2016-09-15",
     "Tran_NamF": null,
-    "Tran_NamL": "Mag Trucking"
+    "Tran_NamL": "McGuire and Hester"
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Marcone"
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Alliance For Jobs - Rebuild California Committee"
   },
   {
     "Filer_ID": "1387983",
@@ -337,6 +239,97 @@
   },
   {
     "Filer_ID": "1387983",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California District Council of Laborers Issues PAC"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "San Francisco Laborer's Local 261 P.A.C."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Shorenstein Realty Services, LP"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "HNTB Holdings"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 25000.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "Gallagher & Burk, Inc. Paving & Grading Contractors"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Alexis",
+    "Tran_NamL": "Pelosi"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "PG&E Corporation"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Josue",
+    "Tran_NamL": "Prada"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "O.C. Jones & Sons, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bridge Housing Corporation"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "Condon-Johnson And Associates, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": null,
+    "Tran_NamL": "Redgwick Construction Company"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "CP VI Franklin, LLC"
+  },
+  {
+    "Filer_ID": "1387983",
     "Tran_Amt1": 2700.0,
     "Tran_Date": "2016-10-06",
     "Tran_NamF": null,
@@ -344,8 +337,148 @@
   },
   {
     "Filer_ID": "1387983",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Columbia Electric, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 3500.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "D-Line Constructors, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Electrical Contractors Trust of Alameda County"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Golden Associates Landscape Architects"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mag Trucking"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Niles Electric Co."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California Chapter, NECA PAC"
+  },
+  {
+    "Filer_ID": "1387983",
     "Tran_Amt1": 36075.0,
     "Tran_Date": "2016-10-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mayor Libby Schaaf for Oakland"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "Silverado Contractors, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Alameda Electrical Distributors"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Chrisp Company"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "J.A. Momaney Services, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Operating Engineers Local Union No. 3 Issues PAC"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Robert A. Bothman, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Striping Graphics"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Tesco Controls, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "YHLA Architects, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Argent Materials, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Economy Lumber"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 750.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Save the Bay Action Fund Committee to Support Proposition 67"
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 1452.04,
+    "Tran_Date": "2016-10-19",
     "Tran_NamF": null,
     "Tran_NamL": "Mayor Libby Schaaf for Oakland"
   },
@@ -358,101 +491,45 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 1452.04,
-    "Tran_Date": "2016-10-19",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-20",
     "Tran_NamF": null,
-    "Tran_NamL": "Mayor Libby Schaaf for Oakland"
+    "Tran_NamL": "Cahill"
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 50000.0,
-    "Tran_Date": "2016-09-15",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-10-20",
     "Tran_NamF": null,
-    "Tran_NamL": "McGuire and Hester"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": null,
-    "Tran_NamL": "Niles Electric Co."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Amanda",
-    "Tran_NamL": "Noguera"
+    "Tran_NamL": "IFPTE Local 21 Issues PAC Fund"
   },
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-10",
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": null,
-    "Tran_NamL": "Northern California Chapter, NECA PAC"
+    "Tran_NamL": "BKF Engineers"
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-09-23",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": null,
-    "Tran_NamL": "Northern California District Council of Laborers Issues PAC"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "O.C. Jones & Sons, Inc."
+    "Tran_NamL": "Beci Electric, Inc."
   },
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-17",
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": null,
-    "Tran_NamL": "Operating Engineers Local Union No. 3 Issues PAC"
+    "Tran_NamL": "CDM Smith"
   },
   {
     "Filer_ID": "1387983",
     "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-09-29",
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": null,
-    "Tran_NamL": "PG&E Corporation"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Parsons Brinckerhoff, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Alexis",
-    "Tran_NamL": "Pelosi"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "Josue",
-    "Tran_NamL": "Prada"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": null,
-    "Tran_NamL": "Redgwick Construction Company"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Robert A. Bothman, Inc."
+    "Tran_NamL": "J.R. (Eddie) and Amy Orton, TTEES"
   },
   {
     "Filer_ID": "1387983",
@@ -463,10 +540,10 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-09-23",
+    "Tran_Amt1": 7500.0,
+    "Tran_Date": "2016-10-28",
     "Tran_NamF": null,
-    "Tran_NamL": "San Francisco Laborer's Local 261 P.A.C."
+    "Tran_NamL": "District Council of Ironworkers Political Issues Committee"
   },
   {
     "Filer_ID": "1387983",
@@ -477,86 +554,9 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 750.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": null,
-    "Tran_NamL": "Save the Bay Action Fund Committee to Support Proposition 67"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Shorenstein Realty Services, LP"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 10000.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": null,
-    "Tran_NamL": "Silverado Contractors, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-05",
-    "Tran_NamF": "Joan",
-    "Tran_NamL": "Story"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-17",
+    "Tran_Date": "2016-11-28",
     "Tran_NamF": null,
-    "Tran_NamL": "Striping Graphics"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "Miye",
-    "Tran_NamL": "Takagi"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Natasha",
-    "Tran_NamL": "Terk"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Tesco Controls, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-08-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "Townsend Public Affairs, Inc."
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-09-06",
-    "Tran_NamF": null,
-    "Tran_NamL": "United Contractors"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-08-01",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Whitehouse"
-  },
-  {
-    "Filer_ID": "1387983",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "YHLA Architects, Inc."
+    "Tran_NamL": "Parsons Brinckerhoff, Inc."
   }
 ]

--- a/build/committee/1388133/contributions/index.json
+++ b/build/committee/1388133/contributions/index.json
@@ -71,16 +71,16 @@
   },
   {
     "Filer_ID": "1388133",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-07-17",
-    "Tran_NamF": "Edwin",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-07-15",
+    "Tran_NamF": "Michael",
     "Tran_NamL": "Hassid"
   },
   {
     "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Daniel",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-07-17",
+    "Tran_NamF": "Edwin",
     "Tran_NamL": "Hassid"
   },
   {
@@ -106,16 +106,16 @@
   },
   {
     "Filer_ID": "1388133",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-07-15",
-    "Tran_NamF": "Michael",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Andre",
     "Tran_NamL": "Hassid"
   },
   {
     "Filer_ID": "1388133",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Andre",
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Daniel",
     "Tran_NamL": "Hassid"
   },
   {

--- a/build/committee/1388133/contributions/index.json
+++ b/build/committee/1388133/contributions/index.json
@@ -1,76 +1,6 @@
 [
   {
     "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Rosamond",
-    "Tran_NamL": "Baiz"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Muriel",
-    "Tran_NamL": "Bentsen"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Parashar",
-    "Tran_NamL": "Bhise"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-06",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Carlson"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-18",
-    "Tran_NamF": "Marianella",
-    "Tran_NamL": "Cateriano"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Steve",
-    "Tran_NamL": "Dostart"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-01",
-    "Tran_NamF": "Loretta",
-    "Tran_NamL": "Durbin"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Fabian"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Paul",
-    "Tran_NamL": "Fromberg"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Norma",
-    "Tran_NamL": "Gillogly"
-  },
-  {
-    "Filer_ID": "1388133",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-07-15",
     "Tran_NamF": "Michael",
@@ -82,118 +12,6 @@
     "Tran_Date": "2016-07-17",
     "Tran_NamF": "Edwin",
     "Tran_NamL": "Hassid"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-07-20",
-    "Tran_NamF": "Steve",
-    "Tran_NamL": "Hassid"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Victoria",
-    "Tran_NamL": "Hassid"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-06",
-    "Tran_NamF": "Suzanne",
-    "Tran_NamL": "Hassid"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Andre",
-    "Tran_NamL": "Hassid"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Hassid"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Helen",
-    "Tran_NamL": "Hwang"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Melvin",
-    "Tran_NamL": "Kaplan"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Sherry",
-    "Tran_NamL": "Lansing"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Phong",
-    "Tran_NamL": "Le"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Karl",
-    "Tran_NamL": "Mattson"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-28",
-    "Tran_NamF": "Gail",
-    "Tran_NamL": "Nebenzahl"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Adam",
-    "Tran_NamL": "Platt"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Alexandra",
-    "Tran_NamL": "Pligavko"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-03",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Sachs"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Ellen",
-    "Tran_NamL": "Schell"
-  },
-  {
-    "Filer_ID": "1388133",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Stacy",
-    "Tran_NamL": "Schusterman"
   },
   {
     "Filer_ID": "1388133",
@@ -212,9 +30,142 @@
   {
     "Filer_ID": "1388133",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-07-20",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Hassid"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Rosamond",
+    "Tran_NamL": "Baiz"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Paul",
+    "Tran_NamL": "Fromberg"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Victoria",
+    "Tran_NamL": "Hassid"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Karl",
+    "Tran_NamL": "Mattson"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Ellen",
+    "Tran_NamL": "Schell"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-02",
     "Tran_NamF": "Gideon",
     "Tran_NamL": "Stein"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Walsh"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Fabian"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-03",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Sachs"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-06",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Carlson"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-06",
+    "Tran_NamF": "Suzanne",
+    "Tran_NamL": "Hassid"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Muriel",
+    "Tran_NamL": "Bentsen"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Parashar",
+    "Tran_NamL": "Bhise"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Norma",
+    "Tran_NamL": "Gillogly"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Andre",
+    "Tran_NamL": "Hassid"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Helen",
+    "Tran_NamL": "Hwang"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Melvin",
+    "Tran_NamL": "Kaplan"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Phong",
+    "Tran_NamL": "Le"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Alexandra",
+    "Tran_NamL": "Pligavko"
   },
   {
     "Filer_ID": "1388133",
@@ -225,9 +176,58 @@
   },
   {
     "Filer_ID": "1388133",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Sherry",
+    "Tran_NamL": "Lansing"
+  },
+  {
+    "Filer_ID": "1388133",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Patrick",
-    "Tran_NamL": "Walsh"
+    "Tran_Date": "2016-08-18",
+    "Tran_NamF": "Marianella",
+    "Tran_NamL": "Cateriano"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Platt"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Hassid"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-28",
+    "Tran_NamF": "Gail",
+    "Tran_NamL": "Nebenzahl"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-01",
+    "Tran_NamF": "Loretta",
+    "Tran_NamL": "Durbin"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Dostart"
+  },
+  {
+    "Filer_ID": "1388133",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Stacy",
+    "Tran_NamL": "Schusterman"
   }
 ]

--- a/build/committee/1388168/contributions/index.json
+++ b/build/committee/1388168/contributions/index.json
@@ -22,6 +22,13 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Albracht"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Matthew",
@@ -31,13 +38,6 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 450.0,
     "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Albracht"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-19",
     "Tran_NamF": "Matthew",
     "Tran_NamL": "Albracht"
   },
@@ -64,16 +64,16 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Irma",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Karen",
     "Tran_NamL": "Anderson"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Karen",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Irma",
     "Tran_NamL": "Anderson"
   },
   {
@@ -197,16 +197,16 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
+    "Tran_Amt1": 300.0,
     "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Natnael",
+    "Tran_NamF": "Miriam",
     "Tran_NamL": "Bereket-Ab"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 300.0,
+    "Tran_Amt1": 250.0,
     "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Miriam",
+    "Tran_NamF": "Natnael",
     "Tran_NamL": "Bereket-Ab"
   },
   {
@@ -240,7 +240,7 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
+    "Tran_Date": "2016-08-20",
     "Tran_NamF": "Karen",
     "Tran_NamL": "Bovarnick"
   },
@@ -254,7 +254,7 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-20",
+    "Tran_Date": "2016-10-17",
     "Tran_NamF": "Karen",
     "Tran_NamL": "Bovarnick"
   },
@@ -310,15 +310,15 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Greggory",
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "James",
     "Tran_NamL": "Brown"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "James",
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Greggory",
     "Tran_NamL": "Brown"
   },
   {
@@ -331,14 +331,14 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-12-01",
+    "Tran_Date": "2016-10-31",
     "Tran_NamF": "Bradley",
     "Tran_NamL": "Brownlow"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
+    "Tran_Date": "2016-12-01",
     "Tran_NamF": "Bradley",
     "Tran_NamL": "Brownlow"
   },
@@ -401,14 +401,14 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-21",
+    "Tran_Date": "2016-08-26",
     "Tran_NamF": "Lucia",
     "Tran_NamL": "Capron"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-26",
+    "Tran_Date": "2016-09-21",
     "Tran_NamF": "Lucia",
     "Tran_NamL": "Capron"
   },
@@ -470,15 +470,15 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-07",
     "Tran_NamF": "Sandra",
     "Tran_NamL": "Cook"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-07",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
     "Tran_NamF": "Sandra",
     "Tran_NamL": "Cook"
   },
@@ -575,15 +575,15 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 31.0,
-    "Tran_Date": "2016-10-15",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Abdul",
     "Tran_NamL": "El-Amin Luqman"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
+    "Tran_Amt1": 31.0,
+    "Tran_Date": "2016-10-15",
     "Tran_NamF": "Abdul",
     "Tran_NamL": "El-Amin Luqman"
   },
@@ -624,15 +624,15 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
     "Tran_NamF": "Amanda",
     "Tran_NamL": "Feinstein"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-05",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
     "Tran_NamF": "Amanda",
     "Tran_NamL": "Feinstein"
   },
@@ -659,16 +659,16 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Natalie",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Debbie",
     "Tran_NamL": "Foster"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Debbie",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Natalie",
     "Tran_NamL": "Foster"
   },
   {
@@ -750,8 +750,8 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 72.0,
-    "Tran_Date": "2016-10-11",
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-08-30",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Geller"
   },
@@ -764,15 +764,15 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 180.0,
-    "Tran_Date": "2016-08-30",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Geller"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-09-24",
+    "Tran_Amt1": 72.0,
+    "Tran_Date": "2016-10-11",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Geller"
   },
@@ -932,15 +932,15 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-24",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Nancy",
     "Tran_NamL": "Hinds"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Nancy",
     "Tran_NamL": "Hinds"
   },
@@ -1009,6 +1009,13 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Venus",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 350.0,
     "Tran_Date": "2016-09-15",
     "Tran_NamF": "Judith",
@@ -1017,21 +1024,14 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Venus",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-25",
+    "Tran_Date": "2016-08-26",
     "Tran_NamF": "LaNiece",
     "Tran_NamL": "Jones"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-25",
     "Tran_NamF": "LaNiece",
     "Tran_NamL": "Jones"
   },
@@ -1059,15 +1059,15 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Scott",
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Joanne",
     "Tran_NamL": "Karchmer"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Joanne",
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Scott",
     "Tran_NamL": "Karchmer"
   },
   {
@@ -1093,8 +1093,8 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-03",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-21",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Kidd"
   },
@@ -1107,8 +1107,8 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-21",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-03",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Kidd"
   },
@@ -1220,6 +1220,13 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Christopher",
     "Tran_NamL": "Lee"
@@ -1227,8 +1234,8 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Cynthia",
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Missy",
     "Tran_NamL": "Lee"
   },
   {
@@ -1241,22 +1248,15 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Missy",
-    "Tran_NamL": "Lee"
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Seble",
+    "Tran_NamL": "Legesse"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-11-08",
     "Tran_NamF": "Selamawit",
-    "Tran_NamL": "Legesse"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Seble",
     "Tran_NamL": "Legesse"
   },
   {
@@ -1394,15 +1394,15 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-11",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-10",
     "Tran_NamF": "Linda",
     "Tran_NamL": "Martin"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-10",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-11",
     "Tran_NamF": "Linda",
     "Tran_NamL": "Martin"
   },
@@ -1457,23 +1457,16 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Peggy",
-    "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 505.0,
-    "Tran_Date": "2016-11-07",
-    "Tran_NamF": "Peggy",
-    "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-08-23",
     "Tran_NamF": "Susan",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Darryl",
     "Tran_NamL": "Moore"
   },
   {
@@ -1492,6 +1485,13 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Peggy",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 75.0,
     "Tran_Date": "2016-10-28",
     "Tran_NamF": "Darryl",
@@ -1499,22 +1499,22 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Darryl",
+    "Tran_Amt1": 505.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Peggy",
     "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Bonnie",
-    "Tran_NamL": "Moran"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Bonnie",
+    "Tran_NamL": "Moran"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-05",
     "Tran_NamF": "Bonnie",
     "Tran_NamL": "Moran"
   },
@@ -1541,15 +1541,15 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-04",
     "Tran_NamF": "Carmen",
     "Tran_NamL": "Murray"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-04",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
     "Tran_NamF": "Carmen",
     "Tran_NamL": "Murray"
   },
@@ -1688,16 +1688,16 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Jacqueline",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Richard",
     "Tran_NamL": "Phillips"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Richard",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Jacqueline",
     "Tran_NamL": "Phillips"
   },
   {
@@ -1724,14 +1724,14 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-12",
+    "Tran_Date": "2016-08-19",
     "Tran_NamF": "Heather",
     "Tran_NamL": "Quintal"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-11",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-12",
     "Tran_NamF": "Heather",
     "Tran_NamL": "Quintal"
   },
@@ -1744,8 +1744,8 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-19",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-11",
     "Tran_NamF": "Heather",
     "Tran_NamL": "Quintal"
   },
@@ -1816,27 +1816,27 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Kathleen",
+    "Tran_NamF": "Gary",
     "Tran_NamL": "Rogers"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Gary",
+    "Tran_NamF": "Kathleen",
     "Tran_NamL": "Rogers"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-14",
+    "Tran_Date": "2016-08-23",
     "Tran_NamF": "Rosalind",
     "Tran_NamL": "Romney"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-23",
+    "Tran_Date": "2016-09-14",
     "Tran_NamF": "Rosalind",
     "Tran_NamL": "Romney"
   },
@@ -1870,16 +1870,16 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Barbara",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Libby",
     "Tran_NamL": "Schaaf"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "Libby",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Barbara",
     "Tran_NamL": "Schaaf"
   },
   {
@@ -1947,15 +1947,15 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-20",
     "Tran_NamF": "Mary Jayne",
     "Tran_NamL": "Sims"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-20",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
     "Tran_NamF": "Mary Jayne",
     "Tran_NamL": "Sims"
   },
@@ -2038,6 +2038,13 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sileshi Sam",
+    "Tran_NamL": "Tadesse"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Getachew",
@@ -2048,13 +2055,6 @@
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Konjit",
-    "Tran_NamL": "Tadesse"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Sileshi Sam",
     "Tran_NamL": "Tadesse"
   },
   {
@@ -2165,14 +2165,14 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-05",
+    "Tran_Date": "2016-09-29",
     "Tran_NamF": "Eric",
     "Tran_NamL": "Ullman"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-29",
+    "Tran_Date": "2016-11-05",
     "Tran_NamF": "Eric",
     "Tran_NamL": "Ullman"
   },
@@ -2241,15 +2241,15 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-21",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-27",
     "Tran_NamF": "Buffy",
     "Tran_NamL": "Wicks"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-27",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
     "Tran_NamF": "Buffy",
     "Tran_NamL": "Wicks"
   },
@@ -2262,13 +2262,6 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Colette",
-    "Tran_NamL": "Winlock"
-  },
-  {
-    "Filer_ID": "1388168",
     "Tran_Amt1": 99.0,
     "Tran_Date": "2016-09-19",
     "Tran_NamF": "Colette",
@@ -2276,16 +2269,23 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Pauline",
-    "Tran_NamL": "Witriol"
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Colette",
+    "Tran_NamL": "Winlock"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Terri",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Pauline",
     "Tran_NamL": "Witriol"
   },
   {
@@ -2311,13 +2311,6 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Cynthia",
-    "Tran_NamL": "Wood"
-  },
-  {
-    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-26",
     "Tran_NamF": "James",
@@ -2328,6 +2321,13 @@
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-09-22",
     "Tran_NamF": "James",
+    "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Cynthia",
     "Tran_NamL": "Wood"
   },
   {
@@ -2424,14 +2424,14 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-18",
+    "Tran_Date": "2016-10-17",
     "Tran_NamF": "Barbara",
     "Tran_NamL": "Zoloth"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
+    "Tran_Date": "2016-10-18",
     "Tran_NamF": "Barbara",
     "Tran_NamL": "Zoloth"
   }

--- a/build/committee/1388168/contributions/index.json
+++ b/build/committee/1388168/contributions/index.json
@@ -1,43 +1,43 @@
 [
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-21",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Ablon"
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Peggy",
+    "Tran_NamL": "Moore"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Margaret",
-    "Tran_NamL": "Adam"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Greggory",
+    "Tran_NamL": "Brown"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Marcy",
-    "Tran_NamL": "Adelman"
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "Alistair",
+    "Tran_NamL": "McElwee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Libby",
+    "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Gooding"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Albracht"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Albracht"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 450.0,
-    "Tran_Date": "2016-11-05",
     "Tran_NamF": "Matthew",
     "Tran_NamL": "Albracht"
   },
@@ -51,37 +51,457 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Amy",
-    "Tran_NamL": "Almsteier"
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Gwendolyn",
+    "Tran_NamL": "Booze"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Al",
-    "Tran_NamL": "Aluetta"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 120.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Anderson"
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Danielle",
+    "Tran_NamL": "Dagostino"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Irma",
-    "Tran_NamL": "Anderson"
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Fine"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Gibbs"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Alejandro",
+    "Tran_NamL": "Illidge"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Ashley",
+    "Tran_NamL": "Lautzenhiser"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Francine",
-    "Tran_NamL": "Anthony"
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Nguyen-Cleary"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Pastena"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-20",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-20",
+    "Tran_NamF": "Joanne",
+    "Tran_NamL": "Karchmer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Ablon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Higgins"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Klose Way Partners, LLC"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Murphy"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Rosalind",
+    "Tran_NamL": "Romney"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sustainable Urban Neighborhoods"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Felinda",
+    "Tran_NamL": "Tran"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Bellino"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Carter"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Lucia",
+    "Tran_NamL": "Capron"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Dianne",
+    "Tran_NamL": "Gregory"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Hawkins"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "LaNiece",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Sam",
+    "Tran_NamL": "Kaspick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Protopappas"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Suzanne",
+    "Tran_NamL": "Rotondo"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Brent",
+    "Tran_NamL": "Turner"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Bair"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Pahlka"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Miye",
+    "Tran_NamL": "Takagi"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Gerber"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Buchanan"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "H",
+    "Tran_NamL": "Burg"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Campaign for Equality"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Coleman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Salvatore",
+    "Tran_NamL": "Fahey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Brendalyn",
+    "Tran_NamL": "Goodall"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Jill",
+    "Tran_NamL": "Habig"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Hinds"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Venus",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Paula",
+    "Tran_NamL": "Kirlin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Kay",
+    "Tran_NamL": "Lawson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Gloria",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Sandy",
+    "Tran_NamL": "Mills"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Amelia",
+    "Tran_NamL": "Paradise"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Pettit"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Wade Jarvis Construction"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Belle",
+    "Tran_NamL": "Cole"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Kerry",
+    "Tran_NamL": "Hamill"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Rosalind",
+    "Tran_NamL": "Romney"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Schmier"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Tye"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Core Security Solutions, Inc."
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "J Blake",
+    "Tran_NamL": "Johansen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Judith",
+    "Tran_NamL": "Johnson"
   },
   {
     "Filer_ID": "1388168",
@@ -92,10 +512,192 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bowers Consulting Firm"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Leslie",
+    "Tran_NamL": "Zimmerman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Marcy",
+    "Tran_NamL": "Adelman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Toni",
+    "Tran_NamL": "Broaddus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Davies"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Le Blanc"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Gwendolyn",
+    "Tran_NamL": "Mitchell"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Solomon Ets-Hokin, Inc."
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Janice",
+    "Tran_NamL": "Wells"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 99.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Colette",
+    "Tran_NamL": "Winlock"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "JoAnn",
+    "Tran_NamL": "Yoshioka"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "M Kathleen",
-    "Tran_NamL": "Archambeau"
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Andrea",
+    "Tran_NamL": "Youngdahl"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Almsteier"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Salwa",
+    "Tran_NamL": "Ibrahim"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Martin",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Peterson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Lucia",
+    "Tran_NamL": "Capron"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 152.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Donald",
+    "Tran_NamL": "Fowler"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Nahass"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Davies"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Lyman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Kathleen",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Wood"
   },
   {
     "Filer_ID": "1388168",
@@ -106,31 +708,318 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Drew",
-    "Tran_NamL": "Aversa"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Baglietto"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Beasley"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bailey"
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Laurie",
+    "Tran_NamL": "Capitelli"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Jonathan",
-    "Tran_NamL": "Bair"
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Benajmin",
+    "Tran_NamL": "Fay"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Fritz"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Raich"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Story"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Tawasha"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Wacker"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Albracht"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Benson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Betterton"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Clarinda",
+    "Tran_NamL": "Cannon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Cindy",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Colbruno"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Regina",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Abdul",
+    "Tran_NamL": "El-Amin Luqman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Gabriel Quinto for El Cerrito City Council 2014"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Brendalyn",
+    "Tran_NamL": "Goodall"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Charlette",
+    "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Hinds"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Joanne",
+    "Tran_NamL": "Karchmer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Levy"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Magana"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Elmoraa",
+    "Tran_NamL": "Magucha-Bey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Monchamp"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Bonnie",
+    "Tran_NamL": "Moran"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Anita",
+    "Tran_NamL": "Ramanathan"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Rasmussen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Mary Jane",
+    "Tran_NamL": "Ricciardulli"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kerry Jo",
+    "Tran_NamL": "Ricketts"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Schock"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Franklin",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Rachel",
+    "Tran_NamL": "Sklar"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sileshi Sam",
+    "Tran_NamL": "Tadesse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "The Inn at Jack London Square"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Valdez"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Regina",
+    "Tran_NamL": "Wallace-Jones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kathleen D.",
+    "Tran_NamL": "Wimberly"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Pauline",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Terri",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Ken",
+    "Tran_NamL": "Yamaguchi"
   },
   {
     "Filer_ID": "1388168",
@@ -142,9 +1031,23 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Bruce",
-    "Tran_NamL": "Beasley"
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Leigh",
+    "Tran_NamL": "Morgan"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Alexandra",
+    "Tran_NamL": "Snow Thede"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Thede"
   },
   {
     "Filer_ID": "1388168",
@@ -152,6 +1055,727 @@
     "Tran_Date": "2016-09-26",
     "Tran_NamF": "Carol",
     "Tran_NamL": "Beck"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Gail",
+    "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Terrance",
+    "Tran_NamL": "Lim"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Laurel",
+    "Tran_NamL": "March"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Nemechek"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Catherine",
+    "Tran_NamL": "Bracy"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Giselle",
+    "Tran_NamL": "Hale"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Spencer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Buffy",
+    "Tran_NamL": "Wicks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Al",
+    "Tran_NamL": "Aluetta"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Jacqueline",
+    "Tran_NamL": "Noguera"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 240.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Shirley",
+    "Tran_NamL": "Remirez"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Ullman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Debbie",
+    "Tran_NamL": "Foster"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Darryl",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Lenoir"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Greggory",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Carmen",
+    "Tran_NamL": "Murray"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Nahas"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Lisbet",
+    "Tran_NamL": "Tellefsen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Dockendorff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Feinstein"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Francis"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Stroup"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "M Kathleen",
+    "Tran_NamL": "Archambeau"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Angelina",
+    "Tran_NamL": "Burnett"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Raymond",
+    "Tran_NamL": "Lankford"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Thompson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Baglietto"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Beverly",
+    "Tran_NamL": "Bueno"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Cook"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Bill",
+    "Tran_NamL": "Dickey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Transport Oakland"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Berley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Kopec"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Missy",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Sickmen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Zee",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-10",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Martin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Drew",
+    "Tran_NamL": "Aversa"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 72.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Vincent",
+    "Tran_NamL": "Leung"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Newsome"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Averell",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Francisco",
+    "Tran_NamL": "Devries"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Elwood Commercial Real Estate"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Flaxman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Earl",
+    "Tran_NamL": "Hamlin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Seth",
+    "Tran_NamL": "Jacobson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Jay-Phares Corporation"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Knutson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "MK Sebree"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Lorna",
+    "Tran_NamL": "Padia-Markus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Zahas"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Mixon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Lupe",
+    "Tran_NamL": "Schoenberger"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Power"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 31.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Abdul",
+    "Tran_NamL": "El-Amin Luqman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Ernest",
+    "Tran_NamL": "Graves"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Wendell",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Lewis"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Patti",
+    "Tran_NamL": "Haladay"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Dana",
+    "Tran_NamL": "Hughes"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Donna",
+    "Tran_NamL": "Korones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Lewis"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Jody",
+    "Tran_NamL": "London"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Price"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Stevens"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Adrienne",
+    "Tran_NamL": "Yank"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Zoloth"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Emily",
+    "Tran_NamL": "Rosenberg"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Zoloth"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Ellen",
+    "Tran_NamL": "Gierson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Alejandro",
+    "Tran_NamL": "Illidge"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Mary Jayne",
+    "Tran_NamL": "Sims"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Soltanovich"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Adam"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Emerick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Natalie",
+    "Tran_NamL": "Foster"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 745.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Peggy",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Marie",
+    "Tran_NamL": "Riehle"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Tillery"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Angela",
+    "Tran_NamL": "Tsay"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Buffy",
+    "Tran_NamL": "Wicks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Colette",
+    "Tran_NamL": "Winlock"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Caryn",
+    "Tran_NamL": "Wolf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Francine",
+    "Tran_NamL": "Anthony"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bailey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "A. Freeman",
+    "Tran_NamL": "Bradley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Cindy",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Durbin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Littleton Consulting Group"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Marti",
+    "Tran_NamL": "Paschal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Nicole",
+    "Tran_NamL": "Derse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Andres",
+    "Tran_NamL": "Garcia-Price"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Padnos"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Irma",
+    "Tran_NamL": "Anderson"
   },
   {
     "Filer_ID": "1388168",
@@ -163,16 +1787,233 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-24",
-    "Tran_NamF": "Dan",
-    "Tran_NamL": "Bellino"
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Dwin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Juenger"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Karchmer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Kernighan"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "LaHorgue"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Benson"
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "MacKinnon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Rick",
+    "Tran_NamL": "Mariano"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Markus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "Wade"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Max",
+    "Tran_NamL": "Zeff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Ron",
+    "Tran_NamL": "Zeff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Zachary",
+    "Tran_NamL": "Zeff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "Christopher"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Garibaldi"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Haley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Hamill"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Jensen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "LaNiece",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Kopff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "Pasquali"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Peggy",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Peggy",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "PMACC"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "Dana",
+    "Tran_NamL": "Parry"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "MacIntyre"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Brown-Stevens"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Caron",
+    "Tran_NamL": "Ewing"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Darryl",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Julius",
+    "Tran_NamL": "Perkins"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Sheila",
+    "Tran_NamL": "Wells"
   },
   {
     "Filer_ID": "1388168",
@@ -184,9 +2025,233 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Brownlow"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "East Bay Rental Housing Association PAC"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Fowler"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Kay",
+    "Tran_NamL": "Lawson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Phillips"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Mary Jayne",
+    "Tran_NamL": "Sims"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Philippa",
+    "Tran_NamL": "Jubelirer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Schock"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-03",
     "Tran_NamF": "Peter",
     "Tran_NamL": "Benvenutti"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Jenny",
+    "Tran_NamL": "Chu"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Suzanne",
+    "Tran_NamL": "Furrer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Megan",
+    "Tran_NamL": "Morrow"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Jenny",
+    "Tran_NamL": "Ong"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Giovanna",
+    "Tran_NamL": "Tanzillo"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Albracht"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Cook"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Feinstein"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Freiberg"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "Glasgow"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Robinne",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Bonnie",
+    "Tran_NamL": "Moran"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Carmen",
+    "Tran_NamL": "Murray"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Jim",
+    "Tran_NamL": "Ratliff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Veronica",
+    "Tran_NamL": "Sanders"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Ullman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Liz",
+    "Tran_NamL": "Brisson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Jacqueline",
+    "Tran_NamL": "Phillips"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Liz",
+    "Tran_NamL": "Rebensdorf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Lang",
+    "Tran_NamL": "Scoble"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Tidrick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Tod",
+    "Tran_NamL": "Vedock"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Katharine",
+    "Tran_NamL": "Wulff"
   },
   {
     "Filer_ID": "1388168",
@@ -211,535 +2276,10 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Steve",
-    "Tran_NamL": "Berley"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Betterton"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Bliss"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Gwendolyn",
-    "Tran_NamL": "Booze"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-20",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Bovarnick"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Bovarnick"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Bovarnick"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bowers Consulting Firm"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Catherine",
-    "Tran_NamL": "Bracy"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "A. Freeman",
-    "Tran_NamL": "Bradley"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Liz",
-    "Tran_NamL": "Brisson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Toni",
-    "Tran_NamL": "Broaddus"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-08-09",
-    "Tran_NamF": "Greggory",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-07",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Greggory",
-    "Tran_NamL": "Brown"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Amanda",
-    "Tran_NamL": "Brown-Stevens"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Bradley",
-    "Tran_NamL": "Brownlow"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-12-01",
-    "Tran_NamF": "Bradley",
-    "Tran_NamL": "Brownlow"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Joan",
-    "Tran_NamL": "Buchanan"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Beverly",
-    "Tran_NamL": "Bueno"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "H",
-    "Tran_NamL": "Burg"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Angelina",
-    "Tran_NamL": "Burnett"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-11-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "California Real Estate PAC"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "Campaign for Equality"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Clarinda",
-    "Tran_NamL": "Cannon"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Laurie",
-    "Tran_NamL": "Capitelli"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Lucia",
-    "Tran_NamL": "Capron"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Lucia",
-    "Tran_NamL": "Capron"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-24",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Carter"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Cindy",
-    "Tran_NamL": "Chavez"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Cindy",
-    "Tran_NamL": "Chavez"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Greg",
-    "Tran_NamL": "Christopher"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Jenny",
-    "Tran_NamL": "Chu"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Colbruno"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Belle",
-    "Tran_NamL": "Cole"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Linda",
-    "Tran_NamL": "Coleman"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Sandra",
-    "Tran_NamL": "Cook"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Sandra",
-    "Tran_NamL": "Cook"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Core Security Solutions, Inc."
-  },
-  {
-    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Woinshet",
     "Tran_NamL": "Daba"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Danielle",
-    "Tran_NamL": "Dagostino"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Sue",
-    "Tran_NamL": "Davies"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Sue",
-    "Tran_NamL": "Davies"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Regina",
-    "Tran_NamL": "Davis"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": "Nicole",
-    "Tran_NamL": "Derse"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Francisco",
-    "Tran_NamL": "Devries"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Bill",
-    "Tran_NamL": "Dickey"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Dockendorff"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Gary",
-    "Tran_NamL": "Durbin"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Miguel",
-    "Tran_NamL": "Dwin"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": null,
-    "Tran_NamL": "East Bay Rental Housing Association PAC"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Abdul",
-    "Tran_NamL": "El-Amin Luqman"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 31.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Abdul",
-    "Tran_NamL": "El-Amin Luqman"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Elwood Commercial Real Estate"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Emerick"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Caron",
-    "Tran_NamL": "Ewing"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Salvatore",
-    "Tran_NamL": "Fahey"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Benajmin",
-    "Tran_NamL": "Fay"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Amanda",
-    "Tran_NamL": "Feinstein"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Amanda",
-    "Tran_NamL": "Feinstein"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": "Yared",
-    "Tran_NamL": "Feleke"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Sarah",
-    "Tran_NamL": "Fine"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Gary",
-    "Tran_NamL": "Flaxman"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Debbie",
-    "Tran_NamL": "Foster"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Natalie",
-    "Tran_NamL": "Foster"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 152.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Donald",
-    "Tran_NamL": "Fowler"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Fowler"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Thomas",
-    "Tran_NamL": "Francis"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Freiberg"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 400.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Karen",
-    "Tran_NamL": "Friedman"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Fritz"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Suzanne",
-    "Tran_NamL": "Furrer"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Gabriel Quinto for El Cerrito City Council 2014"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": "Andres",
-    "Tran_NamL": "Garcia-Price"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Garibaldi"
   },
   {
     "Filer_ID": "1388168",
@@ -750,423 +2290,10 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 180.0,
-    "Tran_Date": "2016-08-30",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Geller"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Geller"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 60.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Geller"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 72.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Geller"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-10",
-    "Tran_NamF": "Edward",
-    "Tran_NamL": "Gerber"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Linda",
-    "Tran_NamL": "Gibbs"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Ellen",
-    "Tran_NamL": "Gierson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": "Messay",
-    "Tran_NamL": "Gima"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": "Bruck",
-    "Tran_NamL": "Girmay"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Janet",
-    "Tran_NamL": "Glasgow"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Brendalyn",
-    "Tran_NamL": "Goodall"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Brendalyn",
-    "Tran_NamL": "Goodall"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-17",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Gooding"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Ernest",
-    "Tran_NamL": "Graves"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Charlette",
-    "Tran_NamL": "Green"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Dianne",
-    "Tran_NamL": "Gregory"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Jill",
-    "Tran_NamL": "Habig"
-  },
-  {
-    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Yilma",
     "Tran_NamL": "Hailemichael"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Patti",
-    "Tran_NamL": "Haladay"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Giselle",
-    "Tran_NamL": "Hale"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Haley"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Kerry",
-    "Tran_NamL": "Hamill"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Sue",
-    "Tran_NamL": "Hamill"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Earl",
-    "Tran_NamL": "Hamlin"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Scott",
-    "Tran_NamL": "Hawkins"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-08-22",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Higgins"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Hinds"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Hinds"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Dana",
-    "Tran_NamL": "Hughes"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Salwa",
-    "Tran_NamL": "Ibrahim"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Alejandro",
-    "Tran_NamL": "Illidge"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Alejandro",
-    "Tran_NamL": "Illidge"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Seth",
-    "Tran_NamL": "Jacobson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Jay-Phares Corporation"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Jensen"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "J Blake",
-    "Tran_NamL": "Johansen"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-10",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Venus",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Judith",
-    "Tran_NamL": "Johnson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "LaNiece",
-    "Tran_NamL": "Jones"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "LaNiece",
-    "Tran_NamL": "Jones"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Philippa",
-    "Tran_NamL": "Jubelirer"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Tom",
-    "Tran_NamL": "Juenger"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 95.0,
-    "Tran_Date": "2016-08-20",
-    "Tran_NamF": "Joanne",
-    "Tran_NamL": "Karchmer"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Joanne",
-    "Tran_NamL": "Karchmer"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Scott",
-    "Tran_NamL": "Karchmer"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Sam",
-    "Tran_NamL": "Kaspick"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Martin",
-    "Tran_NamL": "Kaufman"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Patricia",
-    "Tran_NamL": "Kernighan"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Kidd"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Kidd"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Kidd"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Gail",
-    "Tran_NamL": "King"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Paula",
-    "Tran_NamL": "Kirlin"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Klose Way Partners, LLC"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Knutson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Cynthia",
-    "Tran_NamL": "Kopec"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Steve",
-    "Tran_NamL": "Kopff"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Donna",
-    "Tran_NamL": "Korones"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "LaHorgue"
   },
   {
     "Filer_ID": "1388168",
@@ -1177,76 +2304,6 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Raymond",
-    "Tran_NamL": "Lankford"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Ashley",
-    "Tran_NamL": "Lautzenhiser"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Kay",
-    "Tran_NamL": "Lawson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Kay",
-    "Tran_NamL": "Lawson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Cynthia",
-    "Tran_NamL": "Le Blanc"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Gloria",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Cynthia",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Missy",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Robinne",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Seble",
@@ -1254,248 +2311,10 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": "Selamawit",
-    "Tran_NamL": "Legesse"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Lenoir"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Vincent",
-    "Tran_NamL": "Leung"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Levy"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-16",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Lewis"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Lewis"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Terrance",
-    "Tran_NamL": "Lim"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Littleton Consulting Group"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Jody",
-    "Tran_NamL": "London"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-11",
-    "Tran_NamF": "Steve",
-    "Tran_NamL": "Lowe"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Lyman"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "MK Sebree"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "Patrick",
-    "Tran_NamL": "MacIntyre"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "MacKinnon"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Anthony",
-    "Tran_NamL": "Magana"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Elmoraa",
-    "Tran_NamL": "Magucha-Bey"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "Laurel",
-    "Tran_NamL": "March"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Rick",
-    "Tran_NamL": "Mariano"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Anne",
-    "Tran_NamL": "Marks"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Dennis",
-    "Tran_NamL": "Markus"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-10",
-    "Tran_NamF": "Linda",
-    "Tran_NamL": "Martin"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-11",
-    "Tran_NamF": "Linda",
-    "Tran_NamL": "Martin"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-10",
-    "Tran_NamF": "Alistair",
-    "Tran_NamL": "McElwee"
-  },
-  {
-    "Filer_ID": "1388168",
     "Tran_Amt1": 300.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Behailu",
     "Tran_NamL": "Mekbib"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Sandy",
-    "Tran_NamL": "Mills"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Gwendolyn",
-    "Tran_NamL": "Mitchell"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Mixon"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Amanda",
-    "Tran_NamL": "Monchamp"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-08",
-    "Tran_NamF": "Peggy",
-    "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 30.0,
-    "Tran_Date": "2016-09-30",
-    "Tran_NamF": "Darryl",
-    "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 745.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Peggy",
-    "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Peggy",
-    "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Peggy",
-    "Tran_NamL": "Moore"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Darryl",
-    "Tran_NamL": "Moore"
   },
   {
     "Filer_ID": "1388168",
@@ -1507,541 +2326,9 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Bonnie",
-    "Tran_NamL": "Moran"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Bonnie",
-    "Tran_NamL": "Moran"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Leigh",
-    "Tran_NamL": "Morgan"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Megan",
-    "Tran_NamL": "Morrow"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Murphy"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Carmen",
-    "Tran_NamL": "Murray"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Carmen",
-    "Tran_NamL": "Murray"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Ronald",
-    "Tran_NamL": "Nahas"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-21",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Nahass"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Nemechek"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Newsome"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Nguyen-Cleary"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Jacqueline",
-    "Tran_NamL": "Noguera"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Jenny",
-    "Tran_NamL": "Ong"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "PMACC"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Lorna",
-    "Tran_NamL": "Padia-Markus"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-23",
-    "Tran_NamF": "Sandra",
-    "Tran_NamL": "Padnos"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-31",
-    "Tran_NamF": "Jennifer",
-    "Tran_NamL": "Pahlka"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Amelia",
-    "Tran_NamL": "Paradise"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "Dana",
-    "Tran_NamL": "Parry"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-22",
-    "Tran_NamF": "Marti",
-    "Tran_NamL": "Paschal"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-25",
-    "Tran_NamF": "Greg",
-    "Tran_NamL": "Pasquali"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Pastena"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Julius",
-    "Tran_NamL": "Perkins"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-20",
-    "Tran_NamF": "Derek",
-    "Tran_NamL": "Peterson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Alex",
-    "Tran_NamL": "Pettit"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Phillips"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Jacqueline",
-    "Tran_NamL": "Phillips"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Power"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Price"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Protopappas"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-19",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Quintal"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Quintal"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Quintal"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-11-11",
-    "Tran_NamF": "Heather",
-    "Tran_NamL": "Quintal"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Raich"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Anita",
-    "Tran_NamL": "Ramanathan"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Susan",
-    "Tran_NamL": "Rasmussen"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Jim",
-    "Tran_NamL": "Ratliff"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Liz",
-    "Tran_NamL": "Rebensdorf"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 240.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "Shirley",
-    "Tran_NamL": "Remirez"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Mary Jane",
-    "Tran_NamL": "Ricciardulli"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Kerry Jo",
-    "Tran_NamL": "Ricketts"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Marie",
-    "Tran_NamL": "Riehle"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Gary",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "Kathleen",
-    "Tran_NamL": "Rogers"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Rosalind",
-    "Tran_NamL": "Romney"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Rosalind",
-    "Tran_NamL": "Romney"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Emily",
-    "Tran_NamL": "Rosenberg"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Ron",
     "Tran_NamL": "Rosequist"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Suzanne",
-    "Tran_NamL": "Rotondo"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Veronica",
-    "Tran_NamL": "Sanders"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-11",
-    "Tran_NamF": "Libby",
-    "Tran_NamL": "Schaaf"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Schaaf"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Kenneth",
-    "Tran_NamL": "Schmier"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Schock"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Schock"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": "Lupe",
-    "Tran_NamL": "Schoenberger"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Lang",
-    "Tran_NamL": "Scoble"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Diane",
-    "Tran_NamL": "Sickmen"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Franklin",
-    "Tran_NamL": "Silver"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Silver"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Elizabeth",
-    "Tran_NamL": "Silver"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Mary Jayne",
-    "Tran_NamL": "Sims"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Mary Jayne",
-    "Tran_NamL": "Sims"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Rachel",
-    "Tran_NamL": "Sklar"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Averell",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-15",
-    "Tran_NamF": "Wendell",
-    "Tran_NamL": "Smith"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Alexandra",
-    "Tran_NamL": "Snow Thede"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Solomon Ets-Hokin, Inc."
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Joseph",
-    "Tran_NamL": "Soltanovich"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Spencer"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Eugene",
-    "Tran_NamL": "Stevens"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Joan",
-    "Tran_NamL": "Story"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-05",
-    "Tran_NamF": "Ruth",
-    "Tran_NamL": "Stroup"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "Sustainable Urban Neighborhoods"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Sileshi Sam",
-    "Tran_NamL": "Tadesse"
   },
   {
     "Filer_ID": "1388168",
@@ -2059,304 +2346,10 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-08",
-    "Tran_NamF": "Miye",
-    "Tran_NamL": "Takagi"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Giovanna",
-    "Tran_NamL": "Tanzillo"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Carolyn",
-    "Tran_NamL": "Tawasha"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Taylor"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": "Lisbet",
-    "Tran_NamL": "Tellefsen"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "The Inn at Jack London Square"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "Thede"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-06",
-    "Tran_NamF": "Pamela",
-    "Tran_NamL": "Thompson"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Steve",
-    "Tran_NamL": "Tidrick"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 600.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Linda",
-    "Tran_NamL": "Tillery"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-23",
-    "Tran_NamF": "Felinda",
-    "Tran_NamL": "Tran"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "Transport Oakland"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Angela",
-    "Tran_NamL": "Tsay"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "Brent",
-    "Tran_NamL": "Turner"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Mark",
-    "Tran_NamL": "Tye"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-29",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Ullman"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-05",
-    "Tran_NamF": "Eric",
-    "Tran_NamL": "Ullman"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "David",
-    "Tran_NamL": "Valdez"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-08",
-    "Tran_NamF": "Joan",
-    "Tran_NamL": "Van Horn"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Tod",
-    "Tran_NamL": "Vedock"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": "Ronald",
-    "Tran_NamL": "Wacker"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Greg",
-    "Tran_NamL": "Wade"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "Wade Jarvis Construction"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Regina",
-    "Tran_NamL": "Wallace-Jones"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Janice",
-    "Tran_NamL": "Wells"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-28",
-    "Tran_NamF": "Sheila",
-    "Tran_NamL": "Wells"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "Buffy",
-    "Tran_NamL": "Wicks"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Buffy",
-    "Tran_NamL": "Wicks"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Kathleen D.",
-    "Tran_NamL": "Wimberly"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 99.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Colette",
-    "Tran_NamL": "Winlock"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 20.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Colette",
-    "Tran_NamL": "Winlock"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Terri",
-    "Tran_NamL": "Witriol"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Pauline",
-    "Tran_NamL": "Witriol"
-  },
-  {
-    "Filer_ID": "1388168",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Legesse",
     "Tran_NamL": "Woldemariam"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": "Caryn",
-    "Tran_NamL": "Wolf"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "Zee",
-    "Tran_NamL": "Wong"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-08-26",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Wood"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-22",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Wood"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Cynthia",
-    "Tran_NamL": "Wood"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Wood"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-06",
-    "Tran_NamF": "Katharine",
-    "Tran_NamL": "Wulff"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-24",
-    "Tran_NamF": "Ken",
-    "Tran_NamL": "Yamaguchi"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Adrienne",
-    "Tran_NamL": "Yank"
   },
   {
     "Filer_ID": "1388168",
@@ -2367,45 +2360,66 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Yared",
+    "Tran_NamL": "Feleke"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "JoAnn",
-    "Tran_NamL": "Yoshioka"
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Messay",
+    "Tran_NamL": "Gima"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Bruck",
+    "Tran_NamL": "Girmay"
   },
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-19",
-    "Tran_NamF": "Andrea",
-    "Tran_NamL": "Youngdahl"
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Selamawit",
+    "Tran_NamL": "Legesse"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "Eugene",
-    "Tran_NamL": "Zahas"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Van Horn"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Ron",
-    "Tran_NamL": "Zeff"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-11",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Lowe"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Zachary",
-    "Tran_NamL": "Zeff"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-11",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Martin"
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Max",
-    "Tran_NamL": "Zeff"
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-11-11",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Real Estate PAC"
   },
   {
     "Filer_ID": "1388168",
@@ -2416,23 +2430,9 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Leslie",
-    "Tran_NamL": "Zimmerman"
-  },
-  {
-    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-17",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Zoloth"
-  },
-  {
-    "Filer_ID": "1388168",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "Barbara",
-    "Tran_NamL": "Zoloth"
+    "Tran_Date": "2016-12-01",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Brownlow"
   }
 ]

--- a/build/committee/1388641/contributions/index.json
+++ b/build/committee/1388641/contributions/index.json
@@ -9,15 +9,15 @@
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Catalina",
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Stevan",
     "Tran_NamL": "Alvarado"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Stevan",
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Catalina",
     "Tran_NamL": "Alvarado"
   },
   {
@@ -85,15 +85,15 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 4412.08,
-    "Tran_Date": "2016-11-21",
+    "Tran_Amt1": 12109.23,
+    "Tran_Date": "2016-10-27",
     "Tran_NamF": null,
     "Tran_NamL": "City of Oakland"
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 12109.23,
-    "Tran_Date": "2016-10-27",
+    "Tran_Amt1": 4412.08,
+    "Tran_Date": "2016-11-21",
     "Tran_NamF": null,
     "Tran_NamL": "City of Oakland"
   },
@@ -177,22 +177,15 @@
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-05",
-    "Tran_NamF": "Aliza",
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Selina",
     "Tran_NamL": "Gallo"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Noah",
-    "Tran_NamL": "Gallo"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-04",
-    "Tran_NamF": "Giana",
+    "Tran_Date": "2016-08-29",
+    "Tran_NamF": "Conception",
     "Tran_NamL": "Gallo"
   },
   {
@@ -205,15 +198,22 @@
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Selina",
+    "Tran_Date": "2016-09-04",
+    "Tran_NamF": "Giana",
     "Tran_NamL": "Gallo"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Conception",
+    "Tran_Date": "2016-09-05",
+    "Tran_NamF": "Aliza",
+    "Tran_NamL": "Gallo"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Noah",
     "Tran_NamL": "Gallo"
   },
   {
@@ -337,15 +337,15 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-24",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-28",
     "Tran_NamF": null,
     "Tran_NamL": "Raphael & associates"
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-28",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": null,
     "Tran_NamL": "Raphael & associates"
   },
@@ -568,15 +568,15 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-11-03",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-25",
     "Tran_NamF": "mary",
     "Tran_NamL": "vail"
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-25",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
     "Tran_NamF": "mary",
     "Tran_NamL": "vail"
   },

--- a/build/committee/1388641/contributions/index.json
+++ b/build/committee/1388641/contributions/index.json
@@ -484,14 +484,14 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 12160.38,
+    "Tran_Amt1": 12109.23,
     "Tran_Date": "2016-10-27",
     "Tran_NamF": null,
     "Tran_NamL": "City of Oakland"
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 12109.23,
+    "Tran_Amt1": 12160.38,
     "Tran_Date": "2016-10-27",
     "Tran_NamF": null,
     "Tran_NamL": "City of Oakland"

--- a/build/committee/1388641/contributions/index.json
+++ b/build/committee/1388641/contributions/index.json
@@ -2,27 +2,6 @@
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "451 Hegenberger Gas, Inc."
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Stevan",
-    "Tran_NamL": "Alvarado"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": "Catalina",
-    "Tran_NamL": "Alvarado"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-08-29",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Apodaca"
@@ -30,162 +9,15 @@
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Auto Plus Towing"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": "Rebeca",
-    "Tran_NamL": "Barron"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Louis",
-    "Tran_NamL": "Briones"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": null,
-    "Tran_NamL": "BuildZig"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-10-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "California nurses association political action committee"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-04",
-    "Tran_NamF": null,
-    "Tran_NamL": "California nurses association political action committee"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": null,
-    "Tran_NamL": "California real estate political action committee"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 12160.38,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "City of Oakland"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 12109.23,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "City of Oakland"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 4412.08,
-    "Tran_Date": "2016-11-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "City of Oakland"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "Conley Family Ltd. Partnership"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 1500.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "Construction & General Laborers Local Union 304 PAC"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Digital Design Communications"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Marianne",
-    "Tran_NamL": "Dreisbach"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Jason",
-    "Tran_NamL": "Dreisbach"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Keely",
-    "Tran_NamL": "Dreisbach"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Ronald",
-    "Tran_NamL": "Dreisbach"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Nico",
-    "Tran_NamL": "Enea"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "S.",
-    "Tran_NamL": "Erickson"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Fastrack Airport Parking Inc."
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-09-26",
-    "Tran_NamF": "L.",
-    "Tran_NamL": "Foo"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Selina",
+    "Tran_NamF": "Conception",
     "Tran_NamL": "Gallo"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-08-29",
-    "Tran_NamF": "Conception",
+    "Tran_NamF": "Selina",
     "Tran_NamL": "Gallo"
   },
   {
@@ -211,20 +43,6 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Noah",
-    "Tran_NamL": "Gallo"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "L.",
-    "Tran_NamL": "Goering"
-  },
-  {
-    "Filer_ID": "1388641",
     "Tran_Amt1": 300.0,
     "Tran_Date": "2016-09-08",
     "Tran_NamF": "Emmanuel",
@@ -232,17 +50,52 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Robert",
-    "Tran_NamL": "Gray"
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Louis",
+    "Tran_NamL": "Briones"
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Toby",
-    "Tran_NamL": "Levy"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Conley Family Ltd. Partnership"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Dreisbach"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Keely",
+    "Tran_NamL": "Dreisbach"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Marianne",
+    "Tran_NamL": "Dreisbach"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Dreisbach"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Noah",
+    "Tran_NamL": "Gallo"
   },
   {
     "Filer_ID": "1388641",
@@ -253,38 +106,38 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "Stephen",
-    "Tran_NamL": "Lowe"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "MAR CON CO."
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": "Alastair",
-    "Tran_NamL": "Mactaggart"
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Valdimer",
+    "Tran_NamL": "Nunes"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-30",
-    "Tran_NamF": "Emilio",
-    "Tran_NamL": "Mena"
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Puay",
+    "Tran_NamL": "Phuan"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Singa Development LLC"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-17",
-    "Tran_NamF": "Randy",
-    "Tran_NamL": "Menjivar"
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Evelia",
+    "Tran_NamL": "Villa"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Stevan",
+    "Tran_NamL": "Alvarado"
   },
   {
     "Filer_ID": "1388641",
@@ -296,65 +149,9 @@
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-10-26",
-    "Tran_NamF": "unkJeffrey",
-    "Tran_NamL": "Neustadt"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Valdimer",
-    "Tran_NamL": "Nunes"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "One Stop Automotive and Collision Center Inc."
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-31",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Oram"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "Peralta Street LLC"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Puay",
-    "Tran_NamL": "Phuan"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Raphael & associates"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Raphael & associates"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Emily",
-    "Tran_NamL": "Richardson"
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Catalina",
+    "Tran_NamL": "Alvarado"
   },
   {
     "Filer_ID": "1388641",
@@ -365,24 +162,59 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-11-02",
-    "Tran_NamF": "Rich",
-    "Tran_NamL": "Silverstein"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 350.0,
-    "Tran_Date": "2016-10-19",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-14",
     "Tran_NamF": null,
-    "Tran_NamL": "Sin-Mex Auto Body Shop"
+    "Tran_NamL": "Tulum Innovative Engineering, Inc."
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-12",
+    "Tran_Date": "2016-09-15",
     "Tran_NamF": null,
-    "Tran_NamL": "Singa Development LLC"
+    "Tran_NamL": "451 Hegenberger Gas, Inc."
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Auto Plus Towing"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Rebeca",
+    "Tran_NamL": "Barron"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Digital Design Communications"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Fastrack Airport Parking Inc."
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "MAR CON CO."
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "One Stop Automotive and Collision Center Inc."
   },
   {
     "Filer_ID": "1388641",
@@ -393,38 +225,80 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "The McConnell Group"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": "Willie",
-    "Tran_NamL": "Tomayo"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "Tulum Innovative Engineering, Inc."
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Gray"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-12",
-    "Tran_NamF": "Evelia",
-    "Tran_NamL": "Villa"
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Randy",
+    "Tran_NamL": "Menjivar"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "L.",
+    "Tran_NamL": "Goering"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "rebecca",
+    "Tran_NamL": "kaplan"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "gordon",
+    "Tran_NamL": "link"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "naomi",
+    "Tran_NamL": "schiff"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "russell",
+    "Tran_NamL": "sheppard"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "mary",
+    "Tran_NamL": "vail"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "L.",
+    "Tran_NamL": "Foo"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": "salvador",
-    "Tran_NamL": "anaya"
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "art",
+    "Tran_NamL": "may"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Raphael & associates"
   },
   {
     "Filer_ID": "1388641",
@@ -435,10 +309,38 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-18",
-    "Tran_NamF": "paul",
-    "Tran_NamL": "cardoza"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "sharon",
+    "Tran_NamL": "muir"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "robert",
+    "Tran_NamL": "raich"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "service employees international union local 1021"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "California nurses association political action committee"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": null,
+    "Tran_NamL": "California nurses association political action committee"
   },
   {
     "Filer_ID": "1388641",
@@ -456,13 +358,6 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-10-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "el huarache axteca"
-  },
-  {
-    "Filer_ID": "1388641",
     "Tran_Amt1": 1000.0,
     "Tran_Date": "2016-10-07",
     "Tran_NamF": null,
@@ -471,44 +366,51 @@
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "rebecca",
-    "Tran_NamL": "kaplan"
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "unite here tip state & local fund"
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-14",
-    "Tran_NamF": "keith",
-    "Tran_NamL": "kim"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "gordon",
-    "Tran_NamL": "link"
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "david",
+    "Tran_NamL": "weltin"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-27",
-    "Tran_NamF": "art",
-    "Tran_NamL": "may"
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "fernando",
+    "Tran_NamL": "valenzuela"
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "sharon",
-    "Tran_NamL": "muir"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-13",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-11",
     "Tran_NamF": null,
-    "Tran_NamL": "northern cal district council, ilwu"
+    "Tran_NamL": "California real estate political action committee"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "unity pacalameda labor council"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "salvador",
+    "Tran_NamL": "anaya"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "el huarache axteca"
   },
   {
     "Filer_ID": "1388641",
@@ -526,52 +428,157 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": "robert",
-    "Tran_NamL": "raich"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "naomi",
-    "Tran_NamL": "schiff"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 1400.0,
-    "Tran_Date": "2016-09-30",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-13",
     "Tran_NamF": null,
-    "Tran_NamL": "service employees international union local 1021"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "russell",
-    "Tran_NamL": "sheppard"
+    "Tran_NamL": "northern cal district council, ilwu"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "unite here tip state & local fund"
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "keith",
+    "Tran_NamL": "kim"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-10-11",
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "paul",
+    "Tran_NamL": "cardoza"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-10-19",
     "Tran_NamF": null,
-    "Tran_NamL": "unity pacalameda labor council"
+    "Tran_NamL": "Sin-Mex Auto Body Shop"
   },
   {
     "Filer_ID": "1388641",
     "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-09-25",
-    "Tran_NamF": "mary",
-    "Tran_NamL": "vail"
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "BuildZig"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Alastair",
+    "Tran_NamL": "Mactaggart"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Raphael & associates"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "unkJeffrey",
+    "Tran_NamL": "Neustadt"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 12160.38,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "City of Oakland"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 12109.23,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": null,
+    "Tran_NamL": "City of Oakland"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-30",
+    "Tran_NamF": "Emilio",
+    "Tran_NamL": "Mena"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Lowe"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Oram"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Nico",
+    "Tran_NamL": "Enea"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Emily",
+    "Tran_NamL": "Richardson"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": "Rich",
+    "Tran_NamL": "Silverstein"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "Construction & General Laborers Local Union 304 PAC"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "S.",
+    "Tran_NamL": "Erickson"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Toby",
+    "Tran_NamL": "Levy"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "Peralta Street LLC"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "The McConnell Group"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Willie",
+    "Tran_NamL": "Tomayo"
   },
   {
     "Filer_ID": "1388641",
@@ -582,16 +589,9 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 150.0,
-    "Tran_Date": "2016-10-09",
-    "Tran_NamF": "fernando",
-    "Tran_NamL": "valenzuela"
-  },
-  {
-    "Filer_ID": "1388641",
-    "Tran_Amt1": 300.0,
-    "Tran_Date": "2016-10-07",
-    "Tran_NamF": "david",
-    "Tran_NamL": "weltin"
+    "Tran_Amt1": 4412.08,
+    "Tran_Date": "2016-11-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "City of Oakland"
   }
 ]

--- a/build/committee/1391606/contributions/index.json
+++ b/build/committee/1391606/contributions/index.json
@@ -36,10 +36,10 @@
   },
   {
     "Filer_ID": "1391606",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-11-01",
-    "Tran_NamF": "Christopher",
-    "Tran_NamL": "Curtis"
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": null,
+    "Tran_NamL": "Morse Management"
   },
   {
     "Filer_ID": "1391606",
@@ -50,13 +50,6 @@
   },
   {
     "Filer_ID": "1391606",
-    "Tran_Amt1": 600.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Hashemi Properties"
-  },
-  {
-    "Filer_ID": "1391606",
     "Tran_Amt1": 1000.0,
     "Tran_Date": "2016-10-20",
     "Tran_NamF": null,
@@ -64,15 +57,22 @@
   },
   {
     "Filer_ID": "1391606",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "Lapham Company 1P"
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Neveo",
+    "Tran_NamL": "Mosser"
   },
   {
     "Filer_ID": "1391606",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-11-14",
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Hashemi Properties"
+  },
+  {
+    "Filer_ID": "1391606",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": null,
     "Tran_NamL": "Lapham Company 1P"
   },
@@ -85,16 +85,16 @@
   },
   {
     "Filer_ID": "1391606",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": null,
-    "Tran_NamL": "Morse Management"
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Curtis"
   },
   {
     "Filer_ID": "1391606",
-    "Tran_Amt1": 5000.0,
-    "Tran_Date": "2016-10-20",
-    "Tran_NamF": "Neveo",
-    "Tran_NamL": "Mosser"
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-11-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lapham Company 1P"
   }
 ]

--- a/build/committee/892160/contributions/index.json
+++ b/build/committee/892160/contributions/index.json
@@ -2,7 +2,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
+    "Tran_Date": "2016-07-26",
     "Tran_NamF": "Shaun",
     "Tran_NamL": "Acosta"
   },
@@ -16,21 +16,28 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
+    "Tran_Date": "2016-08-25",
     "Tran_NamF": "Shaun",
     "Tran_NamL": "Acosta"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Andrew E.",
     "Tran_NamL": "Adame"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Andrew E.",
+    "Tran_NamL": "Adame"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
     "Tran_NamF": "Andrew E.",
     "Tran_NamL": "Adame"
   },
@@ -44,35 +51,21 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
+    "Tran_Date": "2016-08-25",
     "Tran_NamF": "Andrew E.",
     "Tran_NamL": "Adame"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Andrew E.",
-    "Tran_NamL": "Adame"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Andrew E.",
-    "Tran_NamL": "Adame"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Richard L.",
-    "Tran_NamL": "Amato"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Andrew E.",
+    "Tran_NamL": "Adame"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Richard L.",
     "Tran_NamL": "Amato"
   },
@@ -86,14 +79,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Richard L.",
-    "Tran_NamL": "Amato"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
+    "Tran_Date": "2016-08-02",
     "Tran_NamF": "Richard L.",
     "Tran_NamL": "Amato"
   },
@@ -107,9 +93,16 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Louie",
-    "Tran_NamL": "Baity"
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Richard L.",
+    "Tran_NamL": "Amato"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Richard L.",
+    "Tran_NamL": "Amato"
   },
   {
     "Filer_ID": "892160",
@@ -121,14 +114,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Louie",
-    "Tran_NamL": "Baity"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-07-26",
     "Tran_NamF": "Louie",
     "Tran_NamL": "Baity"
   },
@@ -149,7 +135,21 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Louie",
+    "Tran_NamL": "Baity"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Louie",
+    "Tran_NamL": "Baity"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Marc A.",
     "Tran_NamL": "Baker"
   },
@@ -163,14 +163,14 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Marc A.",
     "Tran_NamL": "Baker"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Shayn J.",
     "Tran_NamL": "Bannowsky"
   },
@@ -178,6 +178,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Shayn J.",
+    "Tran_NamL": "Bannowsky"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
     "Tran_NamF": "Shayn J.",
     "Tran_NamL": "Bannowsky"
   },
@@ -206,41 +213,6 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Shayn J.",
-    "Tran_NamL": "Bannowsky"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
     "Tran_NamF": "Jason A.",
     "Tran_NamL": "Beach"
   },
@@ -254,9 +226,30 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Bell"
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
   },
   {
     "Filer_ID": "892160",
@@ -268,21 +261,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
+    "Tran_Date": "2016-07-26",
     "Tran_NamF": "Shane",
     "Tran_NamL": "Bell"
   },
@@ -296,28 +275,42 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Samuel W.",
-    "Tran_NamL": "Berry"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Samuel W.",
-    "Tran_NamL": "Berry"
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Samuel W.",
     "Tran_NamL": "Berry"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Samuel W.",
+    "Tran_NamL": "Berry"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
     "Tran_NamF": "Samuel W.",
     "Tran_NamL": "Berry"
   },
@@ -331,7 +324,14 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Samuel W.",
+    "Tran_NamL": "Berry"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Samuel W.",
     "Tran_NamL": "Berry"
   },
@@ -380,27 +380,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Brian K.",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Brian K.",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Brian K.",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-12",
     "Tran_NamF": "Brian K.",
     "Tran_NamL": "Brooks"
@@ -416,6 +395,27 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Brian K.",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Brian K.",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Brian K.",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Brian K.",
     "Tran_NamL": "Brooks"
   },
@@ -450,13 +450,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Edward K",
-    "Tran_NamL": "Buttles"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-04",
     "Tran_NamF": "Edward K",
     "Tran_NamL": "Buttles"
@@ -464,6 +457,13 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Edward K",
+    "Tran_NamL": "Buttles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-12",
     "Tran_NamF": "Steven",
     "Tran_NamL": "Chavez"
@@ -471,14 +471,14 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-08-04",
     "Tran_NamF": "Steven",
     "Tran_NamL": "Chavez"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Steven",
     "Tran_NamL": "Chavez"
   },
@@ -513,13 +513,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Jared M.",
-    "Tran_NamL": "Clark"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-04",
     "Tran_NamF": "Jared M.",
     "Tran_NamL": "Clark"
@@ -528,6 +521,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Jared M.",
+    "Tran_NamL": "Clark"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Dito"
   },
@@ -541,14 +541,14 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Dito"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Thomas B.",
     "Tran_NamL": "Dosier"
   },
@@ -562,14 +562,14 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Thomas B.",
     "Tran_NamL": "Dosier"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Richard",
     "Tran_NamL": "Duong"
   },
@@ -583,7 +583,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Richard",
     "Tran_NamL": "Duong"
   },
@@ -597,13 +597,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Shannon K.",
-    "Tran_NamL": "Dwyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-02",
     "Tran_NamF": "Shannon K.",
     "Tran_NamL": "Dwyer"
@@ -611,9 +604,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Tyler J.",
-    "Tran_NamL": "Ecoffey"
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Shannon K.",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -649,6 +642,20 @@
     "Tran_Date": "2016-08-25",
     "Tran_NamF": "Tyler J.",
     "Tran_NamL": "Ecoffey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Tyler J.",
+    "Tran_NamL": "Ecoffey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Feehan"
   },
   {
     "Filer_ID": "892160",
@@ -668,13 +675,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Feehan"
+    "Tran_NamF": "Joseph D.",
+    "Tran_NamL": "Feller"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-07-26",
     "Tran_NamF": "Joseph D.",
     "Tran_NamL": "Feller"
   },
@@ -682,6 +689,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Joseph D.",
+    "Tran_NamL": "Feller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
     "Tran_NamF": "Joseph D.",
     "Tran_NamL": "Feller"
   },
@@ -702,20 +716,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Joseph D.",
-    "Tran_NamL": "Feller"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Joseph D.",
-    "Tran_NamL": "Feller"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-12",
     "Tran_NamF": "Joseph B.",
     "Tran_NamL": "Garner"
@@ -723,28 +723,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Joseph B.",
-    "Tran_NamL": "Garner"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Joseph B.",
-    "Tran_NamL": "Garner"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Joseph B.",
-    "Tran_NamL": "Garner"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Joseph B.",
     "Tran_NamL": "Garner"
   },
@@ -759,8 +738,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Miguel",
-    "Tran_NamL": "Gomez"
+    "Tran_NamF": "Joseph B.",
+    "Tran_NamL": "Garner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Joseph B.",
+    "Tran_NamL": "Garner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Joseph B.",
+    "Tran_NamL": "Garner"
   },
   {
     "Filer_ID": "892160",
@@ -772,23 +765,16 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-08-04",
     "Tran_NamF": "Miguel",
     "Tran_NamL": "Gomez"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Justin P.",
-    "Tran_NamL": "Gonsalves"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Justin P.",
-    "Tran_NamL": "Gonsalves"
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
   },
   {
     "Filer_ID": "892160",
@@ -807,7 +793,14 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Justin P.",
+    "Tran_NamL": "Gonsalves"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
     "Tran_NamF": "Justin P.",
     "Tran_NamL": "Gonsalves"
   },
@@ -815,6 +808,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Justin P.",
+    "Tran_NamL": "Gonsalves"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Justin P.",
     "Tran_NamL": "Gonsalves"
   },
@@ -842,7 +842,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
+    "Tran_Date": "2016-07-26",
     "Tran_NamF": "Steven P.",
     "Tran_NamL": "Hickey"
   },
@@ -856,16 +856,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
+    "Tran_Date": "2016-08-25",
     "Tran_NamF": "Steven P.",
     "Tran_NamL": "Hickey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Hicks"
   },
   {
     "Filer_ID": "892160",
@@ -877,7 +870,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-08-04",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Hicks"
   },
@@ -885,6 +878,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Keith",
     "Tran_NamL": "Hung"
   },
@@ -898,7 +898,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Keith",
     "Tran_NamL": "Hung"
   },
@@ -912,14 +912,14 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-08-04",
     "Tran_NamF": "Raul",
     "Tran_NamL": "Hurtado"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Raul",
     "Tran_NamL": "Hurtado"
   },
@@ -940,13 +940,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Mario",
-    "Tran_NamL": "Jones"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-04",
     "Tran_NamF": "Mario",
     "Tran_NamL": "Jones"
@@ -955,6 +948,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Joseph",
     "Tran_NamL": "Keahey"
   },
@@ -968,7 +968,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Joseph",
     "Tran_NamL": "Keahey"
   },
@@ -982,14 +982,14 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-08-04",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Kelly"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Kelly"
   },
@@ -1003,13 +1003,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Michael A.",
-    "Tran_NamL": "King"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-04",
     "Tran_NamF": "Michael A.",
     "Tran_NamL": "King"
@@ -1018,6 +1011,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Michael A.",
+    "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Kitt"
   },
@@ -1031,7 +1031,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Kitt"
   },
@@ -1059,13 +1059,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Nathaniel",
-    "Tran_NamL": "Leal"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-12",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
@@ -1080,7 +1073,21 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
     "Tran_NamF": "Jeffrey",
     "Tran_NamL": "Lee"
   },
@@ -1094,9 +1101,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Lee"
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -1109,13 +1116,6 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Lion"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Lion"
   },
@@ -1139,6 +1139,13 @@
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "James",
     "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "McGaw"
   },
   {
     "Filer_ID": "892160",
@@ -1151,13 +1158,6 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "McGaw"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Chris",
     "Tran_NamL": "McGaw"
   },
@@ -1192,13 +1192,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Kai",
-    "Tran_NamL": "Pagani"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-04",
     "Tran_NamF": "Kai",
     "Tran_NamL": "Pagani"
@@ -1206,6 +1199,41 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-31",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-07",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-02",
     "Tran_NamF": "Jacob",
     "Tran_NamL": "Roberts"
@@ -1220,28 +1248,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Jacob",
     "Tran_NamL": "Roberts"
   },
@@ -1255,9 +1262,16 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-07",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Spartacus G.",
+    "Tran_NamL": "Rodriguez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Spartacus G.",
+    "Tran_NamL": "Rodriguez"
   },
   {
     "Filer_ID": "892160",
@@ -1269,28 +1283,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Spartacus G.",
-    "Tran_NamL": "Rodriguez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Spartacus G.",
-    "Tran_NamL": "Rodriguez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-05-31",
     "Tran_NamF": "Nicolas",
     "Tran_NamL": "Romero"
   },
@@ -1304,21 +1297,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Nicolas",
     "Tran_NamL": "Romero"
   },
@@ -1332,7 +1311,7 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-08-02",
     "Tran_NamF": "Nicolas",
     "Tran_NamL": "Romero"
   },
@@ -1340,41 +1319,27 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-31",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Sawyer"
   },
@@ -1388,6 +1353,13 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-26",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Sawyer"
@@ -1395,42 +1367,35 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-05-31",
     "Tran_NamF": "Jarod",
     "Tran_NamL": "Torres"
   },
@@ -1445,6 +1410,41 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Jarod",
     "Tran_NamL": "Torres"
   }

--- a/build/committee/892160/contributions/index.json
+++ b/build/committee/892160/contributions/index.json
@@ -2,926 +2,58 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Shaun",
-    "Tran_NamL": "Acosta"
+    "Tran_Date": "2016-05-31",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Shaun",
-    "Tran_NamL": "Acosta"
+    "Tran_Date": "2016-05-31",
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Shaun",
-    "Tran_NamL": "Acosta"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Andrew E.",
-    "Tran_NamL": "Adame"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Andrew E.",
-    "Tran_NamL": "Adame"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Andrew E.",
-    "Tran_NamL": "Adame"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Andrew E.",
-    "Tran_NamL": "Adame"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Andrew E.",
-    "Tran_NamL": "Adame"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Andrew E.",
-    "Tran_NamL": "Adame"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Richard L.",
-    "Tran_NamL": "Amato"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Richard L.",
-    "Tran_NamL": "Amato"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Richard L.",
-    "Tran_NamL": "Amato"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Richard L.",
-    "Tran_NamL": "Amato"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Richard L.",
-    "Tran_NamL": "Amato"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Richard L.",
-    "Tran_NamL": "Amato"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Louie",
-    "Tran_NamL": "Baity"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Louie",
-    "Tran_NamL": "Baity"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Louie",
-    "Tran_NamL": "Baity"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Louie",
-    "Tran_NamL": "Baity"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Louie",
-    "Tran_NamL": "Baity"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Louie",
-    "Tran_NamL": "Baity"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Marc A.",
-    "Tran_NamL": "Baker"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Marc A.",
-    "Tran_NamL": "Baker"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Marc A.",
-    "Tran_NamL": "Baker"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Shayn J.",
-    "Tran_NamL": "Bannowsky"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Shayn J.",
-    "Tran_NamL": "Bannowsky"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Shayn J.",
-    "Tran_NamL": "Bannowsky"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Shayn J.",
-    "Tran_NamL": "Bannowsky"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Shayn J.",
-    "Tran_NamL": "Bannowsky"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Shayn J.",
-    "Tran_NamL": "Bannowsky"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Jason A.",
-    "Tran_NamL": "Beach"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Shane",
-    "Tran_NamL": "Bell"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Samuel W.",
-    "Tran_NamL": "Berry"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Samuel W.",
-    "Tran_NamL": "Berry"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Samuel W.",
-    "Tran_NamL": "Berry"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Samuel W.",
-    "Tran_NamL": "Berry"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Samuel W.",
-    "Tran_NamL": "Berry"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Samuel W.",
-    "Tran_NamL": "Berry"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Bollinger"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Bollinger"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Matthew",
-    "Tran_NamL": "Bollinger"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
+    "Tran_Date": "2016-05-31",
     "Tran_NamF": "Michael",
-    "Tran_NamL": "Brena"
+    "Tran_NamL": "Sawyer"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
+    "Tran_Date": "2016-05-31",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-07",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-07",
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-06-07",
     "Tran_NamF": "Michael",
-    "Tran_NamL": "Brena"
+    "Tran_NamL": "Sawyer"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Brena"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Brian K.",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Brian K.",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Brian K.",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Brian K.",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Brian K.",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Brian K.",
-    "Tran_NamL": "Brooks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Bruno",
-    "Tran_NamL": "Burgueno"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Bruno",
-    "Tran_NamL": "Burgueno"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Bruno",
-    "Tran_NamL": "Burgueno"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Edward K",
-    "Tran_NamL": "Buttles"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Edward K",
-    "Tran_NamL": "Buttles"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Edward K",
-    "Tran_NamL": "Buttles"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Chavez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Chavez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Steven",
-    "Tran_NamL": "Chavez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Choy"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Choy"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Choy"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Jared M.",
-    "Tran_NamL": "Clark"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Jared M.",
-    "Tran_NamL": "Clark"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Jared M.",
-    "Tran_NamL": "Clark"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Anthony",
-    "Tran_NamL": "Dito"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Anthony",
-    "Tran_NamL": "Dito"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Anthony",
-    "Tran_NamL": "Dito"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Thomas B.",
-    "Tran_NamL": "Dosier"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Thomas B.",
-    "Tran_NamL": "Dosier"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Thomas B.",
-    "Tran_NamL": "Dosier"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Duong"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Duong"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Richard",
-    "Tran_NamL": "Duong"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Shannon K.",
-    "Tran_NamL": "Dwyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Shannon K.",
-    "Tran_NamL": "Dwyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Shannon K.",
-    "Tran_NamL": "Dwyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Tyler J.",
-    "Tran_NamL": "Ecoffey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Tyler J.",
-    "Tran_NamL": "Ecoffey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Tyler J.",
-    "Tran_NamL": "Ecoffey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Tyler J.",
-    "Tran_NamL": "Ecoffey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Tyler J.",
-    "Tran_NamL": "Ecoffey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Tyler J.",
-    "Tran_NamL": "Ecoffey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Feehan"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Feehan"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Deborah",
-    "Tran_NamL": "Feehan"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Joseph D.",
-    "Tran_NamL": "Feller"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Joseph D.",
-    "Tran_NamL": "Feller"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Joseph D.",
-    "Tran_NamL": "Feller"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Joseph D.",
-    "Tran_NamL": "Feller"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Joseph D.",
-    "Tran_NamL": "Feller"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Joseph D.",
-    "Tran_NamL": "Feller"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Joseph B.",
-    "Tran_NamL": "Garner"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Joseph B.",
-    "Tran_NamL": "Garner"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Joseph B.",
-    "Tran_NamL": "Garner"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Joseph B.",
-    "Tran_NamL": "Garner"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Joseph B.",
-    "Tran_NamL": "Garner"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Joseph B.",
-    "Tran_NamL": "Garner"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Miguel",
-    "Tran_NamL": "Gomez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Miguel",
-    "Tran_NamL": "Gomez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Miguel",
-    "Tran_NamL": "Gomez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Justin P.",
-    "Tran_NamL": "Gonsalves"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Justin P.",
-    "Tran_NamL": "Gonsalves"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Justin P.",
-    "Tran_NamL": "Gonsalves"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Justin P.",
-    "Tran_NamL": "Gonsalves"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Justin P.",
-    "Tran_NamL": "Gonsalves"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Justin P.",
-    "Tran_NamL": "Gonsalves"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Simon",
-    "Tran_NamL": "Gowring"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Simon",
-    "Tran_NamL": "Gowring"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Simon",
-    "Tran_NamL": "Gowring"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Steven P.",
-    "Tran_NamL": "Hickey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Steven P.",
-    "Tran_NamL": "Hickey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Steven P.",
-    "Tran_NamL": "Hickey"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Hicks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Hicks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Hicks"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Keith",
-    "Tran_NamL": "Hung"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Keith",
-    "Tran_NamL": "Hung"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Keith",
-    "Tran_NamL": "Hung"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Raul",
-    "Tran_NamL": "Hurtado"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Raul",
-    "Tran_NamL": "Hurtado"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
-    "Tran_NamF": "Raul",
-    "Tran_NamL": "Hurtado"
+    "Tran_Date": "2016-06-07",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
   },
   {
     "Filer_ID": "892160",
@@ -934,20 +66,202 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Mario",
-    "Tran_NamL": "Jones"
+    "Tran_NamF": "Andrew E.",
+    "Tran_NamL": "Adame"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Mario",
-    "Tran_NamL": "Jones"
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Richard L.",
+    "Tran_NamL": "Amato"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-09-13",
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Louie",
+    "Tran_NamL": "Baity"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Marc A.",
+    "Tran_NamL": "Baker"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Shayn J.",
+    "Tran_NamL": "Bannowsky"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Samuel W.",
+    "Tran_NamL": "Berry"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Brena"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Brian K.",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Edward K",
+    "Tran_NamL": "Buttles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Choy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Jared M.",
+    "Tran_NamL": "Clark"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Thomas B.",
+    "Tran_NamL": "Dosier"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Duong"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Tyler J.",
+    "Tran_NamL": "Ecoffey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Feehan"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Joseph D.",
+    "Tran_NamL": "Feller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Joseph B.",
+    "Tran_NamL": "Garner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Justin P.",
+    "Tran_NamL": "Gonsalves"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Raul",
+    "Tran_NamL": "Hurtado"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
     "Tran_NamF": "Mario",
     "Tran_NamL": "Jones"
   },
@@ -961,6 +275,608 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Michael A.",
+    "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Kitt"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Adam L.",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "McGaw"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Chad E.",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-12",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Shaun",
+    "Tran_NamL": "Acosta"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Andrew E.",
+    "Tran_NamL": "Adame"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Richard L.",
+    "Tran_NamL": "Amato"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Louie",
+    "Tran_NamL": "Baity"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Shayn J.",
+    "Tran_NamL": "Bannowsky"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Samuel W.",
+    "Tran_NamL": "Berry"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Brian K.",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Shannon K.",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Tyler J.",
+    "Tran_NamL": "Ecoffey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Joseph D.",
+    "Tran_NamL": "Feller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Joseph B.",
+    "Tran_NamL": "Garner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Justin P.",
+    "Tran_NamL": "Gonsalves"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Simon",
+    "Tran_NamL": "Gowring"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Steven P.",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Spartacus G.",
+    "Tran_NamL": "Rodriguez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-07-26",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Shaun",
+    "Tran_NamL": "Acosta"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Andrew E.",
+    "Tran_NamL": "Adame"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Richard L.",
+    "Tran_NamL": "Amato"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Louie",
+    "Tran_NamL": "Baity"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Shayn J.",
+    "Tran_NamL": "Bannowsky"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Samuel W.",
+    "Tran_NamL": "Berry"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Brian K.",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Shannon K.",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Tyler J.",
+    "Tran_NamL": "Ecoffey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Joseph D.",
+    "Tran_NamL": "Feller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Joseph B.",
+    "Tran_NamL": "Garner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Justin P.",
+    "Tran_NamL": "Gonsalves"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Simon",
+    "Tran_NamL": "Gowring"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Steven P.",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Spartacus G.",
+    "Tran_NamL": "Rodriguez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-02",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Andrew E.",
+    "Tran_NamL": "Adame"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Richard L.",
+    "Tran_NamL": "Amato"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Louie",
+    "Tran_NamL": "Baity"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Marc A.",
+    "Tran_NamL": "Baker"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Shayn J.",
+    "Tran_NamL": "Bannowsky"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Samuel W.",
+    "Tran_NamL": "Berry"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Brena"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Brian K.",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Edward K",
+    "Tran_NamL": "Buttles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Choy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Jared M.",
+    "Tran_NamL": "Clark"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Thomas B.",
+    "Tran_NamL": "Dosier"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Duong"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Tyler J.",
+    "Tran_NamL": "Ecoffey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Feehan"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Joseph D.",
+    "Tran_NamL": "Feller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Joseph B.",
+    "Tran_NamL": "Garner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Justin P.",
+    "Tran_NamL": "Gonsalves"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Raul",
+    "Tran_NamL": "Hurtado"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-08-04",
     "Tran_NamF": "Joseph",
     "Tran_NamL": "Keahey"
@@ -968,6 +884,461 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Michael A.",
+    "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Kitt"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Adam L.",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "McGaw"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Chad E.",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-04",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Shaun",
+    "Tran_NamL": "Acosta"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Andrew E.",
+    "Tran_NamL": "Adame"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Richard L.",
+    "Tran_NamL": "Amato"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Louie",
+    "Tran_NamL": "Baity"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Shayn J.",
+    "Tran_NamL": "Bannowsky"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Samuel W.",
+    "Tran_NamL": "Berry"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Brian K.",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Shannon K.",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Tyler J.",
+    "Tran_NamL": "Ecoffey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Joseph D.",
+    "Tran_NamL": "Feller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Joseph B.",
+    "Tran_NamL": "Garner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Justin P.",
+    "Tran_NamL": "Gonsalves"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Simon",
+    "Tran_NamL": "Gowring"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Steven P.",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Jacob",
+    "Tran_NamL": "Roberts"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Spartacus G.",
+    "Tran_NamL": "Rodriguez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Nicolas",
+    "Tran_NamL": "Romero"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sawyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-08-25",
+    "Tran_NamF": "Jarod",
+    "Tran_NamL": "Torres"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Andrew E.",
+    "Tran_NamL": "Adame"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Richard L.",
+    "Tran_NamL": "Amato"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Louie",
+    "Tran_NamL": "Baity"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Marc A.",
+    "Tran_NamL": "Baker"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Shayn J.",
+    "Tran_NamL": "Bannowsky"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Jason A.",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Samuel W.",
+    "Tran_NamL": "Berry"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Brena"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Brian K.",
+    "Tran_NamL": "Brooks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Edward K",
+    "Tran_NamL": "Buttles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Choy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Jared M.",
+    "Tran_NamL": "Clark"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Thomas B.",
+    "Tran_NamL": "Dosier"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Duong"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Tyler J.",
+    "Tran_NamL": "Ecoffey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Feehan"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Joseph D.",
+    "Tran_NamL": "Feller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Joseph B.",
+    "Tran_NamL": "Garner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Justin P.",
+    "Tran_NamL": "Gonsalves"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Raul",
+    "Tran_NamL": "Hurtado"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Joseph",
     "Tran_NamL": "Keahey"
@@ -975,37 +1346,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Kelly"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "Kelly"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Kelly"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Michael A.",
-    "Tran_NamL": "King"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Michael A.",
-    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -1017,37 +1360,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Kitt"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Daniel",
-    "Tran_NamL": "Kitt"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Kitt"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Adam L.",
-    "Tran_NamL": "Lauber"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Adam L.",
-    "Tran_NamL": "Lauber"
   },
   {
     "Filer_ID": "892160",
@@ -1059,37 +1374,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Nathaniel",
-    "Tran_NamL": "Leal"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Nathaniel",
-    "Tran_NamL": "Leal"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Lee"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Jeffrey",
-    "Tran_NamL": "Lee"
   },
   {
     "Filer_ID": "892160",
@@ -1101,37 +1388,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Lion"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Kevin",
-    "Tran_NamL": "Lion"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Lion"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Mardakis"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "James",
-    "Tran_NamL": "Mardakis"
   },
   {
     "Filer_ID": "892160",
@@ -1143,37 +1402,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "McGaw"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Chris",
-    "Tran_NamL": "McGaw"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Chris",
     "Tran_NamL": "McGaw"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Chad E.",
-    "Tran_NamL": "Navarro"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Chad E.",
-    "Tran_NamL": "Navarro"
   },
   {
     "Filer_ID": "892160",
@@ -1185,20 +1416,6 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Kai",
-    "Tran_NamL": "Pagani"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Kai",
-    "Tran_NamL": "Pagani"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Kai",
     "Tran_NamL": "Pagani"
@@ -1206,128 +1423,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-07",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Jacob",
-    "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Jacob",
     "Tran_NamL": "Roberts"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Spartacus G.",
-    "Tran_NamL": "Rodriguez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Spartacus G.",
-    "Tran_NamL": "Rodriguez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Spartacus G.",
-    "Tran_NamL": "Rodriguez"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-07",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Nicolas",
-    "Tran_NamL": "Romero"
   },
   {
     "Filer_ID": "892160",
@@ -1339,107 +1437,9 @@
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-07",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Michael",
-    "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Sawyer"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-05-31",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-06-07",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-12",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-07-26",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-02",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-04",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2016-08-25",
-    "Tran_NamF": "Jarod",
-    "Tran_NamL": "Torres"
   },
   {
     "Filer_ID": "892160",

--- a/build/committee/960997/contributions/index.json
+++ b/build/committee/960997/contributions/index.json
@@ -8,15 +8,15 @@
   },
   {
     "Filer_ID": "960997",
-    "Tran_Amt1": 25000.0,
-    "Tran_Date": "2016-10-27",
+    "Tran_Amt1": 45000.0,
+    "Tran_Date": "2016-10-13",
     "Tran_NamF": null,
     "Tran_NamL": "CALIFORNIA CHARTER SCHOOLS ASSOCIATIONADVOCATES ISSUES COMMITTEE"
   },
   {
     "Filer_ID": "960997",
-    "Tran_Amt1": 45000.0,
-    "Tran_Date": "2016-10-13",
+    "Tran_Amt1": 25000.0,
+    "Tran_Date": "2016-10-27",
     "Tran_NamF": null,
     "Tran_NamL": "CALIFORNIA CHARTER SCHOOLS ASSOCIATIONADVOCATES ISSUES COMMITTEE"
   },

--- a/build/committee/960997/contributions/index.json
+++ b/build/committee/960997/contributions/index.json
@@ -8,27 +8,6 @@
   },
   {
     "Filer_ID": "960997",
-    "Tran_Amt1": 45000.0,
-    "Tran_Date": "2016-10-13",
-    "Tran_NamF": null,
-    "Tran_NamL": "CALIFORNIA CHARTER SCHOOLS ASSOCIATIONADVOCATES ISSUES COMMITTEE"
-  },
-  {
-    "Filer_ID": "960997",
-    "Tran_Amt1": 25000.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": null,
-    "Tran_NamL": "CALIFORNIA CHARTER SCHOOLS ASSOCIATIONADVOCATES ISSUES COMMITTEE"
-  },
-  {
-    "Filer_ID": "960997",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-11-03",
-    "Tran_NamF": null,
-    "Tran_NamL": "CALIFORNIA TEAMSTERS PUBLIC AFFAIRS COUNCIL  ISSUES ACCOUNT"
-  },
-  {
-    "Filer_ID": "960997",
     "Tran_Amt1": 5000.0,
     "Tran_Date": "2016-10-07",
     "Tran_NamF": "Gregory",
@@ -43,17 +22,17 @@
   },
   {
     "Filer_ID": "960997",
-    "Tran_Amt1": 1000.0,
-    "Tran_Date": "2016-11-08",
+    "Tran_Amt1": 3500.0,
+    "Tran_Date": "2016-10-07",
     "Tran_NamF": null,
-    "Tran_NamL": "Northern California Carpenters Regional Council Issues PAC"
+    "Tran_NamL": "Sheet Metal Workers' Local Union 104 Issues Account"
   },
   {
     "Filer_ID": "960997",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-10-27",
-    "Tran_NamF": "John",
-    "Tran_NamL": "Protopappas"
+    "Tran_Amt1": 45000.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "CALIFORNIA CHARTER SCHOOLS ASSOCIATIONADVOCATES ISSUES COMMITTEE"
   },
   {
     "Filer_ID": "960997",
@@ -64,9 +43,30 @@
   },
   {
     "Filer_ID": "960997",
-    "Tran_Amt1": 3500.0,
-    "Tran_Date": "2016-10-07",
+    "Tran_Amt1": 25000.0,
+    "Tran_Date": "2016-10-27",
     "Tran_NamF": null,
-    "Tran_NamL": "Sheet Metal Workers' Local Union 104 Issues Account"
+    "Tran_NamL": "CALIFORNIA CHARTER SCHOOLS ASSOCIATIONADVOCATES ISSUES COMMITTEE"
+  },
+  {
+    "Filer_ID": "960997",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Protopappas"
+  },
+  {
+    "Filer_ID": "960997",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "CALIFORNIA TEAMSTERS PUBLIC AFFAIRS COUNCIL  ISSUES ACCOUNT"
+  },
+  {
+    "Filer_ID": "960997",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "Northern California Carpenters Regional Council Issues PAC"
   }
 ]

--- a/build/committee/983545/contributions/index.json
+++ b/build/committee/983545/contributions/index.json
@@ -1,17 +1,17 @@
 [
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 105.5,
-    "Tran_Date": "2016-10-17",
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-01-06",
     "Tran_NamF": null,
-    "Tran_NamL": "ABC Security Service, Inc."
+    "Tran_NamL": "Piedmont Grocery Co."
   },
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 158.3,
-    "Tran_Date": "2016-10-21",
-    "Tran_NamF": null,
-    "Tran_NamL": "Bishop O'Dowd High School"
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-01-11",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Stimson"
   },
   {
     "Filer_ID": "983545",
@@ -19,41 +19,6 @@
     "Tran_Date": "2016-01-12",
     "Tran_NamF": null,
     "Tran_NamL": "Clear Channel Outdoor"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 145.7,
-    "Tran_Date": "2016-07-06",
-    "Tran_NamF": null,
-    "Tran_NamL": "Clear Channel Outdoor"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 109.3,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "Donahue Fitzgerald LLP"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 125.0,
-    "Tran_Date": "2016-10-19",
-    "Tran_NamF": null,
-    "Tran_NamL": "Douglas Parking LLC"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-03-14",
-    "Tran_NamF": null,
-    "Tran_NamL": "Federal Express"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 153.2,
-    "Tran_Date": "2016-11-29",
-    "Tran_NamF": null,
-    "Tran_NamL": "Gallagher & Burk, Inc."
   },
   {
     "Filer_ID": "983545",
@@ -65,58 +30,9 @@
   {
     "Filer_ID": "983545",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-14",
+    "Tran_Date": "2016-03-14",
     "Tran_NamF": null,
-    "Tran_NamL": "Golden State Warriors"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 20.84,
-    "Tran_Date": "2016-12-22",
-    "Tran_NamF": null,
-    "Tran_NamL": "Hilton Oakland Airport"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 145.7,
-    "Tran_Date": "2016-07-01",
-    "Tran_NamF": null,
-    "Tran_NamL": "Horizon Beverage Company"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-06-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "KaiserAir, Inc."
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 137.2,
-    "Tran_Date": "2016-09-23",
-    "Tran_NamF": null,
-    "Tran_NamL": "MBH Architects"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 62.5,
-    "Tran_Date": "2016-05-17",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Marriott - City Center"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 665.33,
-    "Tran_Date": "2016-12-15",
-    "Tran_NamF": null,
-    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce"
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-07-07",
-    "Tran_NamF": null,
-    "Tran_NamL": "PG&E Corporation"
+    "Tran_NamL": "Federal Express"
   },
   {
     "Filer_ID": "983545",
@@ -127,17 +43,10 @@
   },
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-01-06",
+    "Tran_Amt1": 62.5,
+    "Tran_Date": "2016-05-17",
     "Tran_NamF": null,
-    "Tran_NamL": "Piedmont Grocery Co."
-  },
-  {
-    "Filer_ID": "983545",
-    "Tran_Amt1": 121.4,
-    "Tran_Date": "2016-11-30",
-    "Tran_NamF": null,
-    "Tran_NamL": "Rolls-Royce Engine Services - Oakland Inc."
+    "Tran_NamL": "Oakland Marriott - City Center"
   },
   {
     "Filer_ID": "983545",
@@ -148,17 +57,45 @@
   },
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-01-11",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Stimson"
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-06-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "KaiserAir, Inc."
   },
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 38.0,
-    "Tran_Date": "2016-10-11",
-    "Tran_NamF": "Charles",
-    "Tran_NamL": "Stimson"
+    "Tran_Amt1": 153.2,
+    "Tran_Date": "2016-06-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Whole Foods Market"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 109.3,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "Donahue Fitzgerald LLP"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 145.7,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "Horizon Beverage Company"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 145.7,
+    "Tran_Date": "2016-07-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "Clear Channel Outdoor"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-07-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "PG&E Corporation"
   },
   {
     "Filer_ID": "983545",
@@ -169,9 +106,72 @@
   },
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 153.2,
-    "Tran_Date": "2016-06-28",
+    "Tran_Amt1": 137.2,
+    "Tran_Date": "2016-09-23",
     "Tran_NamF": null,
-    "Tran_NamL": "Whole Foods Market"
+    "Tran_NamL": "MBH Architects"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 38.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Stimson"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 105.5,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "ABC Security Service, Inc."
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 125.0,
+    "Tran_Date": "2016-10-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Douglas Parking LLC"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 158.3,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bishop O'Dowd High School"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "Golden State Warriors"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 153.2,
+    "Tran_Date": "2016-11-29",
+    "Tran_NamF": null,
+    "Tran_NamL": "Gallagher & Burk, Inc."
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 121.4,
+    "Tran_Date": "2016-11-30",
+    "Tran_NamF": null,
+    "Tran_NamL": "Rolls-Royce Engine Services - Oakland Inc."
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 665.33,
+    "Tran_Date": "2016-12-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Metropolitan Chamber of Commerce"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 20.84,
+    "Tran_Date": "2016-12-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Hilton Oakland Airport"
   }
 ]

--- a/build/committee/983545/contributions/index.json
+++ b/build/committee/983545/contributions/index.json
@@ -15,15 +15,15 @@
   },
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 145.7,
-    "Tran_Date": "2016-07-06",
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-01-12",
     "Tran_NamF": null,
     "Tran_NamL": "Clear Channel Outdoor"
   },
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 2500.0,
-    "Tran_Date": "2016-01-12",
+    "Tran_Amt1": 145.7,
+    "Tran_Date": "2016-07-06",
     "Tran_NamF": null,
     "Tran_NamL": "Clear Channel Outdoor"
   },
@@ -58,14 +58,14 @@
   {
     "Filer_ID": "983545",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-11-14",
+    "Tran_Date": "2016-02-02",
     "Tran_NamF": null,
     "Tran_NamL": "Golden State Warriors"
   },
   {
     "Filer_ID": "983545",
     "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-02-02",
+    "Tran_Date": "2016-11-14",
     "Tran_NamF": null,
     "Tran_NamL": "Golden State Warriors"
   },
@@ -148,15 +148,15 @@
   },
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 38.0,
-    "Tran_Date": "2016-10-11",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-01-11",
     "Tran_NamF": "Charles",
     "Tran_NamL": "Stimson"
   },
   {
     "Filer_ID": "983545",
-    "Tran_Amt1": 200.0,
-    "Tran_Date": "2016-01-11",
+    "Tran_Amt1": 38.0,
+    "Tran_Date": "2016-10-11",
     "Tran_NamF": "Charles",
     "Tran_NamL": "Stimson"
   },

--- a/build/committee/S10088/contributions/index.json
+++ b/build/committee/S10088/contributions/index.json
@@ -1,34 +1,6 @@
 [
   {
     "Filer_ID": "S10088",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2016-02-24",
-    "Tran_NamF": "Cathy",
-    "Tran_NamL": "Adams"
-  },
-  {
-    "Filer_ID": "S10088",
-    "Tran_Amt1": -500.0,
-    "Tran_Date": "2016-03-21",
-    "Tran_NamF": "Cathy",
-    "Tran_NamL": "Adams"
-  },
-  {
-    "Filer_ID": "S10088",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-15",
-    "Tran_NamF": "Gwendolyn",
-    "Tran_NamL": "Booze"
-  },
-  {
-    "Filer_ID": "S10088",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-05-02",
-    "Tran_NamF": "Gwendolyn",
-    "Tran_NamL": "Booze"
-  },
-  {
-    "Filer_ID": "S10088",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-01-01",
     "Tran_NamF": "William",
@@ -37,9 +9,16 @@
   {
     "Filer_ID": "S10088",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-12-23",
-    "Tran_NamF": "Rena",
-    "Tran_NamL": "Rickles"
+    "Tran_Date": "2016-01-21",
+    "Tran_NamF": "Frank",
+    "Tran_NamL": "Russo"
+  },
+  {
+    "Filer_ID": "S10088",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-21",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Skinner"
   },
   {
     "Filer_ID": "S10088",
@@ -51,9 +30,44 @@
   {
     "Filer_ID": "S10088",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-21",
-    "Tran_NamF": "Frank",
-    "Tran_NamL": "Russo"
+    "Tran_Date": "2016-02-15",
+    "Tran_NamF": "Gwendolyn",
+    "Tran_NamL": "Booze"
+  },
+  {
+    "Filer_ID": "S10088",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-02-24",
+    "Tran_NamF": "Cathy",
+    "Tran_NamL": "Adams"
+  },
+  {
+    "Filer_ID": "S10088",
+    "Tran_Amt1": 70.0,
+    "Tran_Date": "2016-03-17",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Skinner"
+  },
+  {
+    "Filer_ID": "S10088",
+    "Tran_Amt1": -500.0,
+    "Tran_Date": "2016-03-21",
+    "Tran_NamF": "Cathy",
+    "Tran_NamL": "Adams"
+  },
+  {
+    "Filer_ID": "S10088",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-03-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "Swanson for Senate 2016"
+  },
+  {
+    "Filer_ID": "S10088",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-05-02",
+    "Tran_NamF": "Gwendolyn",
+    "Tran_NamL": "Booze"
   },
   {
     "Filer_ID": "S10088",
@@ -65,22 +79,8 @@
   {
     "Filer_ID": "S10088",
     "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-21",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Skinner"
-  },
-  {
-    "Filer_ID": "S10088",
-    "Tran_Amt1": 70.0,
-    "Tran_Date": "2016-03-17",
-    "Tran_NamF": "Nancy",
-    "Tran_NamL": "Skinner"
-  },
-  {
-    "Filer_ID": "S10088",
-    "Tran_Amt1": 100.0,
-    "Tran_Date": "2016-03-25",
-    "Tran_NamF": null,
-    "Tran_NamL": "Swanson for Senate 2016"
+    "Tran_Date": "2016-12-23",
+    "Tran_NamF": "Rena",
+    "Tran_NamL": "Rickles"
   }
 ]

--- a/build/committee/S10088/contributions/index.json
+++ b/build/committee/S10088/contributions/index.json
@@ -15,15 +15,15 @@
   },
   {
     "Filer_ID": "S10088",
-    "Tran_Amt1": 75.0,
-    "Tran_Date": "2016-05-02",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-02-15",
     "Tran_NamF": "Gwendolyn",
     "Tran_NamL": "Booze"
   },
   {
     "Filer_ID": "S10088",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-02-15",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2016-05-02",
     "Tran_NamF": "Gwendolyn",
     "Tran_NamL": "Booze"
   },
@@ -51,6 +51,13 @@
   {
     "Filer_ID": "S10088",
     "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-01-21",
+    "Tran_NamF": "Frank",
+    "Tran_NamL": "Russo"
+  },
+  {
+    "Filer_ID": "S10088",
+    "Tran_Amt1": 50.0,
     "Tran_Date": "2016-05-03",
     "Tran_NamF": "Frank",
     "Tran_NamL": "Russo"
@@ -59,20 +66,13 @@
     "Filer_ID": "S10088",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-01-21",
-    "Tran_NamF": "Frank",
-    "Tran_NamL": "Russo"
-  },
-  {
-    "Filer_ID": "S10088",
-    "Tran_Amt1": 70.0,
-    "Tran_Date": "2016-03-17",
     "Tran_NamF": "Nancy",
     "Tran_NamL": "Skinner"
   },
   {
     "Filer_ID": "S10088",
-    "Tran_Amt1": 50.0,
-    "Tran_Date": "2016-01-21",
+    "Tran_Amt1": 70.0,
+    "Tran_Date": "2016-03-17",
     "Tran_NamF": "Nancy",
     "Tran_NamL": "Skinner"
   },

--- a/build/referendum/3/supporting/index.json
+++ b/build/referendum/3/supporting/index.json
@@ -7,16 +7,16 @@
   "number": "JJ",
   "supporting_organizations": [
     {
-      "id": "1364564",
-      "name": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
-      "payee": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
-      "amount": 376155.64
-    },
-    {
       "id": "1385949",
       "name": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "payee": "Causa Justa :: Just Cause (nonprofit 501(c)(3))",
       "amount": 183890.79
+    },
+    {
+      "id": "1364564",
+      "name": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
+      "payee": "Committee to Protect Oakland Renters - Yes on Measure JJ, sponsored by labor and community organizations",
+      "amount": 376155.64
     }
   ],
   "total_contributions": 477719.80999999994,

--- a/build/referendum/6/supporting/index.json
+++ b/build/referendum/6/supporting/index.json
@@ -7,12 +7,6 @@
   "number": "G1",
   "supporting_organizations": [
     {
-      "id": null,
-      "name": "YES ON G1, SPONSORED BY GO PUBLIC SCHOOLS ADVOCATES",
-      "payee": "YES ON G1, SPONSORED BY GO PUBLIC SCHOOLS ADVOCATES",
-      "amount": 14108.45
-    },
-    {
       "id": "1331137",
       "name": "Families and Educators for Public Education, Sponsored by Go Public Schools Advocates",
       "payee": "Families and Educators for Public Education, Sponsored by Go Public Schools Advocates",
@@ -23,6 +17,12 @@
       "name": "Friends of Oakland Public Schools Yes on G1 2016",
       "payee": "Friends of Oakland Public Schools Yes on G1 2016",
       "amount": 32926.02
+    },
+    {
+      "id": null,
+      "name": "YES ON G1, SPONSORED BY GO PUBLIC SCHOOLS ADVOCATES",
+      "payee": "YES ON G1, SPONSORED BY GO PUBLIC SCHOOLS ADVOCATES",
+      "amount": 14108.45
     }
   ],
   "total_contributions": 142500.0,

--- a/build/stats/index.json
+++ b/build/stats/index.json
@@ -1,3 +1,3 @@
 {
-  "date_processed": "2017-06-12"
+  "date_processed": "2017-06-17"
 }

--- a/calculators/committee_contribution_list_calculator.rb
+++ b/calculators/committee_contribution_list_calculator.rb
@@ -40,8 +40,8 @@ class CommitteeContributionListCalculator
 
     @committees.each do |committee|
       filer_id = committee['Filer_ID'].to_s
-      sorted =
-        Array(contributions_by_committee[filer_id]).sort_by { |row| row['Tran_NamL'] }
+      sorted = Array(contributions_by_committee[filer_id])
+        .sort_by { |row| [row['Tran_NamL'], row['Tran_Date']] }
 
       committee.save_calculation(:contribution_list, sorted)
     end

--- a/calculators/committee_contribution_list_calculator.rb
+++ b/calculators/committee_contribution_list_calculator.rb
@@ -41,7 +41,7 @@ class CommitteeContributionListCalculator
     @committees.each do |committee|
       filer_id = committee['Filer_ID'].to_s
       sorted = Array(contributions_by_committee[filer_id])
-        .sort_by { |row| [row['Tran_NamL'], row['Tran_Date']] }
+        .sort_by { |row| [row['Tran_Date'], row['Tran_NamL'], row['Tran_NamF'] || ''] }
 
       committee.save_calculation(:contribution_list, sorted)
     end

--- a/calculators/committee_contribution_list_calculator.rb
+++ b/calculators/committee_contribution_list_calculator.rb
@@ -41,7 +41,14 @@ class CommitteeContributionListCalculator
     @committees.each do |committee|
       filer_id = committee['Filer_ID'].to_s
       sorted = Array(contributions_by_committee[filer_id])
-        .sort_by { |row| [row['Tran_Date'], row['Tran_NamL'], row['Tran_NamF'] || ''] }
+        .sort_by do |row|
+          [
+            row['Tran_Date'],
+            row['Tran_NamL'],
+            row['Tran_NamF'] || '',
+            row['Tran_Amt1'],
+          ]
+      end
 
       committee.save_calculation(:contribution_list, sorted)
     end

--- a/calculators/referendum_supporters_calculator.rb
+++ b/calculators/referendum_supporters_calculator.rb
@@ -12,6 +12,7 @@ class ReferendumSupportersCalculator
         SUM("Amount") AS "Total_Amount"
       FROM "Measure_Expenditures"
       GROUP BY "Filer_ID", "Filer_NamL", "Measure_Number", "Bal_Name", "Sup_Opp_Cd"
+      ORDER BY "Filer_NamL" ASC
     SQL
 
     summary_other = ActiveRecord::Base.connection.execute(<<-SQL)

--- a/ssconvert.rb
+++ b/ssconvert.rb
@@ -22,8 +22,10 @@ xlsx.sheets.each do |sheet|
     loop do
       row = file.next
 
-      # HACK: the datetimes seem to have a weird formatting string
-      # ("mm/dd/yyy") in the XLSX spreadsheet which has an extra "y" at the end.
+      # HACK: the datetimes in the XLSX spreadsheet seem to have a weird
+      # formatting string ("mm/dd/yyy") which has an extra "y" at the end. By
+      # converting the format string to "yyyy-mm-dd" we can get a date formatted
+      # properly for import into the database.
       row.each do |cell|
         if cell.type == :date
           cell.instance_variable_set(:@format, "yyyy-mm-dd")


### PR DESCRIPTION
It's important that we get only the best diffs when we run `make process` - no diffs caused by different ordering behavior between computers.

For this, I added a couple more fields to the sorting code in the contributions list and an ORDER BY in the supporting committees code.

(Scroll to the bottom to see the actual diff.)