### PR TITLE
Use CTEs and views for subqueries

### DIFF
--- a/build/committee/1307016/contributions/index.json
+++ b/build/committee/1307016/contributions/index.json
@@ -113,6 +113,34 @@
   },
   {
     "Filer_ID": "1307016",
+    "Tran_Amt1": 4500.0,
+    "Tran_Date": "2017-01-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "The McConnell Group, Inc."
+  },
+  {
+    "Filer_ID": "1307016",
+    "Tran_Amt1": 4500.0,
+    "Tran_Date": "2017-01-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "The McConnell Group, Inc."
+  },
+  {
+    "Filer_ID": "1307016",
+    "Tran_Amt1": 4500.0,
+    "Tran_Date": "2017-01-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "The McConnell Group, Inc."
+  },
+  {
+    "Filer_ID": "1307016",
+    "Tran_Amt1": 4500.0,
+    "Tran_Date": "2017-01-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "The McConnell Group, Inc."
+  },
+  {
+    "Filer_ID": "1307016",
     "Tran_Amt1": 7500.0,
     "Tran_Date": "2017-09-18",
     "Tran_NamF": null,

--- a/build/committee/1331137/contributions/index.json
+++ b/build/committee/1331137/contributions/index.json
@@ -932,6 +932,13 @@
   },
   {
     "Filer_ID": "1331137",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2015-08-18",
+    "Tran_NamF": "JILL",
+    "Tran_NamL": "HABIG"
+  },
+  {
+    "Filer_ID": "1331137",
     "Tran_Amt1": 5.0,
     "Tran_Date": "2015-08-18",
     "Tran_NamF": "LAILA",

--- a/build/committee/1342695/contributions/index.json
+++ b/build/committee/1342695/contributions/index.json
@@ -542,6 +542,20 @@
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
     "Tran_Date": "2015-12-18",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Addleman"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2015-12-18",
+    "Tran_NamF": null,
+    "Tran_NamL": "Pansue Vernon Garden Apts."
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2015-12-18",
     "Tran_NamF": null,
     "Tran_NamL": "Pansue Vernon Garden Apts."
   },
@@ -1230,6 +1244,13 @@
     "Tran_Date": "2016-10-18",
     "Tran_NamF": null,
     "Tran_NamL": "Salles Group"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Luise",
+    "Tran_NamL": "Hall"
   },
   {
     "Filer_ID": "1342695",
@@ -2264,6 +2285,13 @@
     "Filer_ID": "1342695",
     "Tran_Amt1": 30.0,
     "Tran_Date": "2017-09-29",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 30.0,
+    "Tran_Date": "2017-09-29",
     "Tran_NamF": null,
     "Tran_NamL": "Lenox Properties"
   },
@@ -2287,6 +2315,13 @@
     "Tran_Date": "2017-09-29",
     "Tran_NamF": null,
     "Tran_NamL": "Rowland Property Management"
+  },
+  {
+    "Filer_ID": "1342695",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2017-10-02",
+    "Tran_NamF": null,
+    "Tran_NamL": "S&H Properties"
   },
   {
     "Filer_ID": "1342695",

--- a/build/committee/1345259/contributions/index.json
+++ b/build/committee/1345259/contributions/index.json
@@ -135,6 +135,20 @@
   {
     "Filer_ID": "1345259",
     "Tran_Amt1": 958.33,
+    "Tran_Date": "2016-07-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 958.33,
+    "Tran_Date": "2016-08-01",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 958.33,
     "Tran_Date": "2016-08-01",
     "Tran_NamF": null,
     "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
@@ -162,10 +176,73 @@
   },
   {
     "Filer_ID": "1345259",
+    "Tran_Amt1": 12000.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "CTA/ABC PAC"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 12000.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "CTA/ABC PAC"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 12000.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "CTA/ABC PAC"
+  },
+  {
+    "Filer_ID": "1345259",
     "Tran_Amt1": 13000.0,
     "Tran_Date": "2016-09-25",
     "Tran_NamF": null,
     "Tran_NamL": "CTA/ABC PAC"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 13000.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "CTA/ABC PAC"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 13000.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "CTA/ABC PAC"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 13000.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": null,
+    "Tran_NamL": "CTA/ABC PAC"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 1576.25,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 1576.25,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
+  },
+  {
+    "Filer_ID": "1345259",
+    "Tran_Amt1": 1576.25,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": null,
+    "Tran_NamL": "OAKLAND EDUCATION ASSOCIATION"
   },
   {
     "Filer_ID": "1345259",

--- a/build/committee/1362261/contributions/index.json
+++ b/build/committee/1362261/contributions/index.json
@@ -50,17 +50,17 @@
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2015-09-08",
-    "Tran_NamF": null,
-    "Tran_NamL": "AJE Partners"
-  },
-  {
-    "Filer_ID": "1362261",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2015-09-08",
     "Tran_NamF": "Sabrina",
     "Tran_NamL": "Aery"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2015-09-08",
+    "Tran_NamF": null,
+    "Tran_NamL": "AJE Partners"
   },
   {
     "Filer_ID": "1362261",
@@ -141,17 +141,17 @@
   },
   {
     "Filer_ID": "1362261",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2015-09-08",
-    "Tran_NamF": "Francisco",
-    "Tran_NamL": "DeVries"
-  },
-  {
-    "Filer_ID": "1362261",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2015-09-08",
     "Tran_NamF": "Darlene",
     "Tran_NamL": "Demanicor"
+  },
+  {
+    "Filer_ID": "1362261",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2015-09-08",
+    "Tran_NamF": "Francisco",
+    "Tran_NamL": "DeVries"
   },
   {
     "Filer_ID": "1362261",

--- a/build/committee/1375179/contributions/index.json
+++ b/build/committee/1375179/contributions/index.json
@@ -169,17 +169,17 @@
   },
   {
     "Filer_ID": "1375179",
-    "Tran_Amt1": 500.0,
-    "Tran_Date": "2015-02-12",
-    "Tran_NamF": null,
-    "Tran_NamL": "SK Builders"
-  },
-  {
-    "Filer_ID": "1375179",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2015-02-12",
     "Tran_NamF": null,
     "Tran_NamL": "Showtime Construction"
+  },
+  {
+    "Filer_ID": "1375179",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2015-02-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "SK Builders"
   },
   {
     "Filer_ID": "1375179",

--- a/build/committee/1379121/contributions/index.json
+++ b/build/committee/1379121/contributions/index.json
@@ -10,8 +10,29 @@
     "Filer_ID": "1379121",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2015-12-11",
+    "Tran_NamF": "Aimee",
+    "Tran_NamL": "Allison"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2015-12-11",
     "Tran_NamF": "Martin",
     "Tran_NamL": "Caraves"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2015-12-11",
+    "Tran_NamF": "Martin",
+    "Tran_NamL": "Caraves"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2015-12-12",
+    "Tran_NamF": "Nidya",
+    "Tran_NamL": "Baez"
   },
   {
     "Filer_ID": "1379121",
@@ -29,10 +50,31 @@
   },
   {
     "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2015-12-12",
+    "Tran_NamF": "Mariano",
+    "Tran_NamL": "Contreras"
+  },
+  {
+    "Filer_ID": "1379121",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2015-12-12",
     "Tran_NamF": "Chanterria",
     "Tran_NamL": "McGilbra"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2015-12-12",
+    "Tran_NamF": "Chanterria",
+    "Tran_NamL": "McGilbra"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2015-12-12",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Terry"
   },
   {
     "Filer_ID": "1379121",
@@ -50,6 +92,20 @@
   },
   {
     "Filer_ID": "1379121",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2015-12-31",
+    "Tran_NamF": "Paul Lamont",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2015-12-31",
+    "Tran_NamF": "Gerry",
+    "Tran_NamL": "Garzon"
+  },
+  {
+    "Filer_ID": "1379121",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2015-12-31",
     "Tran_NamF": "Gerry",
@@ -61,6 +117,20 @@
     "Tran_Date": "2015-12-31",
     "Tran_NamF": "Donna P.",
     "Tran_NamL": "Llang"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2015-12-31",
+    "Tran_NamF": "Donna P.",
+    "Tran_NamL": "Llang"
+  },
+  {
+    "Filer_ID": "1379121",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2015-12-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "Mar Con Company"
   },
   {
     "Filer_ID": "1379121",

--- a/build/committee/1381041/contributions/index.json
+++ b/build/committee/1381041/contributions/index.json
@@ -981,10 +981,10 @@
   },
   {
     "Filer_ID": "1381041",
-    "Tran_Amt1": 250.0,
+    "Tran_Amt1": 125.0,
     "Tran_Date": "2016-10-24",
-    "Tran_NamF": "DANA",
-    "Tran_NamL": "HUGHES"
+    "Tran_NamF": "MICHAEL",
+    "Tran_NamL": "DIMOCK"
   },
   {
     "Filer_ID": "1381041",
@@ -992,6 +992,13 @@
     "Tran_Date": "2016-10-24",
     "Tran_NamF": "Thomas J.",
     "Tran_NamL": "Higgins"
+  },
+  {
+    "Filer_ID": "1381041",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "DANA",
+    "Tran_NamL": "HUGHES"
   },
   {
     "Filer_ID": "1381041",

--- a/build/committee/1382408/contributions/index.json
+++ b/build/committee/1382408/contributions/index.json
@@ -386,17 +386,17 @@
   },
   {
     "Filer_ID": "1382408",
-    "Tran_Amt1": 700.0,
-    "Tran_Date": "2016-06-16",
-    "Tran_NamF": null,
-    "Tran_NamL": "PMACC dba Harborside Health Center"
-  },
-  {
-    "Filer_ID": "1382408",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-06-16",
     "Tran_NamF": "Sue",
     "Tran_NamL": "Piper"
+  },
+  {
+    "Filer_ID": "1382408",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-06-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "PMACC dba Harborside Health Center"
   },
   {
     "Filer_ID": "1382408",

--- a/build/committee/1385180/contributions/index.json
+++ b/build/committee/1385180/contributions/index.json
@@ -9,7 +9,28 @@
   {
     "Filer_ID": "1385180",
     "Tran_Amt1": 50000.0,
+    "Tran_Date": "2016-04-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC (NON-PROFIT 501(C)(6))"
+  },
+  {
+    "Filer_ID": "1385180",
+    "Tran_Amt1": 50000.0,
     "Tran_Date": "2016-05-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC (NON-PROFIT 501(C)(6))"
+  },
+  {
+    "Filer_ID": "1385180",
+    "Tran_Amt1": 50000.0,
+    "Tran_Date": "2016-05-10",
+    "Tran_NamF": null,
+    "Tran_NamL": "AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC (NON-PROFIT 501(C)(6))"
+  },
+  {
+    "Filer_ID": "1385180",
+    "Tran_Amt1": 200000.0,
+    "Tran_Date": "2016-05-18",
     "Tran_NamF": null,
     "Tran_NamL": "AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC (NON-PROFIT 501(C)(6))"
   },
@@ -30,7 +51,28 @@
   {
     "Filer_ID": "1385180",
     "Tran_Amt1": 100000.0,
+    "Tran_Date": "2016-06-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC (NON-PROFIT 501(C)(6))"
+  },
+  {
+    "Filer_ID": "1385180",
+    "Tran_Amt1": 100000.0,
     "Tran_Date": "2016-06-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC (NON-PROFIT 501(C)(6))"
+  },
+  {
+    "Filer_ID": "1385180",
+    "Tran_Amt1": 100000.0,
+    "Tran_Date": "2016-06-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC (NON-PROFIT 501(C)(6))"
+  },
+  {
+    "Filer_ID": "1385180",
+    "Tran_Amt1": 100000.0,
+    "Tran_Date": "2016-06-27",
     "Tran_NamF": null,
     "Tran_NamL": "AMERICAN BEVERAGE ASSOCIATION CALIFORNIA PAC (NON-PROFIT 501(C)(6))"
   },

--- a/build/committee/1386416/contributions/index.json
+++ b/build/committee/1386416/contributions/index.json
@@ -372,6 +372,13 @@
   },
   {
     "Filer_ID": "1386416",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-12-17",
+    "Tran_NamF": "Lauren",
+    "Tran_NamL": "Dutton"
+  },
+  {
+    "Filer_ID": "1386416",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2017-03-21",
     "Tran_NamF": "David",

--- a/build/committee/1387192/contributions/index.json
+++ b/build/committee/1387192/contributions/index.json
@@ -498,6 +498,13 @@
   },
   {
     "Filer_ID": "1387192",
+    "Tran_Amt1": 104.09,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Perla",
+    "Tran_NamL": "Rodriguez"
+  },
+  {
+    "Filer_ID": "1387192",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-28",
     "Tran_NamF": "Aida",

--- a/build/committee/1387983/contributions/index.json
+++ b/build/committee/1387983/contributions/index.json
@@ -330,6 +330,13 @@
   },
   {
     "Filer_ID": "1387983",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "CP VI Franklin, LLC"
+  },
+  {
+    "Filer_ID": "1387983",
     "Tran_Amt1": 2700.0,
     "Tran_Date": "2016-10-06",
     "Tran_NamF": null,
@@ -505,17 +512,17 @@
   },
   {
     "Filer_ID": "1387983",
-    "Tran_Amt1": 2000.0,
-    "Tran_Date": "2016-10-24",
-    "Tran_NamF": null,
-    "Tran_NamL": "BKF Engineers"
-  },
-  {
-    "Filer_ID": "1387983",
     "Tran_Amt1": 1500.0,
     "Tran_Date": "2016-10-24",
     "Tran_NamF": null,
     "Tran_NamL": "Beci Electric, Inc."
+  },
+  {
+    "Filer_ID": "1387983",
+    "Tran_Amt1": 2000.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "BKF Engineers"
   },
   {
     "Filer_ID": "1387983",

--- a/build/committee/1388168/contributions/index.json
+++ b/build/committee/1388168/contributions/index.json
@@ -15,10 +15,45 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-08",
+    "Tran_NamF": "Peggy",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-08-09",
     "Tran_NamF": "Greggory",
     "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Greggory",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-09",
+    "Tran_NamF": "Greggory",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "Alistair",
+    "Tran_NamL": "McElwee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-10",
+    "Tran_NamF": "Alistair",
+    "Tran_NamL": "McElwee"
   },
   {
     "Filer_ID": "1388168",
@@ -37,9 +72,44 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Libby",
+    "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-11",
+    "Tran_NamF": "Libby",
+    "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-08-17",
     "Tran_NamF": "John",
     "Tran_NamL": "Gooding"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Gooding"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-17",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Gooding"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Albracht"
   },
   {
     "Filer_ID": "1388168",
@@ -54,6 +124,34 @@
     "Tran_Date": "2016-08-19",
     "Tran_NamF": "Eric",
     "Tran_NamL": "Alexander"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Alexander"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Alexander"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Gwendolyn",
+    "Tran_NamL": "Booze"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Gwendolyn",
+    "Tran_NamL": "Booze"
   },
   {
     "Filer_ID": "1388168",
@@ -73,8 +171,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Danielle",
+    "Tran_NamL": "Dagostino"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Danielle",
+    "Tran_NamL": "Dagostino"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
     "Tran_NamF": "Sarah",
     "Tran_NamL": "Fine"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Fine"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Sarah",
+    "Tran_NamL": "Fine"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Gibbs"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Gibbs"
   },
   {
     "Filer_ID": "1388168",
@@ -99,10 +239,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Ashley",
+    "Tran_NamL": "Lautzenhiser"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Ashley",
+    "Tran_NamL": "Lautzenhiser"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-08-19",
     "Tran_NamF": "John",
     "Tran_NamL": "Nguyen-Cleary"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Nguyen-Cleary"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Nguyen-Cleary"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Pastena"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Pastena"
   },
   {
     "Filer_ID": "1388168",
@@ -121,9 +303,44 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-19",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-20",
     "Tran_NamF": "Karen",
     "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-20",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-20",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 95.0,
+    "Tran_Date": "2016-08-20",
+    "Tran_NamF": "Joanne",
+    "Tran_NamL": "Karchmer"
   },
   {
     "Filer_ID": "1388168",
@@ -145,6 +362,27 @@
     "Tran_Date": "2016-08-21",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Ablon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-08-21",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Ablon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Higgins"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-08-22",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Higgins"
   },
   {
     "Filer_ID": "1388168",
@@ -171,6 +409,34 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-08-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Klose Way Partners, LLC"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Klose Way Partners, LLC"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Moore"
   },
@@ -180,6 +446,34 @@
     "Tran_Date": "2016-08-23",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Murphy"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Murphy"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Murphy"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Rosalind",
+    "Tran_NamL": "Romney"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Rosalind",
+    "Tran_NamL": "Romney"
   },
   {
     "Filer_ID": "1388168",
@@ -199,8 +493,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-08-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sustainable Urban Neighborhoods"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sustainable Urban Neighborhoods"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
     "Tran_NamF": "Felinda",
     "Tran_NamL": "Tran"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Felinda",
+    "Tran_NamL": "Tran"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-23",
+    "Tran_NamF": "Felinda",
+    "Tran_NamL": "Tran"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Bellino"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Bellino"
   },
   {
     "Filer_ID": "1388168",
@@ -218,6 +554,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Carter"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-24",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Carter"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Lucia",
+    "Tran_NamL": "Capron"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Lucia",
+    "Tran_NamL": "Capron"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-08-26",
     "Tran_NamF": "Lucia",
@@ -229,6 +593,34 @@
     "Tran_Date": "2016-08-26",
     "Tran_NamF": "Dianne",
     "Tran_NamL": "Gregory"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Dianne",
+    "Tran_NamL": "Gregory"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Dianne",
+    "Tran_NamL": "Gregory"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Hawkins"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Hawkins"
   },
   {
     "Filer_ID": "1388168",
@@ -248,6 +640,34 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-26",
+    "Tran_NamF": "LaNiece",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "LaNiece",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Sam",
+    "Tran_NamL": "Kaspick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Sam",
+    "Tran_NamL": "Kaspick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
     "Tran_NamF": "Sam",
     "Tran_NamL": "Kaspick"
   },
@@ -257,6 +677,34 @@
     "Tran_Date": "2016-08-26",
     "Tran_NamF": "John",
     "Tran_NamL": "Protopappas"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Protopappas"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Protopappas"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Suzanne",
+    "Tran_NamL": "Rotondo"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Suzanne",
+    "Tran_NamL": "Rotondo"
   },
   {
     "Filer_ID": "1388168",
@@ -276,8 +724,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Brent",
+    "Tran_NamL": "Turner"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "Brent",
+    "Tran_NamL": "Turner"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
     "Tran_NamF": "James",
     "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-26",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Bair"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Bair"
   },
   {
     "Filer_ID": "1388168",
@@ -292,6 +782,34 @@
     "Tran_Date": "2016-08-30",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 180.0,
+    "Tran_Date": "2016-08-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Pahlka"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-08-31",
+    "Tran_NamF": "Jennifer",
+    "Tran_NamL": "Pahlka"
   },
   {
     "Filer_ID": "1388168",
@@ -317,9 +835,51 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-07",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-08",
     "Tran_NamF": "Miye",
     "Tran_NamL": "Takagi"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Miye",
+    "Tran_NamL": "Takagi"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-08",
+    "Tran_NamF": "Miye",
+    "Tran_NamL": "Takagi"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Gerber"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Gerber"
   },
   {
     "Filer_ID": "1388168",
@@ -338,9 +898,51 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-10",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-12",
     "Tran_NamF": "Heather",
     "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-12",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Buchanan"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Buchanan"
   },
   {
     "Filer_ID": "1388168",
@@ -358,10 +960,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "H",
+    "Tran_NamL": "Burg"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "H",
+    "Tran_NamL": "Burg"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": null,
     "Tran_NamL": "Campaign for Equality"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Campaign for Equality"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Campaign for Equality"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Coleman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Coleman"
   },
   {
     "Filer_ID": "1388168",
@@ -379,10 +1023,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Salvatore",
+    "Tran_NamL": "Fahey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Salvatore",
+    "Tran_NamL": "Fahey"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Brendalyn",
     "Tran_NamL": "Goodall"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Brendalyn",
+    "Tran_NamL": "Goodall"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Brendalyn",
+    "Tran_NamL": "Goodall"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Jill",
+    "Tran_NamL": "Habig"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Jill",
+    "Tran_NamL": "Habig"
   },
   {
     "Filer_ID": "1388168",
@@ -400,10 +1086,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Hinds"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Hinds"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Venus",
     "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Venus",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Venus",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Paula",
+    "Tran_NamL": "Kirlin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Paula",
+    "Tran_NamL": "Kirlin"
   },
   {
     "Filer_ID": "1388168",
@@ -430,8 +1158,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Gloria",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Gloria",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
     "Tran_NamF": "Anne",
     "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Sandy",
+    "Tran_NamL": "Mills"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Sandy",
+    "Tran_NamL": "Mills"
   },
   {
     "Filer_ID": "1388168",
@@ -456,6 +1226,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Amelia",
+    "Tran_NamL": "Paradise"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Amelia",
+    "Tran_NamL": "Paradise"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Pettit"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Pettit"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Alex",
@@ -467,6 +1265,34 @@
     "Tran_Date": "2016-09-13",
     "Tran_NamF": "Barbara",
     "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Schaaf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Wade Jarvis Construction"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "Wade Jarvis Construction"
   },
   {
     "Filer_ID": "1388168",
@@ -486,8 +1312,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Belle",
+    "Tran_NamL": "Cole"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Belle",
+    "Tran_NamL": "Cole"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Kerry",
+    "Tran_NamL": "Hamill"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Kerry",
+    "Tran_NamL": "Hamill"
   },
   {
     "Filer_ID": "1388168",
@@ -505,10 +1373,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Rosalind",
+    "Tran_NamL": "Romney"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Rosalind",
+    "Tran_NamL": "Romney"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-09-14",
     "Tran_NamF": "Kenneth",
     "Tran_NamL": "Schmier"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Schmier"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Schmier"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Tye"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-14",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Tye"
   },
   {
     "Filer_ID": "1388168",
@@ -528,8 +1438,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Core Security Solutions, Inc."
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "Core Security Solutions, Inc."
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
     "Tran_NamF": "J Blake",
     "Tran_NamL": "Johansen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "J Blake",
+    "Tran_NamL": "Johansen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "J Blake",
+    "Tran_NamL": "Johansen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Judith",
+    "Tran_NamL": "Johnson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-15",
+    "Tran_NamF": "Judith",
+    "Tran_NamL": "Johnson"
   },
   {
     "Filer_ID": "1388168",
@@ -547,6 +1499,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "M Kathleen",
+    "Tran_NamL": "Archambeau"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": "M Kathleen",
+    "Tran_NamL": "Archambeau"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bowers Consulting Firm"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-16",
+    "Tran_NamF": null,
+    "Tran_NamL": "Bowers Consulting Firm"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-16",
     "Tran_NamF": null,
@@ -558,6 +1538,34 @@
     "Tran_Date": "2016-09-17",
     "Tran_NamF": "James",
     "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Leslie",
+    "Tran_NamL": "Zimmerman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-17",
+    "Tran_NamF": "Leslie",
+    "Tran_NamL": "Zimmerman"
   },
   {
     "Filer_ID": "1388168",
@@ -577,8 +1585,43 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Marcy",
+    "Tran_NamL": "Adelman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Marcy",
+    "Tran_NamL": "Adelman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
     "Tran_NamF": "Toni",
     "Tran_NamL": "Broaddus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Toni",
+    "Tran_NamL": "Broaddus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Toni",
+    "Tran_NamL": "Broaddus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Davies"
   },
   {
     "Filer_ID": "1388168",
@@ -599,7 +1642,49 @@
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-19",
     "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Le Blanc"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Le Blanc"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Cynthia",
     "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Gwendolyn",
+    "Tran_NamL": "Mitchell"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Gwendolyn",
+    "Tran_NamL": "Mitchell"
   },
   {
     "Filer_ID": "1388168",
@@ -614,6 +1699,34 @@
     "Tran_Date": "2016-09-19",
     "Tran_NamF": null,
     "Tran_NamL": "Solomon Ets-Hokin, Inc."
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Solomon Ets-Hokin, Inc."
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": null,
+    "Tran_NamL": "Solomon Ets-Hokin, Inc."
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Janice",
+    "Tran_NamL": "Wells"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Janice",
+    "Tran_NamL": "Wells"
   },
   {
     "Filer_ID": "1388168",
@@ -638,10 +1751,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "JoAnn",
+    "Tran_NamL": "Yoshioka"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "JoAnn",
+    "Tran_NamL": "Yoshioka"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-09-19",
     "Tran_NamF": "Andrea",
     "Tran_NamL": "Youngdahl"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Andrea",
+    "Tran_NamL": "Youngdahl"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-19",
+    "Tran_NamF": "Andrea",
+    "Tran_NamL": "Youngdahl"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Almsteier"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Amy",
+    "Tran_NamL": "Almsteier"
   },
   {
     "Filer_ID": "1388168",
@@ -661,8 +1816,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Salwa",
+    "Tran_NamL": "Ibrahim"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Salwa",
+    "Tran_NamL": "Ibrahim"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
     "Tran_NamF": "Martin",
     "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Martin",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Martin",
+    "Tran_NamL": "Kaufman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Peterson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-20",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Peterson"
   },
   {
     "Filer_ID": "1388168",
@@ -680,10 +1877,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Lucia",
+    "Tran_NamL": "Capron"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Lucia",
+    "Tran_NamL": "Capron"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 152.0,
     "Tran_Date": "2016-09-21",
     "Tran_NamF": "Donald",
     "Tran_NamL": "Fowler"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 152.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Donald",
+    "Tran_NamL": "Fowler"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 152.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Donald",
+    "Tran_NamL": "Fowler"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
   },
   {
     "Filer_ID": "1388168",
@@ -701,10 +1940,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Nahass"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-21",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Nahass"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-09-22",
     "Tran_NamF": "Sue",
     "Tran_NamL": "Davies"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Davies"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Davies"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Lyman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Lyman"
   },
   {
     "Filer_ID": "1388168",
@@ -724,8 +2005,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
     "Tran_NamF": "Kathleen",
     "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Kathleen",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "Kathleen",
+    "Tran_NamL": "Rogers"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-22",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Wood"
   },
   {
     "Filer_ID": "1388168",
@@ -745,8 +2068,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Lee",
+    "Tran_NamL": "Aurich"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Lee",
+    "Tran_NamL": "Aurich"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
     "Tran_NamF": "Bruce",
     "Tran_NamL": "Beasley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Beasley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Beasley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Laurie",
+    "Tran_NamL": "Capitelli"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Laurie",
+    "Tran_NamL": "Capitelli"
   },
   {
     "Filer_ID": "1388168",
@@ -766,8 +2131,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Benajmin",
+    "Tran_NamL": "Fay"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Benajmin",
+    "Tran_NamL": "Fay"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
     "Tran_NamF": "David",
     "Tran_NamL": "Fritz"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Fritz"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Fritz"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Raich"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Raich"
   },
   {
     "Filer_ID": "1388168",
@@ -785,10 +2192,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Story"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Story"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-09-23",
     "Tran_NamF": "Carolyn",
     "Tran_NamL": "Tawasha"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Tawasha"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Tawasha"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Wacker"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-23",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Wacker"
   },
   {
     "Filer_ID": "1388168",
@@ -806,10 +2255,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Albracht"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Albracht"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Kenneth",
     "Tran_NamL": "Benson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Benson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Benson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Betterton"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Betterton"
   },
   {
     "Filer_ID": "1388168",
@@ -827,10 +2318,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Clarinda",
     "Tran_NamL": "Cannon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Clarinda",
+    "Tran_NamL": "Cannon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Clarinda",
+    "Tran_NamL": "Cannon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Cindy",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Cindy",
+    "Tran_NamL": "Chavez"
   },
   {
     "Filer_ID": "1388168",
@@ -848,10 +2381,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Colbruno"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Colbruno"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Regina",
     "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Regina",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Regina",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Abdul",
+    "Tran_NamL": "El-Amin Luqman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Abdul",
+    "Tran_NamL": "El-Amin Luqman"
   },
   {
     "Filer_ID": "1388168",
@@ -869,10 +2444,45 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 400.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Friedman"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": null,
     "Tran_NamL": "Gabriel Quinto for El Cerrito City Council 2014"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Gabriel Quinto for El Cerrito City Council 2014"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "Gabriel Quinto for El Cerrito City Council 2014"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 60.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
   },
   {
     "Filer_ID": "1388168",
@@ -890,10 +2500,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Brendalyn",
+    "Tran_NamL": "Goodall"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Brendalyn",
+    "Tran_NamL": "Goodall"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Charlette",
     "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Charlette",
+    "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Charlette",
+    "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Hinds"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Hinds"
   },
   {
     "Filer_ID": "1388168",
@@ -911,10 +2563,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Joanne",
+    "Tran_NamL": "Karchmer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Joanne",
+    "Tran_NamL": "Karchmer"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Christopher",
     "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Levy"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Levy"
   },
   {
     "Filer_ID": "1388168",
@@ -932,10 +2626,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Magana"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Magana"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Elmoraa",
     "Tran_NamL": "Magucha-Bey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Elmoraa",
+    "Tran_NamL": "Magucha-Bey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Elmoraa",
+    "Tran_NamL": "Magucha-Bey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Monchamp"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Monchamp"
   },
   {
     "Filer_ID": "1388168",
@@ -953,6 +2689,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Bonnie",
+    "Tran_NamL": "Moran"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Bonnie",
+    "Tran_NamL": "Moran"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Anita",
+    "Tran_NamL": "Ramanathan"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Anita",
+    "Tran_NamL": "Ramanathan"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Anita",
@@ -964,6 +2728,34 @@
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Rasmussen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Rasmussen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Rasmussen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Mary Jane",
+    "Tran_NamL": "Ricciardulli"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Mary Jane",
+    "Tran_NamL": "Ricciardulli"
   },
   {
     "Filer_ID": "1388168",
@@ -983,8 +2775,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kerry Jo",
+    "Tran_NamL": "Ricketts"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kerry Jo",
+    "Tran_NamL": "Ricketts"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Schock"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Schock"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Schock"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Franklin",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Franklin",
+    "Tran_NamL": "Silver"
   },
   {
     "Filer_ID": "1388168",
@@ -1004,8 +2838,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Rachel",
+    "Tran_NamL": "Sklar"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Rachel",
+    "Tran_NamL": "Sklar"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Sileshi Sam",
     "Tran_NamL": "Tadesse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sileshi Sam",
+    "Tran_NamL": "Tadesse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Sileshi Sam",
+    "Tran_NamL": "Tadesse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "The Inn at Jack London Square"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": null,
+    "Tran_NamL": "The Inn at Jack London Square"
   },
   {
     "Filer_ID": "1388168",
@@ -1023,10 +2899,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Valdez"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Valdez"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-24",
     "Tran_NamF": "Regina",
     "Tran_NamL": "Wallace-Jones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Regina",
+    "Tran_NamL": "Wallace-Jones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Regina",
+    "Tran_NamL": "Wallace-Jones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kathleen D.",
+    "Tran_NamL": "Wimberly"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Kathleen D.",
+    "Tran_NamL": "Wimberly"
   },
   {
     "Filer_ID": "1388168",
@@ -1053,8 +2971,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Pauline",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Pauline",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
     "Tran_NamF": "Terri",
     "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Terri",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Terri",
+    "Tran_NamL": "Witriol"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Ken",
+    "Tran_NamL": "Yamaguchi"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-24",
+    "Tran_NamF": "Ken",
+    "Tran_NamL": "Yamaguchi"
   },
   {
     "Filer_ID": "1388168",
@@ -1069,6 +3029,34 @@
     "Tran_Date": "2016-09-25",
     "Tran_NamF": "Rosalind",
     "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Rosalind",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Rosalind",
+    "Tran_NamL": "Barnett"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Leigh",
+    "Tran_NamL": "Morgan"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Leigh",
+    "Tran_NamL": "Morgan"
   },
   {
     "Filer_ID": "1388168",
@@ -1088,8 +3076,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Alexandra",
+    "Tran_NamL": "Snow Thede"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Alexandra",
+    "Tran_NamL": "Snow Thede"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-25",
     "Tran_NamF": "Chris",
     "Tran_NamL": "Thede"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Thede"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-25",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Thede"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Carol",
+    "Tran_NamL": "Beck"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Carol",
+    "Tran_NamL": "Beck"
   },
   {
     "Filer_ID": "1388168",
@@ -1107,10 +3137,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Gail",
+    "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Gail",
+    "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-26",
     "Tran_NamF": "Terrance",
     "Tran_NamL": "Lim"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Terrance",
+    "Tran_NamL": "Lim"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Terrance",
+    "Tran_NamL": "Lim"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Laurel",
+    "Tran_NamL": "March"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "Laurel",
+    "Tran_NamL": "March"
   },
   {
     "Filer_ID": "1388168",
@@ -1128,6 +3200,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Nemechek"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-26",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Nemechek"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Catherine",
+    "Tran_NamL": "Bracy"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Catherine",
+    "Tran_NamL": "Bracy"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-09-27",
     "Tran_NamF": "Catherine",
@@ -1142,10 +3242,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Giselle",
+    "Tran_NamL": "Hale"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Giselle",
+    "Tran_NamL": "Hale"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-09-27",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Spencer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Spencer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Spencer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Buffy",
+    "Tran_NamL": "Wicks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "Buffy",
+    "Tran_NamL": "Wicks"
   },
   {
     "Filer_ID": "1388168",
@@ -1165,8 +3307,43 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Al",
+    "Tran_NamL": "Aluetta"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Al",
+    "Tran_NamL": "Aluetta"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
     "Tran_NamF": "Jacqueline",
     "Tran_NamL": "Noguera"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Jacqueline",
+    "Tran_NamL": "Noguera"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Jacqueline",
+    "Tran_NamL": "Noguera"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 240.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": "Shirley",
+    "Tran_NamL": "Remirez"
   },
   {
     "Filer_ID": "1388168",
@@ -1181,6 +3358,34 @@
     "Tran_Date": "2016-09-29",
     "Tran_NamF": "Eric",
     "Tran_NamL": "Ullman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Ullman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-29",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Ullman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Debbie",
+    "Tran_NamL": "Foster"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-09-30",
+    "Tran_NamF": "Debbie",
+    "Tran_NamL": "Foster"
   },
   {
     "Filer_ID": "1388168",
@@ -1205,10 +3410,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Lenoir"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-03",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Lenoir"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 150.0,
     "Tran_Date": "2016-10-04",
     "Tran_NamF": "Greggory",
     "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Greggory",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Greggory",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Carmen",
+    "Tran_NamL": "Murray"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Carmen",
+    "Tran_NamL": "Murray"
   },
   {
     "Filer_ID": "1388168",
@@ -1226,10 +3473,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Nahas"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Nahas"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-04",
     "Tran_NamF": "Deborah",
     "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Deborah",
+    "Tran_NamL": "Taylor"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Lisbet",
+    "Tran_NamL": "Tellefsen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-04",
+    "Tran_NamF": "Lisbet",
+    "Tran_NamL": "Tellefsen"
   },
   {
     "Filer_ID": "1388168",
@@ -1249,8 +3538,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Dockendorff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Dockendorff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
     "Tran_NamF": "Amanda",
     "Tran_NamL": "Feinstein"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Feinstein"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Feinstein"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Francis"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Francis"
   },
   {
     "Filer_ID": "1388168",
@@ -1268,6 +3599,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Stroup"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-05",
+    "Tran_NamF": "Ruth",
+    "Tran_NamL": "Stroup"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "M Kathleen",
+    "Tran_NamL": "Archambeau"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "M Kathleen",
+    "Tran_NamL": "Archambeau"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-10-06",
     "Tran_NamF": "M Kathleen",
@@ -1279,6 +3638,34 @@
     "Tran_Date": "2016-10-06",
     "Tran_NamF": "Angelina",
     "Tran_NamL": "Burnett"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Angelina",
+    "Tran_NamL": "Burnett"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Angelina",
+    "Tran_NamL": "Burnett"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Raymond",
+    "Tran_NamL": "Lankford"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Raymond",
+    "Tran_NamL": "Lankford"
   },
   {
     "Filer_ID": "1388168",
@@ -1304,9 +3691,51 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Thompson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-06",
+    "Tran_NamF": "Pamela",
+    "Tran_NamL": "Thompson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-07",
     "Tran_NamF": "Nancy",
     "Tran_NamL": "Baglietto"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Baglietto"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Nancy",
+    "Tran_NamL": "Baglietto"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Beverly",
+    "Tran_NamL": "Bueno"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Beverly",
+    "Tran_NamL": "Bueno"
   },
   {
     "Filer_ID": "1388168",
@@ -1324,6 +3753,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Cook"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Cook"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Bill",
+    "Tran_NamL": "Dickey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Bill",
+    "Tran_NamL": "Dickey"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-10-07",
     "Tran_NamF": "Bill",
@@ -1335,6 +3792,34 @@
     "Tran_Date": "2016-10-07",
     "Tran_NamF": "Heather",
     "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Quintal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Transport Oakland"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 1500.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Transport Oakland"
   },
   {
     "Filer_ID": "1388168",
@@ -1354,6 +3839,34 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Berley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Berley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Kopec"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Kopec"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-09",
     "Tran_NamF": "Cynthia",
     "Tran_NamL": "Kopec"
   },
@@ -1368,8 +3881,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Missy",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Missy",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
     "Tran_NamF": "Diane",
     "Tran_NamL": "Sickmen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Sickmen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Diane",
+    "Tran_NamL": "Sickmen"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Zee",
+    "Tran_NamL": "Wong"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-09",
+    "Tran_NamF": "Zee",
+    "Tran_NamL": "Wong"
   },
   {
     "Filer_ID": "1388168",
@@ -1394,6 +3949,27 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Drew",
+    "Tran_NamL": "Aversa"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Drew",
+    "Tran_NamL": "Aversa"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 72.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Geller"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 72.0,
     "Tran_Date": "2016-10-11",
     "Tran_NamF": "Brian",
@@ -1405,6 +3981,34 @@
     "Tran_Date": "2016-10-11",
     "Tran_NamF": "Vincent",
     "Tran_NamL": "Leung"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Vincent",
+    "Tran_NamL": "Leung"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Vincent",
+    "Tran_NamL": "Leung"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Newsome"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Newsome"
   },
   {
     "Filer_ID": "1388168",
@@ -1423,6 +4027,34 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Averell",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-11",
+    "Tran_NamF": "Averell",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Francisco",
+    "Tran_NamL": "Devries"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Francisco",
+    "Tran_NamL": "Devries"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-12",
     "Tran_NamF": "Francisco",
     "Tran_NamL": "Devries"
@@ -1433,6 +4065,34 @@
     "Tran_Date": "2016-10-12",
     "Tran_NamF": null,
     "Tran_NamL": "Elwood Commercial Real Estate"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Elwood Commercial Real Estate"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Elwood Commercial Real Estate"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Flaxman"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Flaxman"
   },
   {
     "Filer_ID": "1388168",
@@ -1452,8 +4112,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Earl",
+    "Tran_NamL": "Hamlin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Earl",
+    "Tran_NamL": "Hamlin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
     "Tran_NamF": "Seth",
     "Tran_NamL": "Jacobson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Seth",
+    "Tran_NamL": "Jacobson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Seth",
+    "Tran_NamL": "Jacobson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Jay-Phares Corporation"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": null,
+    "Tran_NamL": "Jay-Phares Corporation"
   },
   {
     "Filer_ID": "1388168",
@@ -1471,6 +4173,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Knutson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Knutson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "MK Sebree"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "MK Sebree"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 500.0,
     "Tran_Date": "2016-10-12",
     "Tran_NamF": "Michael",
@@ -1482,6 +4212,34 @@
     "Tran_Date": "2016-10-12",
     "Tran_NamF": "Lorna",
     "Tran_NamL": "Padia-Markus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Lorna",
+    "Tran_NamL": "Padia-Markus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Lorna",
+    "Tran_NamL": "Padia-Markus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Zahas"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-12",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Zahas"
   },
   {
     "Filer_ID": "1388168",
@@ -1501,6 +4259,34 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Mixon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Mixon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Lupe",
+    "Tran_NamL": "Schoenberger"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": "Lupe",
+    "Tran_NamL": "Schoenberger"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-13",
     "Tran_NamF": "Lupe",
     "Tran_NamL": "Schoenberger"
   },
@@ -1510,6 +4296,27 @@
     "Tran_Date": "2016-10-14",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Power"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Power"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-14",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Power"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 31.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Abdul",
+    "Tran_NamL": "El-Amin Luqman"
   },
   {
     "Filer_ID": "1388168",
@@ -1529,7 +4336,49 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Ernest",
+    "Tran_NamL": "Graves"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Ernest",
+    "Tran_NamL": "Graves"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
     "Tran_NamF": "David",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Elizabeth",
+    "Tran_NamL": "Silver"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Elizabeth",
     "Tran_NamL": "Silver"
   },
   {
@@ -1548,6 +4397,27 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Wendell",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-15",
+    "Tran_NamF": "Wendell",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 50.0,
+    "Tran_Date": "2016-10-16",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Lewis"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 50.0,
     "Tran_Date": "2016-10-16",
     "Tran_NamF": "Barbara",
@@ -1559,6 +4429,34 @@
     "Tran_Date": "2016-10-17",
     "Tran_NamF": "Karen",
     "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Bovarnick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Patti",
+    "Tran_NamL": "Haladay"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Patti",
+    "Tran_NamL": "Haladay"
   },
   {
     "Filer_ID": "1388168",
@@ -1578,8 +4476,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Dana",
+    "Tran_NamL": "Hughes"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Dana",
+    "Tran_NamL": "Hughes"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
     "Tran_NamF": "Donna",
     "Tran_NamL": "Korones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Donna",
+    "Tran_NamL": "Korones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Donna",
+    "Tran_NamL": "Korones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Lewis"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Lewis"
   },
   {
     "Filer_ID": "1388168",
@@ -1597,6 +4537,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Jody",
+    "Tran_NamL": "London"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Jody",
+    "Tran_NamL": "London"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Price"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Price"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-17",
     "Tran_NamF": "Barbara",
@@ -1608,6 +4576,34 @@
     "Tran_Date": "2016-10-17",
     "Tran_NamF": "Eugene",
     "Tran_NamL": "Stevens"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Stevens"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Eugene",
+    "Tran_NamL": "Stevens"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Adrienne",
+    "Tran_NamL": "Yank"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-17",
+    "Tran_NamF": "Adrienne",
+    "Tran_NamL": "Yank"
   },
   {
     "Filer_ID": "1388168",
@@ -1634,8 +4630,50 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Emily",
+    "Tran_NamL": "Rosenberg"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Emily",
+    "Tran_NamL": "Rosenberg"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
     "Tran_NamF": "Cynthia",
     "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Cynthia",
+    "Tran_NamL": "Wood"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Zoloth"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-18",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "Zoloth"
   },
   {
     "Filer_ID": "1388168",
@@ -1650,6 +4688,34 @@
     "Tran_Date": "2016-10-20",
     "Tran_NamF": "Ellen",
     "Tran_NamL": "Gierson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Ellen",
+    "Tran_NamL": "Gierson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Ellen",
+    "Tran_NamL": "Gierson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Alejandro",
+    "Tran_NamL": "Illidge"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Alejandro",
+    "Tran_NamL": "Illidge"
   },
   {
     "Filer_ID": "1388168",
@@ -1674,6 +4740,34 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Soltanovich"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Soltanovich"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Adam"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Margaret",
+    "Tran_NamL": "Adam"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-10-21",
     "Tran_NamF": "Margaret",
@@ -1688,10 +4782,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 120.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Karen",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-21",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Emerick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Emerick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Emerick"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Natalie",
+    "Tran_NamL": "Foster"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Natalie",
+    "Tran_NamL": "Foster"
   },
   {
     "Filer_ID": "1388168",
@@ -1716,10 +4852,45 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 745.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Peggy",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-21",
     "Tran_NamF": "Marie",
     "Tran_NamL": "Riehle"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Marie",
+    "Tran_NamL": "Riehle"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Marie",
+    "Tran_NamL": "Riehle"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Tillery"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 600.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Linda",
+    "Tran_NamL": "Tillery"
   },
   {
     "Filer_ID": "1388168",
@@ -1737,10 +4908,45 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Angela",
+    "Tran_NamL": "Tsay"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Angela",
+    "Tran_NamL": "Tsay"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-21",
     "Tran_NamF": "Buffy",
     "Tran_NamL": "Wicks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Buffy",
+    "Tran_NamL": "Wicks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Buffy",
+    "Tran_NamL": "Wicks"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 20.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Colette",
+    "Tran_NamL": "Winlock"
   },
   {
     "Filer_ID": "1388168",
@@ -1758,10 +4964,52 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Caryn",
+    "Tran_NamL": "Wolf"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-21",
+    "Tran_NamF": "Caryn",
+    "Tran_NamL": "Wolf"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-10-22",
     "Tran_NamF": "Francine",
     "Tran_NamL": "Anthony"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Francine",
+    "Tran_NamL": "Anthony"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Francine",
+    "Tran_NamL": "Anthony"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bailey"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bailey"
   },
   {
     "Filer_ID": "1388168",
@@ -1779,6 +5027,27 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "A. Freeman",
+    "Tran_NamL": "Bradley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Cindy",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Cindy",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-10-22",
     "Tran_NamF": "Cindy",
@@ -1790,6 +5059,34 @@
     "Tran_Date": "2016-10-22",
     "Tran_NamF": "Gary",
     "Tran_NamL": "Durbin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Durbin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Durbin"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Littleton Consulting Group"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Littleton Consulting Group"
   },
   {
     "Filer_ID": "1388168",
@@ -1808,9 +5105,37 @@
   {
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Marti",
+    "Tran_NamL": "Paschal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-22",
+    "Tran_NamF": "Marti",
+    "Tran_NamL": "Paschal"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-23",
     "Tran_NamF": "Nicole",
     "Tran_NamL": "Derse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Nicole",
+    "Tran_NamL": "Derse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Andres",
+    "Tran_NamL": "Garcia-Price"
   },
   {
     "Filer_ID": "1388168",
@@ -1828,10 +5153,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-23",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Padnos"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-24",
     "Tran_NamF": "Irma",
     "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Irma",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Beda"
   },
   {
     "Filer_ID": "1388168",
@@ -1849,10 +5195,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Dwin"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-24",
     "Tran_NamF": "Tom",
     "Tran_NamL": "Juenger"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Tom",
+    "Tran_NamL": "Juenger"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Karchmer"
   },
   {
     "Filer_ID": "1388168",
@@ -1870,10 +5237,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Patricia",
+    "Tran_NamL": "Kernighan"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-24",
     "Tran_NamF": "Michael",
     "Tran_NamL": "LaHorgue"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "LaHorgue"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Barbara",
+    "Tran_NamL": "MacKinnon"
   },
   {
     "Filer_ID": "1388168",
@@ -1893,8 +5281,29 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Rick",
+    "Tran_NamL": "Mariano"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": "Dennis",
     "Tran_NamL": "Markus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Markus"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "Wade"
   },
   {
     "Filer_ID": "1388168",
@@ -1921,7 +5330,28 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Max",
+    "Tran_NamL": "Zeff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
     "Tran_NamF": "Ron",
+    "Tran_NamL": "Zeff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Ron",
+    "Tran_NamL": "Zeff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-24",
+    "Tran_NamF": "Zachary",
     "Tran_NamL": "Zeff"
   },
   {
@@ -1937,6 +5367,20 @@
     "Tran_Date": "2016-10-25",
     "Tran_NamF": "Greg",
     "Tran_NamL": "Christopher"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "Christopher"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Garibaldi"
   },
   {
     "Filer_ID": "1388168",
@@ -1956,8 +5400,29 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Haley"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
     "Tran_NamF": "Sue",
     "Tran_NamL": "Hamill"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Sue",
+    "Tran_NamL": "Hamill"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Anne",
+    "Tran_NamL": "Jensen"
   },
   {
     "Filer_ID": "1388168",
@@ -1975,6 +5440,20 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "LaNiece",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-25",
     "Tran_NamF": "Christopher",
@@ -1989,10 +5468,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Kopff"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-25",
     "Tran_NamF": "Greg",
     "Tran_NamL": "Pasquali"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-25",
+    "Tran_NamF": "Greg",
+    "Tran_NamL": "Pasquali"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Bliss"
   },
   {
     "Filer_ID": "1388168",
@@ -2024,10 +5524,10 @@
   },
   {
     "Filer_ID": "1388168",
-    "Tran_Amt1": 700.0,
+    "Tran_Amt1": 250.0,
     "Tran_Date": "2016-10-26",
-    "Tran_NamF": null,
-    "Tran_NamL": "PMACC"
+    "Tran_NamF": "Dana",
+    "Tran_NamL": "Parry"
   },
   {
     "Filer_ID": "1388168",
@@ -2035,6 +5535,27 @@
     "Tran_Date": "2016-10-26",
     "Tran_NamF": "Dana",
     "Tran_NamL": "Parry"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "PMACC"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": null,
+    "Tran_NamL": "PMACC"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 350.0,
+    "Tran_Date": "2016-10-26",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Wood"
   },
   {
     "Filer_ID": "1388168",
@@ -2052,10 +5573,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-27",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "MacIntyre"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-10-28",
     "Tran_NamF": "Amanda",
     "Tran_NamL": "Brown-Stevens"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Brown-Stevens"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Caron",
+    "Tran_NamL": "Ewing"
   },
   {
     "Filer_ID": "1388168",
@@ -2089,8 +5631,29 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Julius",
+    "Tran_NamL": "Perkins"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
     "Tran_NamF": "Sheila",
     "Tran_NamL": "Wells"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-10-28",
+    "Tran_NamF": "Sheila",
+    "Tran_NamL": "Wells"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-29",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Benson"
   },
   {
     "Filer_ID": "1388168",
@@ -2108,10 +5671,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Brownlow"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 1400.0,
     "Tran_Date": "2016-10-31",
     "Tran_NamF": null,
     "Tran_NamL": "East Bay Rental Housing Association PAC"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": null,
+    "Tran_NamL": "East Bay Rental Housing Association PAC"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Carolyn",
+    "Tran_NamL": "Fowler"
   },
   {
     "Filer_ID": "1388168",
@@ -2136,6 +5720,20 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Phillips"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-10-31",
+    "Tran_NamF": "Mary Jayne",
+    "Tran_NamL": "Sims"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-10-31",
     "Tran_NamF": "Mary Jayne",
@@ -2157,6 +5755,20 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-01",
+    "Tran_NamF": "Philippa",
+    "Tran_NamL": "Jubelirer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-02",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Schock"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-11-02",
     "Tran_NamF": "Robert",
@@ -2168,6 +5780,13 @@
     "Tran_Date": "2016-11-03",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Ablon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Peter",
+    "Tran_NamL": "Benvenutti"
   },
   {
     "Filer_ID": "1388168",
@@ -2199,6 +5818,20 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Suzanne",
+    "Tran_NamL": "Furrer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Kidd"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-11-03",
     "Tran_NamF": "Robert",
@@ -2213,10 +5846,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Megan",
+    "Tran_NamL": "Morrow"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-11-03",
     "Tran_NamF": "Jenny",
     "Tran_NamL": "Ong"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Jenny",
+    "Tran_NamL": "Ong"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-03",
+    "Tran_NamF": "Giovanna",
+    "Tran_NamL": "Tanzillo"
   },
   {
     "Filer_ID": "1388168",
@@ -2241,10 +5895,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 450.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Albracht"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-05",
     "Tran_NamF": "Sandra",
     "Tran_NamL": "Cook"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Sandra",
+    "Tran_NamL": "Cook"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Feinstein"
   },
   {
     "Filer_ID": "1388168",
@@ -2264,8 +5939,29 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Freiberg"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
     "Tran_NamF": "Janet",
     "Tran_NamL": "Glasgow"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Janet",
+    "Tran_NamL": "Glasgow"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Robinne",
+    "Tran_NamL": "Lee"
   },
   {
     "Filer_ID": "1388168",
@@ -2290,10 +5986,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Carmen",
+    "Tran_NamL": "Murray"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-11-05",
     "Tran_NamF": "Jim",
     "Tran_NamL": "Ratliff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Jim",
+    "Tran_NamL": "Ratliff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Veronica",
+    "Tran_NamL": "Sanders"
   },
   {
     "Filer_ID": "1388168",
@@ -2311,10 +6028,24 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-05",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Ullman"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.31,
     "Tran_Date": "2016-11-06",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Ablon"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Liz",
+    "Tran_NamL": "Brisson"
   },
   {
     "Filer_ID": "1388168",
@@ -2346,6 +6077,13 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Jacqueline",
+    "Tran_NamL": "Phillips"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-11-06",
     "Tran_NamF": "Liz",
@@ -2357,6 +6095,20 @@
     "Tran_Date": "2016-11-06",
     "Tran_NamF": "Lang",
     "Tran_NamL": "Scoble"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Lang",
+    "Tran_NamL": "Scoble"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Tidrick"
   },
   {
     "Filer_ID": "1388168",
@@ -2376,8 +6128,29 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Tod",
+    "Tran_NamL": "Vedock"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
     "Tran_NamF": "Katharine",
     "Tran_NamL": "Wulff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-06",
+    "Tran_NamF": "Katharine",
+    "Tran_NamL": "Wulff"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Sophia",
+    "Tran_NamL": "Bereket"
   },
   {
     "Filer_ID": "1388168",
@@ -2391,6 +6164,20 @@
     "Tran_Amt1": 300.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Miriam",
+    "Tran_NamL": "Bereket-Ab"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Miriam",
+    "Tran_NamL": "Bereket-Ab"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Natnael",
     "Tran_NamL": "Bereket-Ab"
   },
   {
@@ -2409,10 +6196,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Woinshet",
+    "Tran_NamL": "Daba"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Mulmebet",
     "Tran_NamL": "Geldo Challa"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Mulmebet",
+    "Tran_NamL": "Geldo Challa"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Yilma",
+    "Tran_NamL": "Hailemichael"
   },
   {
     "Filer_ID": "1388168",
@@ -2432,8 +6240,29 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Tsedenya",
+    "Tran_NamL": "Lakew"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-07",
     "Tran_NamF": "Seble",
     "Tran_NamL": "Legesse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Seble",
+    "Tran_NamL": "Legesse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 300.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Behailu",
+    "Tran_NamL": "Mekbib"
   },
   {
     "Filer_ID": "1388168",
@@ -2465,9 +6294,30 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Ron",
+    "Tran_NamL": "Rosequist"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Getachew",
+    "Tran_NamL": "Tadesse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Getachew",
+    "Tran_NamL": "Tadesse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Konjit",
     "Tran_NamL": "Tadesse"
   },
   {
@@ -2486,10 +6336,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Legesse",
+    "Tran_NamL": "Woldemariam"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-07",
     "Tran_NamF": "Asrat",
     "Tran_NamL": "Yigeza"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-07",
+    "Tran_NamF": "Asrat",
+    "Tran_NamL": "Yigeza"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 500.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Yared",
+    "Tran_NamL": "Feleke"
   },
   {
     "Filer_ID": "1388168",
@@ -2509,6 +6380,20 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 100.0,
     "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Messay",
+    "Tran_NamL": "Gima"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Bruck",
+    "Tran_NamL": "Girmay"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-11-08",
     "Tran_NamF": "Bruck",
     "Tran_NamL": "Girmay"
   },
@@ -2523,8 +6408,29 @@
     "Filer_ID": "1388168",
     "Tran_Amt1": 200.0,
     "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Selamawit",
+    "Tran_NamL": "Legesse"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-08",
     "Tran_NamF": "Joan",
     "Tran_NamL": "Van Horn"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 200.0,
+    "Tran_Date": "2016-11-08",
+    "Tran_NamF": "Joan",
+    "Tran_NamL": "Van Horn"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-11-11",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Lowe"
   },
   {
     "Filer_ID": "1388168",
@@ -2556,10 +6462,31 @@
   },
   {
     "Filer_ID": "1388168",
+    "Tran_Amt1": 1400.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": null,
+    "Tran_NamL": "California Real Estate PAC"
+  },
+  {
+    "Filer_ID": "1388168",
     "Tran_Amt1": 700.0,
     "Tran_Date": "2016-11-15",
     "Tran_NamF": "George",
     "Tran_NamL": "Zimmer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 700.0,
+    "Tran_Date": "2016-11-15",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Zimmer"
+  },
+  {
+    "Filer_ID": "1388168",
+    "Tran_Amt1": 100.0,
+    "Tran_Date": "2016-12-01",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Brownlow"
   },
   {
     "Filer_ID": "1388168",

--- a/build/committee/1388641/contributions/index.json
+++ b/build/committee/1388641/contributions/index.json
@@ -295,10 +295,10 @@
   },
   {
     "Filer_ID": "1388641",
-    "Tran_Amt1": 250.0,
-    "Tran_Date": "2016-09-28",
-    "Tran_NamF": null,
-    "Tran_NamL": "Raphael & associates"
+    "Tran_Amt1": 150.0,
+    "Tran_Date": "2016-09-27",
+    "Tran_NamF": "art",
+    "Tran_NamL": "may"
   },
   {
     "Filer_ID": "1388641",
@@ -320,6 +320,13 @@
     "Tran_Date": "2016-09-28",
     "Tran_NamF": "robert",
     "Tran_NamL": "raich"
+  },
+  {
+    "Filer_ID": "1388641",
+    "Tran_Amt1": 250.0,
+    "Tran_Date": "2016-09-28",
+    "Tran_NamF": null,
+    "Tran_NamL": "Raphael & associates"
   },
   {
     "Filer_ID": "1388641",

--- a/build/committee/1391606/contributions/index.json
+++ b/build/committee/1391606/contributions/index.json
@@ -99,6 +99,13 @@
   },
   {
     "Filer_ID": "1391606",
+    "Tran_Amt1": 1000.0,
+    "Tran_Date": "2016-11-14",
+    "Tran_NamF": null,
+    "Tran_NamL": "Lapham Company 1P"
+  },
+  {
+    "Filer_ID": "1391606",
     "Tran_Amt1": 1172.0,
     "Tran_Date": "2017-03-13",
     "Tran_NamF": null,

--- a/build/committee/892160/contributions/index.json
+++ b/build/committee/892160/contributions/index.json
@@ -10,8 +10,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
     "Tran_NamF": "Bruno",
     "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
   },
   {
     "Filer_ID": "892160",
@@ -31,8 +52,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
   },
   {
     "Filer_ID": "892160",
@@ -52,8 +94,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-01-08",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -73,8 +136,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -94,8 +178,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -115,6 +220,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-01-08",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Murphree"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Murphree"
   },
@@ -124,6 +243,20 @@
     "Tran_Date": "2015-01-08",
     "Tran_NamF": "Chad",
     "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-08",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -143,8 +276,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-01-14",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
   },
   {
     "Filer_ID": "892160",
@@ -164,8 +318,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-01-14",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
     "Tran_NamF": "Jerome",
     "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -185,6 +360,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-01-14",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
     "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
   },
@@ -194,6 +383,20 @@
     "Tran_Date": "2015-01-14",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-01-14",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -213,8 +416,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
     "Tran_NamF": "Bruno",
     "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
   },
   {
     "Filer_ID": "892160",
@@ -234,8 +458,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
   },
   {
     "Filer_ID": "892160",
@@ -255,8 +500,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-05",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -276,8 +542,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -297,8 +584,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -318,6 +626,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-05",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Murphree"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Murphree"
   },
@@ -327,6 +649,20 @@
     "Tran_Date": "2015-02-05",
     "Tran_NamF": "Chad",
     "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-05",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -346,6 +682,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-13",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-13",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-13",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
   },
@@ -355,6 +705,20 @@
     "Tran_Date": "2015-02-13",
     "Tran_NamF": "Dennis",
     "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-13",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-13",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
   },
   {
     "Filer_ID": "892160",
@@ -381,6 +745,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-13",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-13",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-13",
     "Tran_NamF": "James",
     "Tran_NamL": "Gundlach"
   },
@@ -395,8 +773,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-13",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-13",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-13",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-13",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -416,6 +815,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-26",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-26",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-26",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
   },
@@ -425,6 +838,20 @@
     "Tran_Date": "2015-02-26",
     "Tran_NamF": "Dennis",
     "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-26",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-26",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
   },
   {
     "Filer_ID": "892160",
@@ -451,6 +878,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-26",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-26",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-26",
     "Tran_NamF": "James",
     "Tran_NamL": "Gundlach"
   },
@@ -465,8 +906,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-02-26",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-26",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-26",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-02-26",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -500,8 +962,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
     "Tran_NamF": "Bruno",
     "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
   },
   {
     "Filer_ID": "892160",
@@ -521,8 +1004,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
   },
   {
     "Filer_ID": "892160",
@@ -542,8 +1046,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-03-19",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -563,8 +1088,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -584,8 +1130,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -605,6 +1172,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-03-19",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Murphree"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Murphree"
   },
@@ -614,6 +1195,20 @@
     "Tran_Date": "2015-03-19",
     "Tran_NamF": "Chad",
     "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-03-19",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -633,8 +1228,50 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-04-16",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
   },
   {
     "Filer_ID": "892160",
@@ -654,8 +1291,43 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
     "Tran_NamF": "Jerome",
     "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -675,6 +1347,34 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-04-16",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
     "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
   },
@@ -684,6 +1384,34 @@
     "Tran_Date": "2015-04-16",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-16",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -703,8 +1431,50 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-04-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
   },
   {
     "Filer_ID": "892160",
@@ -724,8 +1494,43 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
     "Tran_NamF": "Jerome",
     "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -745,6 +1550,34 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-04-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
     "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
   },
@@ -754,6 +1587,34 @@
     "Tran_Date": "2015-04-30",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-04-30",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -780,8 +1641,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
     "Tran_NamF": "Bruno",
     "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
   },
   {
     "Filer_ID": "892160",
@@ -801,8 +1683,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
   },
   {
     "Filer_ID": "892160",
@@ -822,8 +1725,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-05-21",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -850,8 +1774,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -871,8 +1816,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -892,6 +1858,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-05-21",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Murphree"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Murphree"
   },
@@ -901,6 +1881,20 @@
     "Tran_Date": "2015-05-21",
     "Tran_NamF": "Chad",
     "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-21",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -920,8 +1914,50 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-05-31",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
   },
   {
     "Filer_ID": "892160",
@@ -941,8 +1977,43 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
     "Tran_NamF": "Jerome",
     "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -962,6 +2033,34 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-05-31",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
     "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
   },
@@ -971,6 +2070,34 @@
     "Tran_Date": "2015-05-31",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-05-31",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -990,8 +2117,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
     "Tran_NamF": "Bruno",
     "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
   },
   {
     "Filer_ID": "892160",
@@ -1011,8 +2159,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
   },
   {
     "Filer_ID": "892160",
@@ -1032,8 +2201,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-02",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -1053,8 +2243,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -1074,8 +2285,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -1095,6 +2327,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-02",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Murphree"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Murphree"
   },
@@ -1104,6 +2350,20 @@
     "Tran_Date": "2015-06-02",
     "Tran_NamF": "Chad",
     "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-02",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -1123,8 +2383,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
     "Tran_NamF": "Bruno",
     "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
   },
   {
     "Filer_ID": "892160",
@@ -1144,8 +2425,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
   },
   {
     "Filer_ID": "892160",
@@ -1165,8 +2467,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-06",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -1186,8 +2509,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -1207,6 +2551,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
   },
@@ -1216,6 +2574,20 @@
     "Tran_Date": "2015-06-06",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Lion"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
   },
   {
     "Filer_ID": "892160",
@@ -1237,6 +2609,20 @@
     "Tran_Date": "2015-06-06",
     "Tran_NamF": "Chad",
     "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-06-06",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -1438,6 +2824,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
     "Tran_NamF": "Neptali",
     "Tran_NamL": "Bonifacio"
   },
@@ -1550,6 +2943,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
     "Tran_NamF": "Edward",
     "Tran_NamL": "Buttles"
   },
@@ -1608,6 +3015,13 @@
     "Tran_Date": "2015-07-16",
     "Tran_NamF": "Andre",
     "Tran_NamL": "Chapital"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
   },
   {
     "Filer_ID": "892160",
@@ -1776,6 +3190,13 @@
     "Tran_Date": "2015-07-16",
     "Tran_NamF": "Zoraida",
     "Tran_NamL": "Diaz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
   },
   {
     "Filer_ID": "892160",
@@ -2089,6 +3510,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
     "Tran_NamF": "Scott",
     "Tran_NamL": "Gonsolin"
   },
@@ -2112,6 +3540,13 @@
     "Tran_Date": "2015-07-16",
     "Tran_NamF": "Dewayne",
     "Tran_NamL": "Gray"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
   },
   {
     "Filer_ID": "892160",
@@ -2285,6 +3720,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Hillesheim"
   },
@@ -2350,6 +3792,13 @@
     "Tran_Date": "2015-07-16",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Hughes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -2453,6 +3902,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
     "Tran_NamF": "Sherman",
     "Tran_NamL": "Jones"
   },
@@ -2502,6 +3958,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Kennedy"
   },
@@ -2511,6 +3974,13 @@
     "Tran_Date": "2015-07-16",
     "Tran_NamF": "Shanah",
     "Tran_NamL": "Keyes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -2614,6 +4084,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
   },
@@ -2651,6 +4135,13 @@
     "Tran_Date": "2015-07-16",
     "Tran_NamF": "Charles",
     "Tran_NamL": "Lightfoot III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -2742,6 +4233,13 @@
     "Tran_Date": "2015-07-16",
     "Tran_NamF": "Tyrone",
     "Tran_NamL": "Mancuso"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
   },
   {
     "Filer_ID": "892160",
@@ -2950,6 +4448,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Navarro"
   },
@@ -3050,6 +4555,13 @@
     "Tran_Date": "2015-07-16",
     "Tran_NamF": "Tracy",
     "Tran_NamL": "Paganelli"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-16",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -3972,6 +5484,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Bradley",
     "Tran_NamL": "Arganbright"
   },
@@ -4023,6 +5549,27 @@
     "Tran_Date": "2015-07-23",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
   },
   {
     "Filer_ID": "892160",
@@ -4112,6 +5659,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Bodnar"
   },
@@ -4170,6 +5731,20 @@
     "Tran_Date": "2015-07-23",
     "Tran_NamF": "Percy",
     "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
   },
   {
     "Filer_ID": "892160",
@@ -4336,7 +5911,21 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Conover"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "D'Marcus",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "John",
     "Tran_NamL": "Cooper"
   },
   {
@@ -4385,6 +5974,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Ryan",
     "Tran_NamL": "Davis"
   },
@@ -4399,20 +5995,6 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
-    "Tran_NamF": "Nicholas",
-    "Tran_NamL": "DeLaTorre"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-07-23",
-    "Tran_NamF": "Allison",
-    "Tran_NamL": "DePalma"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Dearborn"
   },
@@ -4420,8 +6002,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Nicholas",
+    "Tran_NamL": "DeLaTorre"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Carl",
     "Tran_NamL": "Denyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Allison",
+    "Tran_NamL": "DePalma"
   },
   {
     "Filer_ID": "892160",
@@ -4441,15 +6037,15 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "DiRegolo"
+    "Tran_NamF": "Bryan",
+    "Tran_NamL": "Dillingham"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
-    "Tran_NamF": "Bryan",
-    "Tran_NamL": "Dillingham"
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "DiRegolo"
   },
   {
     "Filer_ID": "892160",
@@ -4492,6 +6088,20 @@
     "Tran_Date": "2015-07-23",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Durante"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -4721,6 +6331,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Kelley",
     "Tran_NamL": "Hackett"
   },
@@ -4792,6 +6416,27 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
     "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
   },
   {
@@ -4973,8 +6618,36 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Nuronn",
     "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -5134,6 +6807,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Ralph",
     "Tran_NamL": "Martinez"
   },
@@ -5274,6 +6954,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Cameron",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Montes"
   },
@@ -5386,6 +7073,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "O'Neil"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Ronald",
     "Tran_NamL": "Oatis"
   },
@@ -5458,6 +7152,13 @@
     "Tran_Date": "2015-07-23",
     "Tran_NamF": "Robin",
     "Tran_NamL": "Payne"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Chip",
+    "Tran_NamL": "Paynter"
   },
   {
     "Filer_ID": "892160",
@@ -5652,8 +7353,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Hamza",
+    "Tran_NamL": "Sabha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
     "Tran_NamF": "Lupe",
     "Tran_NamL": "Salazar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "DonRick",
+    "Tran_NamL": "Sanderson"
   },
   {
     "Filer_ID": "892160",
@@ -5731,6 +7446,13 @@
     "Tran_Date": "2015-07-23",
     "Tran_NamF": "Rob",
     "Tran_NamL": "Snodgrass"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-07-23",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Somers"
   },
   {
     "Filer_ID": "892160",
@@ -6037,6 +7759,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Doug",
+    "Tran_NamL": "Abbott"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Abel"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Susan",
     "Tran_NamL": "Abel"
   },
@@ -6079,6 +7815,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Aguilar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Mike",
     "Tran_NamL": "Agustin"
   },
@@ -6095,6 +7838,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Moises",
     "Tran_NamL": "Alvarado"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Amormino"
   },
   {
     "Filer_ID": "892160",
@@ -6158,6 +7908,20 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Dominic",
     "Tran_NamL": "Antes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
   },
   {
     "Filer_ID": "892160",
@@ -6296,6 +8060,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Austin",
     "Tran_NamL": "Beck"
   },
@@ -6318,6 +8096,13 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Gregory",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Shane",
     "Tran_NamL": "Bell"
   },
   {
@@ -6429,6 +8214,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Bodnar"
   },
@@ -6445,6 +8244,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Eleanor",
     "Tran_NamL": "Bolin-Chew"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
   },
   {
     "Filer_ID": "892160",
@@ -6597,6 +8403,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Christopher",
     "Tran_NamL": "Brunetti"
   },
@@ -6639,6 +8459,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Brendan",
     "Tran_NamL": "Burke"
   },
@@ -6662,6 +8489,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Joseph",
     "Tran_NamL": "Bustonera"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
   },
   {
     "Filer_ID": "892160",
@@ -6814,6 +8648,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Christopher",
     "Tran_NamL": "Chew"
   },
@@ -6926,6 +8767,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Conover"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Heather",
     "Tran_NamL": "Cook"
   },
@@ -6934,6 +8782,13 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "D'Marcus",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "John",
     "Tran_NamL": "Cooper"
   },
   {
@@ -7031,6 +8886,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Ryan",
     "Tran_NamL": "Davis"
   },
@@ -7045,22 +8907,15 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
-    "Tran_NamF": "Nicholas",
-    "Tran_NamL": "DeLaTorre"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-08-20",
-    "Tran_NamF": "Allison",
-    "Tran_NamL": "DePalma"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Dearborn"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Nicholas",
+    "Tran_NamL": "DeLaTorre"
   },
   {
     "Filer_ID": "892160",
@@ -7075,6 +8930,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Carl",
     "Tran_NamL": "Denyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Allison",
+    "Tran_NamL": "DePalma"
   },
   {
     "Filer_ID": "892160",
@@ -7108,13 +8970,6 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "DiRegolo"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Zoraida",
     "Tran_NamL": "Diaz"
   },
@@ -7124,6 +8979,20 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Bryan",
     "Tran_NamL": "Dillingham"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "DiRegolo"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
   },
   {
     "Filer_ID": "892160",
@@ -7201,6 +9070,20 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Gabriela",
     "Tran_NamL": "Duvall"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -7633,6 +9516,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Scott",
     "Tran_NamL": "Gonsolin"
   },
@@ -7698,6 +9588,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Dewayne",
     "Tran_NamL": "Gray"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
   },
   {
     "Filer_ID": "892160",
@@ -7782,6 +9679,20 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Gordon",
     "Tran_NamL": "Gullett II"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
   },
   {
     "Filer_ID": "892160",
@@ -7969,8 +9880,36 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
   },
   {
     "Filer_ID": "892160",
@@ -8118,6 +10057,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Hughes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -8291,6 +10237,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Sherman",
     "Tran_NamL": "Jones"
   },
@@ -8347,6 +10300,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Amanda",
     "Tran_NamL": "Kemp"
   },
@@ -8375,8 +10335,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Shanah",
     "Tran_NamL": "Keyes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -8398,6 +10379,20 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Matthew",
     "Tran_NamL": "Knaus"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -8543,6 +10538,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
   },
@@ -8615,6 +10624,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Charles",
     "Tran_NamL": "Lightfoot III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -8769,6 +10785,20 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "James",
     "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Marks"
   },
   {
     "Filer_ID": "892160",
@@ -9026,6 +11056,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Cameron",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Maurice",
     "Tran_NamL": "Miranda"
   },
@@ -9166,6 +11203,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Francisco",
     "Tran_NamL": "Navarro"
   },
@@ -9259,6 +11303,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Blake",
     "Tran_NamL": "O'Hara"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "O'Neil"
   },
   {
     "Filer_ID": "892160",
@@ -9383,6 +11434,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Matthew",
     "Tran_NamL": "Pagsolingan"
   },
@@ -9462,6 +11520,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Robin",
     "Tran_NamL": "Payne"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Chip",
+    "Tran_NamL": "Paynter"
   },
   {
     "Filer_ID": "892160",
@@ -9817,6 +11882,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Hamza",
+    "Tran_NamL": "Sabha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
     "Tran_NamF": "Christopher",
     "Tran_NamL": "Salas"
   },
@@ -9875,6 +11947,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Terrence",
     "Tran_NamL": "Sanders"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "DonRick",
+    "Tran_NamL": "Sanderson"
   },
   {
     "Filer_ID": "892160",
@@ -10085,6 +12164,13 @@
     "Tran_Date": "2015-08-20",
     "Tran_NamF": "Herbert",
     "Tran_NamL": "Soares III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-08-20",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Somers"
   },
   {
     "Filer_ID": "892160",
@@ -10951,6 +13037,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
     "Tran_NamF": "Neptali",
     "Tran_NamL": "Bonifacio"
   },
@@ -11063,6 +13156,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
     "Tran_NamF": "Edward",
     "Tran_NamL": "Buttles"
   },
@@ -11121,6 +13228,13 @@
     "Tran_Date": "2015-09-17",
     "Tran_NamF": "Andre",
     "Tran_NamL": "Chapital"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
   },
   {
     "Filer_ID": "892160",
@@ -11289,6 +13403,13 @@
     "Tran_Date": "2015-09-17",
     "Tran_NamF": "Zoraida",
     "Tran_NamL": "Diaz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
   },
   {
     "Filer_ID": "892160",
@@ -11602,6 +13723,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
     "Tran_NamF": "Scott",
     "Tran_NamL": "Gonsolin"
   },
@@ -11625,6 +13753,13 @@
     "Tran_Date": "2015-09-17",
     "Tran_NamF": "Dewayne",
     "Tran_NamL": "Gray"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
   },
   {
     "Filer_ID": "892160",
@@ -11798,6 +13933,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Hillesheim"
   },
@@ -11863,6 +14005,13 @@
     "Tran_Date": "2015-09-17",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Hughes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -11966,6 +14115,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
     "Tran_NamF": "Sherman",
     "Tran_NamL": "Jones"
   },
@@ -12015,6 +14171,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Kennedy"
   },
@@ -12024,6 +14187,13 @@
     "Tran_Date": "2015-09-17",
     "Tran_NamF": "Shanah",
     "Tran_NamL": "Keyes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -12127,6 +14297,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
   },
@@ -12164,6 +14348,13 @@
     "Tran_Date": "2015-09-17",
     "Tran_NamF": "Charles",
     "Tran_NamL": "Lightfoot III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -12255,6 +14446,13 @@
     "Tran_Date": "2015-09-17",
     "Tran_NamF": "Tyrone",
     "Tran_NamL": "Mancuso"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
   },
   {
     "Filer_ID": "892160",
@@ -12463,6 +14661,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Navarro"
   },
@@ -12563,6 +14768,13 @@
     "Tran_Date": "2015-09-17",
     "Tran_NamF": "Tracy",
     "Tran_NamL": "Paganelli"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-17",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -13366,8 +15578,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Camillo",
+    "Tran_NamL": "Abady"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Doug",
     "Tran_NamL": "Abbott"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Doug",
+    "Tran_NamL": "Abbott"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Susan",
+    "Tran_NamL": "Abel"
   },
   {
     "Filer_ID": "892160",
@@ -13387,8 +15620,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Abele"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Douglas",
     "Tran_NamL": "Abram"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Abram"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Adams"
   },
   {
     "Filer_ID": "892160",
@@ -13408,8 +15662,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ryan",
+    "Tran_NamL": "Agrella"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Richard",
     "Tran_NamL": "Aguilar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Aguilar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Mike",
+    "Tran_NamL": "Agustin"
   },
   {
     "Filer_ID": "892160",
@@ -13429,6 +15704,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Allen"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Amormino"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Matthew",
     "Tran_NamL": "Amormino"
   },
@@ -13437,6 +15726,20 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Edwin",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Edwin",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jess",
     "Tran_NamL": "Anderson"
   },
   {
@@ -13457,8 +15760,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Seth",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Walter",
     "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Walter",
+    "Tran_NamL": "Anderson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Simon",
+    "Tran_NamL": "Andrade"
   },
   {
     "Filer_ID": "892160",
@@ -13478,6 +15802,48 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Bradley",
+    "Tran_NamL": "Arganbright"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Bradley",
     "Tran_NamL": "Arganbright"
   },
@@ -13486,6 +15852,20 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Bruce",
+    "Tran_NamL": "Armstrong"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Bruce",
+    "Tran_NamL": "Armstrong"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Walter",
     "Tran_NamL": "Armstrong"
   },
   {
@@ -13506,8 +15886,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Adria",
+    "Tran_NamL": "Aslanian"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Joseph",
     "Tran_NamL": "Baldwin"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Baldwin"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Barry"
   },
   {
     "Filer_ID": "892160",
@@ -13527,8 +15928,71 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Bauer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
   },
   {
     "Filer_ID": "892160",
@@ -13548,8 +16012,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Benfield"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Mark",
     "Tran_NamL": "Bennett"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Bennett"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Bernard"
   },
   {
     "Filer_ID": "892160",
@@ -13569,6 +16054,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Leonard",
+    "Tran_NamL": "Bettencourt"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Bidmead"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Edward",
     "Tran_NamL": "Bidmead"
   },
@@ -13577,6 +16076,20 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Matthew",
+    "Tran_NamL": "Blair"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Blair"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
     "Tran_NamL": "Blair"
   },
   {
@@ -13597,8 +16110,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Bland"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Francis",
     "Tran_NamL": "Blay-Miezah"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Francis",
+    "Tran_NamL": "Blay-Miezah"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jesse",
+    "Tran_NamL": "Blaylock"
   },
   {
     "Filer_ID": "892160",
@@ -13618,7 +16152,56 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Robert",
+    "Tran_NamL": "Bodnar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Bodnar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Rory",
     "Tran_NamL": "Bodnar"
   },
   {
@@ -13639,8 +16222,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Book"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Borchard"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Borchard"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Paige",
+    "Tran_NamL": "Bowie"
   },
   {
     "Filer_ID": "892160",
@@ -13660,6 +16264,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Bowles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Arnie",
+    "Tran_NamL": "Brockmire"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Arnie",
     "Tran_NamL": "Brockmire"
   },
@@ -13668,6 +16286,20 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Garrett",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Garrett",
+    "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Percy",
     "Tran_NamL": "Brown"
   },
   {
@@ -13688,6 +16320,48 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Brunetti"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Christopher",
     "Tran_NamL": "Brunetti"
   },
@@ -13702,7 +16376,28 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brandon",
+    "Tran_NamL": "Buckley"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Brendan",
+    "Tran_NamL": "Burke"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brendan",
+    "Tran_NamL": "Burke"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Daniel",
     "Tran_NamL": "Burke"
   },
   {
@@ -13723,8 +16418,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Sean",
+    "Tran_NamL": "Burrows"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Joseph",
     "Tran_NamL": "Bustonera"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Bustonera"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Call"
   },
   {
     "Filer_ID": "892160",
@@ -13744,8 +16460,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Camitz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Terence",
     "Tran_NamL": "Carey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Terence",
+    "Tran_NamL": "Carey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Kent",
+    "Tran_NamL": "Carlin"
   },
   {
     "Filer_ID": "892160",
@@ -13765,6 +16502,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Armigh",
+    "Tran_NamL": "Carrizalez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Cartee"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Cartee"
   },
@@ -13773,6 +16524,20 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Mark",
+    "Tran_NamL": "Carter"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Carter"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Randall",
     "Tran_NamL": "Carter"
   },
   {
@@ -13793,8 +16558,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ryan",
+    "Tran_NamL": "Castro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Mark",
     "Tran_NamL": "Cavanaugh"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Cavanaugh"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Centoni"
   },
   {
     "Filer_ID": "892160",
@@ -13814,8 +16600,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Anton",
+    "Tran_NamL": "Chism"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "John",
     "Tran_NamL": "Coady"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Coady"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Cobb III"
   },
   {
     "Filer_ID": "892160",
@@ -13835,6 +16642,34 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brandon",
+    "Tran_NamL": "Cole"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Conover"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Conover"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Conover"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Douglas",
     "Tran_NamL": "Conover"
   },
@@ -13843,6 +16678,34 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "D'Marcus",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "D'Marcus",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
     "Tran_NamL": "Cooper"
   },
   {
@@ -13863,8 +16726,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Malcolm",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Stephanie",
     "Tran_NamL": "Corti"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Stephanie",
+    "Tran_NamL": "Corti"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jeffery",
+    "Tran_NamL": "Crouse"
   },
   {
     "Filer_ID": "892160",
@@ -13884,7 +16768,42 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Darling"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ryan",
     "Tran_NamL": "Davis"
   },
   {
@@ -13905,15 +16824,8 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
-    "Tran_NamF": "Nicholas",
-    "Tran_NamL": "DeLaTorre"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-09-30",
-    "Tran_NamF": "Allison",
-    "Tran_NamL": "DePalma"
+    "Tran_NamF": "Charohn",
+    "Tran_NamL": "Dawson"
   },
   {
     "Filer_ID": "892160",
@@ -13926,8 +16838,57 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Dearborn"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Nicholas",
+    "Tran_NamL": "DeLaTorre"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Nicholas",
+    "Tran_NamL": "DeLaTorre"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Carl",
     "Tran_NamL": "Denyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Carl",
+    "Tran_NamL": "Denyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Allison",
+    "Tran_NamL": "DePalma"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Allison",
+    "Tran_NamL": "DePalma"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Derickson"
   },
   {
     "Filer_ID": "892160",
@@ -13947,8 +16908,8 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "DiRegolo"
+    "Tran_NamF": "Paul",
+    "Tran_NamL": "Derickson"
   },
   {
     "Filer_ID": "892160",
@@ -13956,6 +16917,34 @@
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Bryan",
     "Tran_NamL": "Dillingham"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Bryan",
+    "Tran_NamL": "Dillingham"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "DiRegolo"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "DiRegolo"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Larry",
+    "Tran_NamL": "Drexler"
   },
   {
     "Filer_ID": "892160",
@@ -13975,8 +16964,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ted",
+    "Tran_NamL": "Duarte"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Gary",
     "Tran_NamL": "Dunbar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Dunbar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brendan",
+    "Tran_NamL": "Dunham"
   },
   {
     "Filer_ID": "892160",
@@ -13996,8 +17006,57 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ninh",
+    "Tran_NamL": "Duong"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Durante"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Durante"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -14017,8 +17076,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Laura",
+    "Tran_NamL": "Elder"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Andrew",
     "Tran_NamL": "Elliott"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Andrew",
+    "Tran_NamL": "Elliott"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Katharine",
+    "Tran_NamL": "Erhardt"
   },
   {
     "Filer_ID": "892160",
@@ -14038,8 +17118,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Alan",
+    "Tran_NamL": "Evans"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Ferreira"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Ferreira"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Herbert",
+    "Tran_NamL": "Ferrer"
   },
   {
     "Filer_ID": "892160",
@@ -14059,8 +17160,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Fitzgerald"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Justin",
     "Tran_NamL": "Forni"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Justin",
+    "Tran_NamL": "Forni"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Frago"
   },
   {
     "Filer_ID": "892160",
@@ -14080,8 +17202,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jared",
+    "Tran_NamL": "Franchi"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Brandon",
     "Tran_NamL": "Franco"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brandon",
+    "Tran_NamL": "Franco"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Franklin"
   },
   {
     "Filer_ID": "892160",
@@ -14101,6 +17244,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Craig",
+    "Tran_NamL": "Fujii"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Fuller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Fuller"
   },
@@ -14109,6 +17266,20 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Arturo",
+    "Tran_NamL": "Garcia"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Arturo",
+    "Tran_NamL": "Garcia"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Bo",
     "Tran_NamL": "Garcia"
   },
   {
@@ -14129,7 +17300,28 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Garcia"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Miguel",
+    "Tran_NamL": "Garcia"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Garcia"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ryan",
     "Tran_NamL": "Garcia"
   },
   {
@@ -14150,8 +17342,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Gattey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Anthony",
     "Tran_NamL": "Giustino"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Giustino"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Gonzales"
   },
   {
     "Filer_ID": "892160",
@@ -14171,6 +17384,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Andres",
+    "Tran_NamL": "Gonzalez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ronell",
+    "Tran_NamL": "Gordon"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Ronell",
     "Tran_NamL": "Gordon"
   },
@@ -14185,7 +17412,28 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jonathan",
+    "Tran_NamL": "Goulding"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Brian",
+    "Tran_NamL": "Graham"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Graham"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jeff",
     "Tran_NamL": "Graham"
   },
   {
@@ -14206,8 +17454,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Shenah",
+    "Tran_NamL": "Groom"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Holly",
     "Tran_NamL": "Guier"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Holly",
+    "Tran_NamL": "Guier"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Benjamin",
+    "Tran_NamL": "Guild"
   },
   {
     "Filer_ID": "892160",
@@ -14227,8 +17496,57 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Kelley",
     "Tran_NamL": "Hackett"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Kelley",
+    "Tran_NamL": "Hackett"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Hall"
   },
   {
     "Filer_ID": "892160",
@@ -14248,8 +17566,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Hamilton"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Chris",
     "Tran_NamL": "Hann"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Chris",
+    "Tran_NamL": "Hann"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Frank",
+    "Tran_NamL": "Harrah"
   },
   {
     "Filer_ID": "892160",
@@ -14269,8 +17608,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Harris"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jamie",
     "Tran_NamL": "Harrison"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jamie",
+    "Tran_NamL": "Harrison"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Hartmann"
   },
   {
     "Filer_ID": "892160",
@@ -14290,6 +17650,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Christian",
+    "Tran_NamL": "Hary"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Havenhill"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "John",
     "Tran_NamL": "Havenhill"
   },
@@ -14298,6 +17672,62 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
   },
   {
@@ -14318,8 +17748,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Hill"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Marc",
     "Tran_NamL": "Hinton"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Marc",
+    "Tran_NamL": "Hinton"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Justin",
+    "Tran_NamL": "Hoglund"
   },
   {
     "Filer_ID": "892160",
@@ -14339,6 +17790,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Holmgren"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Hopken"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Hopken"
   },
@@ -14347,6 +17812,20 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Allen",
+    "Tran_NamL": "Horton"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Allen",
+    "Tran_NamL": "Horton"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Kenneth",
     "Tran_NamL": "Horton"
   },
   {
@@ -14367,6 +17846,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Hoskins"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Huang"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "David",
     "Tran_NamL": "Huang"
   },
@@ -14381,7 +17874,28 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Derek",
+    "Tran_NamL": "Huber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "David",
+    "Tran_NamL": "Hurtado"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Hurtado"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ricky",
     "Tran_NamL": "Hurtado"
   },
   {
@@ -14402,8 +17916,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Pao-Fu",
+    "Tran_NamL": "Hwang"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Ramsey",
     "Tran_NamL": "Ismail"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ramsey",
+    "Tran_NamL": "Ismail"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Wellington",
+    "Tran_NamL": "Jackson"
   },
   {
     "Filer_ID": "892160",
@@ -14423,6 +17958,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Jansen"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Jensen"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Jensen"
   },
@@ -14437,7 +17986,28 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Roy",
+    "Tran_NamL": "Johns"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Darrell",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Darrell",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Gary",
     "Tran_NamL": "Jones"
   },
   {
@@ -14458,8 +18028,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Stephen",
+    "Tran_NamL": "Keating"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Amanda",
     "Tran_NamL": "Kemp"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Amanda",
+    "Tran_NamL": "Kemp"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Sean",
+    "Tran_NamL": "Kenison"
   },
   {
     "Filer_ID": "892160",
@@ -14479,8 +18070,85 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Nuronn",
     "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Nuronn",
+    "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -14500,8 +18168,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Kramm"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Scott",
     "Tran_NamL": "Krauss"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Krauss"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Thanh",
+    "Tran_NamL": "La"
   },
   {
     "Filer_ID": "892160",
@@ -14521,8 +18210,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Frank",
+    "Tran_NamL": "Laguna"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Brian",
     "Tran_NamL": "Lane"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Lane"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "William",
+    "Tran_NamL": "Larsen"
   },
   {
     "Filer_ID": "892160",
@@ -14542,8 +18252,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Kimberly",
+    "Tran_NamL": "Larson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Aaron",
     "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Aaron",
+    "Tran_NamL": "Lee"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Lemoine"
   },
   {
     "Filer_ID": "892160",
@@ -14563,8 +18294,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Mark",
+    "Tran_NamL": "Lewis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Carlos",
     "Tran_NamL": "Leyva"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Carlos",
+    "Tran_NamL": "Leyva"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Licon"
   },
   {
     "Filer_ID": "892160",
@@ -14584,8 +18336,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Samuel",
+    "Tran_NamL": "LoBese"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jeffrey",
     "Tran_NamL": "Luepke"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Luepke"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dean",
+    "Tran_NamL": "Lundstrom"
   },
   {
     "Filer_ID": "892160",
@@ -14605,8 +18378,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Lary",
+    "Tran_NamL": "Lyall"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Paul",
     "Tran_NamL": "Mahar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Paul",
+    "Tran_NamL": "Mahar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Randall",
+    "Tran_NamL": "Mancuso"
   },
   {
     "Filer_ID": "892160",
@@ -14626,8 +18420,43 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Nathan",
+    "Tran_NamL": "Mar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Gary",
     "Tran_NamL": "March"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "March"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Marks"
   },
   {
     "Filer_ID": "892160",
@@ -14647,8 +18476,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ralph",
+    "Tran_NamL": "Martinez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Matthews"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Matthews"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Bailus",
+    "Tran_NamL": "McAdams"
   },
   {
     "Filer_ID": "892160",
@@ -14668,8 +18518,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "McGill"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Chase",
     "Tran_NamL": "McGrew"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Chase",
+    "Tran_NamL": "McGrew"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "McInnis"
   },
   {
     "Filer_ID": "892160",
@@ -14689,8 +18560,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "McMillan"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Phillip",
     "Tran_NamL": "McMullen"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Phillip",
+    "Tran_NamL": "McMullen"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dentrick",
+    "Tran_NamL": "McNorton"
   },
   {
     "Filer_ID": "892160",
@@ -14710,8 +18602,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Joseph",
+    "Tran_NamL": "Medina"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Patrick",
     "Tran_NamL": "Mehew"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Mehew"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Edmund",
+    "Tran_NamL": "Melikian"
   },
   {
     "Filer_ID": "892160",
@@ -14731,8 +18644,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Mike",
+    "Tran_NamL": "Melton"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Menchini"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Menchini"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Mengell"
   },
   {
     "Filer_ID": "892160",
@@ -14752,8 +18686,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Menise"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Justin",
     "Tran_NamL": "Merrick"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Justin",
+    "Tran_NamL": "Merrick"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Mikel"
   },
   {
     "Filer_ID": "892160",
@@ -14773,8 +18728,43 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jamal",
+    "Tran_NamL": "Miles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Cameron",
     "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Cameron",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Cameron",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Cameron",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Daniel",
+    "Tran_NamL": "Montes"
   },
   {
     "Filer_ID": "892160",
@@ -14794,8 +18784,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Moore"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Alex",
     "Tran_NamL": "Moyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Alex",
+    "Tran_NamL": "Moyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Moyles"
   },
   {
     "Filer_ID": "892160",
@@ -14815,8 +18826,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Harry",
+    "Tran_NamL": "Myers"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Dan",
     "Tran_NamL": "Nachtman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dan",
+    "Tran_NamL": "Nachtman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ryan",
+    "Tran_NamL": "Nance"
   },
   {
     "Filer_ID": "892160",
@@ -14836,8 +18868,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Francisco",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Thomas",
     "Tran_NamL": "Neuerburg"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Neuerburg"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Nguyen"
   },
   {
     "Filer_ID": "892160",
@@ -14857,6 +18910,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Bryant",
+    "Tran_NamL": "Nielsen"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ryan",
+    "Tran_NamL": "Nishimoto"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Ryan",
     "Tran_NamL": "Nishimoto"
   },
@@ -14865,6 +18932,20 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Christopher",
+    "Tran_NamL": "O'Brien"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "O'Brien"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Paul",
     "Tran_NamL": "O'Brien"
   },
   {
@@ -14885,8 +18966,43 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Blake",
+    "Tran_NamL": "O'Hara"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Steven",
     "Tran_NamL": "O'Neil"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "O'Neil"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "O'Neil"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "O'Neil"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Oatis"
   },
   {
     "Filer_ID": "892160",
@@ -14906,6 +19022,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Carlos",
+    "Tran_NamL": "Olivarez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Emmy",
+    "Tran_NamL": "Opene"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Emmy",
     "Tran_NamL": "Opene"
   },
@@ -14920,7 +19050,28 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Ortzow"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Gary",
+    "Tran_NamL": "Owens"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Gary",
+    "Tran_NamL": "Owens"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Thurman",
     "Tran_NamL": "Owens"
   },
   {
@@ -14941,8 +19092,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Palmer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Aaron",
     "Tran_NamL": "Panfilio"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Aaron",
+    "Tran_NamL": "Panfilio"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Pappas"
   },
   {
     "Filer_ID": "892160",
@@ -14962,8 +19134,43 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Patton"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Robin",
     "Tran_NamL": "Payne"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Robin",
+    "Tran_NamL": "Payne"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Chip",
+    "Tran_NamL": "Paynter"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Chip",
+    "Tran_NamL": "Paynter"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Chip",
+    "Tran_NamL": "Paynter"
   },
   {
     "Filer_ID": "892160",
@@ -14983,8 +19190,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Pendley"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Juan",
     "Tran_NamL": "Perez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Juan",
+    "Tran_NamL": "Perez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Joshua",
+    "Tran_NamL": "Perry"
   },
   {
     "Filer_ID": "892160",
@@ -15004,8 +19232,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Petersen"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Lee",
     "Tran_NamL": "Phillips"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Lee",
+    "Tran_NamL": "Phillips"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Portteus"
   },
   {
     "Filer_ID": "892160",
@@ -15025,8 +19274,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Xavier",
+    "Tran_NamL": "Poulleau"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Markus",
     "Tran_NamL": "Powell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Markus",
+    "Tran_NamL": "Powell"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Preston"
   },
   {
     "Filer_ID": "892160",
@@ -15046,8 +19316,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Querner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "James",
     "Tran_NamL": "Quintana"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Quintana"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Stephanie",
+    "Tran_NamL": "Radecke"
   },
   {
     "Filer_ID": "892160",
@@ -15067,8 +19358,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Ramia"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Chad",
     "Tran_NamL": "Ramnarine"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Ramnarine"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Rardin"
   },
   {
     "Filer_ID": "892160",
@@ -15088,8 +19400,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Gerard",
+    "Tran_NamL": "Rawson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Ryan",
     "Tran_NamL": "Richter"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ryan",
+    "Tran_NamL": "Richter"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Richard",
+    "Tran_NamL": "Riggs"
   },
   {
     "Filer_ID": "892160",
@@ -15109,8 +19442,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Rinna"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Paul",
     "Tran_NamL": "Rivera"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Paul",
+    "Tran_NamL": "Rivera"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Roark"
   },
   {
     "Filer_ID": "892160",
@@ -15130,8 +19484,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Rocha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jeremy",
     "Tran_NamL": "Roderick"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jeremy",
+    "Tran_NamL": "Roderick"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Rubino"
   },
   {
     "Filer_ID": "892160",
@@ -15151,8 +19526,43 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Cory",
+    "Tran_NamL": "Rutherglen"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Hamza",
     "Tran_NamL": "Sabha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Hamza",
+    "Tran_NamL": "Sabha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Hamza",
+    "Tran_NamL": "Sabha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Hamza",
+    "Tran_NamL": "Sabha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Lupe",
+    "Tran_NamL": "Salazar"
   },
   {
     "Filer_ID": "892160",
@@ -15179,6 +19589,27 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "DonRick",
+    "Tran_NamL": "Sanderson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "DonRick",
+    "Tran_NamL": "Sanderson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "DonRick",
+    "Tran_NamL": "Sanderson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Sarna"
   },
@@ -15193,8 +19624,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Matt",
+    "Tran_NamL": "Schelegle"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Jennifer",
     "Tran_NamL": "Schmid"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Ronald",
+    "Tran_NamL": "Schmidt"
   },
   {
     "Filer_ID": "892160",
@@ -15249,6 +19694,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Sheehan"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "Sheridan"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Sheridan"
   },
@@ -15298,6 +19757,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Sean",
+    "Tran_NamL": "Sinclair"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Sinkay"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "James",
     "Tran_NamL": "Sinkay"
   },
@@ -15314,6 +19787,20 @@
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "John",
     "Tran_NamL": "Skokan III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Skokan III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Sloan Jr."
   },
   {
     "Filer_ID": "892160",
@@ -15361,8 +19848,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Phillip",
+    "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Terence",
     "Tran_NamL": "Smith"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Rob",
+    "Tran_NamL": "Snodgrass"
   },
   {
     "Filer_ID": "892160",
@@ -15389,6 +19890,27 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Somers"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Somers"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Somers"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "David",
     "Tran_NamL": "Sparks"
   },
@@ -15398,6 +19920,20 @@
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "John",
     "Tran_NamL": "Stanchina"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Stanchina"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Stange"
   },
   {
     "Filer_ID": "892160",
@@ -15439,6 +19975,20 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Scott",
+    "Tran_NamL": "Stewart"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Scott",
+    "Tran_NamL": "Stielstra"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Scott",
     "Tran_NamL": "Stielstra"
   },
   {
@@ -15447,6 +19997,13 @@
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Dennis",
     "Tran_NamL": "Stock"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Stunkel"
   },
   {
     "Filer_ID": "892160",
@@ -15501,6 +20058,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Clare",
+    "Tran_NamL": "Takhar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Timothy",
     "Tran_NamL": "Takis"
   },
@@ -15515,8 +20079,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Paul",
+    "Tran_NamL": "Tappan"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Bonnie",
     "Tran_NamL": "Terra"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Bonnie",
+    "Tran_NamL": "Terra"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Donald",
+    "Tran_NamL": "Terry"
   },
   {
     "Filer_ID": "892160",
@@ -15543,8 +20128,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Derrick",
+    "Tran_NamL": "Thomas"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Kenneth",
     "Tran_NamL": "Thomey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Kenneth",
+    "Tran_NamL": "Thomey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Cary",
+    "Tran_NamL": "Thompson"
   },
   {
     "Filer_ID": "892160",
@@ -15566,6 +20172,13 @@
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Thrower"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Tyson",
+    "Tran_NamL": "Tiago"
   },
   {
     "Filer_ID": "892160",
@@ -15648,6 +20261,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Tran"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Tuan",
     "Tran_NamL": "Tran"
   },
@@ -15690,6 +20310,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Truax"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Raymond",
     "Tran_NamL": "Tsang"
   },
@@ -15699,6 +20326,13 @@
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Brandon",
     "Tran_NamL": "Tsukroff"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Manh",
+    "Tran_NamL": "Tu-Hyunh"
   },
   {
     "Filer_ID": "892160",
@@ -15732,6 +20366,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Jeffrey",
+    "Tran_NamL": "Unruh"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Michelle",
+    "Tran_NamL": "Unruh"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Michelle",
     "Tran_NamL": "Unruh"
   },
@@ -15748,6 +20396,20 @@
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Verdie"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Robert",
+    "Tran_NamL": "Verdie"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Charles",
+    "Tran_NamL": "Verhoeven"
   },
   {
     "Filer_ID": "892160",
@@ -15774,7 +20436,21 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Walder"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Charles",
+    "Tran_NamL": "Walker"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Rick",
     "Tran_NamL": "Walker"
   },
   {
@@ -15795,8 +20471,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Steve",
+    "Tran_NamL": "Walker"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "John",
     "Tran_NamL": "Walsh III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Walsh III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "George",
+    "Tran_NamL": "Warren"
   },
   {
     "Filer_ID": "892160",
@@ -15830,8 +20527,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Watkins, III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Emmanuel",
     "Tran_NamL": "Watson"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Kip",
+    "Tran_NamL": "Weber"
   },
   {
     "Filer_ID": "892160",
@@ -15851,6 +20562,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Allan",
+    "Tran_NamL": "Weeks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Randall",
+    "Tran_NamL": "West"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Randall",
     "Tran_NamL": "West"
   },
@@ -15860,6 +20585,13 @@
     "Tran_Date": "2015-09-30",
     "Tran_NamF": "Scott",
     "Tran_NamL": "West"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Brent",
+    "Tran_NamL": "Whalley"
   },
   {
     "Filer_ID": "892160",
@@ -15893,8 +20625,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Whiting"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "James",
     "Tran_NamL": "Whitty"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Kyle",
+    "Tran_NamL": "Willet"
   },
   {
     "Filer_ID": "892160",
@@ -15921,8 +20667,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Dave",
+    "Tran_NamL": "Winnacker"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Josh",
     "Tran_NamL": "Wojtkiewicz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Thomas",
+    "Tran_NamL": "Wong"
   },
   {
     "Filer_ID": "892160",
@@ -15949,8 +20709,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Eric",
+    "Tran_NamL": "Wright"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "Duncan",
     "Tran_NamL": "Wylie"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Duncan",
+    "Tran_NamL": "Wylie"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Frank",
+    "Tran_NamL": "Wynn"
   },
   {
     "Filer_ID": "892160",
@@ -15984,8 +20765,29 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Sang",
+    "Tran_NamL": "Yi"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
     "Tran_NamF": "David",
     "Tran_NamL": "Yoder"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Yoder"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-09-30",
+    "Tran_NamF": "Christopher",
+    "Tran_NamL": "Young"
   },
   {
     "Filer_ID": "892160",
@@ -16145,6 +20947,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Bradley",
     "Tran_NamL": "Arganbright"
   },
@@ -16196,6 +21012,27 @@
     "Tran_Date": "2015-10-20",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
   },
   {
     "Filer_ID": "892160",
@@ -16285,6 +21122,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Bodnar"
   },
@@ -16343,6 +21194,20 @@
     "Tran_Date": "2015-10-20",
     "Tran_NamF": "Percy",
     "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
   },
   {
     "Filer_ID": "892160",
@@ -16509,7 +21374,21 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Conover"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "D'Marcus",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "John",
     "Tran_NamL": "Cooper"
   },
   {
@@ -16558,6 +21437,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Ryan",
     "Tran_NamL": "Davis"
   },
@@ -16572,20 +21458,6 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
-    "Tran_NamF": "Nicholas",
-    "Tran_NamL": "DeLaTorre"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-10-20",
-    "Tran_NamF": "Allison",
-    "Tran_NamL": "DePalma"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Dearborn"
   },
@@ -16593,8 +21465,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Nicholas",
+    "Tran_NamL": "DeLaTorre"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Carl",
     "Tran_NamL": "Denyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Allison",
+    "Tran_NamL": "DePalma"
   },
   {
     "Filer_ID": "892160",
@@ -16614,15 +21500,15 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "DiRegolo"
+    "Tran_NamF": "Bryan",
+    "Tran_NamL": "Dillingham"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
-    "Tran_NamF": "Bryan",
-    "Tran_NamL": "Dillingham"
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "DiRegolo"
   },
   {
     "Filer_ID": "892160",
@@ -16665,6 +21551,20 @@
     "Tran_Date": "2015-10-20",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Durante"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -16894,6 +21794,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Kelley",
     "Tran_NamL": "Hackett"
   },
@@ -16965,6 +21879,27 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
     "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
   },
   {
@@ -17146,8 +22081,36 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Nuronn",
     "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -17307,6 +22270,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Ralph",
     "Tran_NamL": "Martinez"
   },
@@ -17447,6 +22417,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Cameron",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Montes"
   },
@@ -17559,6 +22536,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "O'Neil"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Ronald",
     "Tran_NamL": "Oatis"
   },
@@ -17631,6 +22615,13 @@
     "Tran_Date": "2015-10-20",
     "Tran_NamF": "Robin",
     "Tran_NamL": "Payne"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Chip",
+    "Tran_NamL": "Paynter"
   },
   {
     "Filer_ID": "892160",
@@ -17825,8 +22816,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Hamza",
+    "Tran_NamL": "Sabha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
     "Tran_NamF": "Lupe",
     "Tran_NamL": "Salazar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "DonRick",
+    "Tran_NamL": "Sanderson"
   },
   {
     "Filer_ID": "892160",
@@ -17904,6 +22909,13 @@
     "Tran_Date": "2015-10-20",
     "Tran_NamF": "Rob",
     "Tran_NamL": "Snodgrass"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-20",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Somers"
   },
   {
     "Filer_ID": "892160",
@@ -18399,6 +23411,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
     "Tran_NamF": "Neptali",
     "Tran_NamL": "Bonifacio"
   },
@@ -18511,6 +23530,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
     "Tran_NamF": "Edward",
     "Tran_NamL": "Buttles"
   },
@@ -18569,6 +23602,13 @@
     "Tran_Date": "2015-10-31",
     "Tran_NamF": "Andre",
     "Tran_NamL": "Chapital"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
   },
   {
     "Filer_ID": "892160",
@@ -18737,6 +23777,13 @@
     "Tran_Date": "2015-10-31",
     "Tran_NamF": "Zoraida",
     "Tran_NamL": "Diaz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
   },
   {
     "Filer_ID": "892160",
@@ -19050,6 +24097,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
     "Tran_NamF": "Scott",
     "Tran_NamL": "Gonsolin"
   },
@@ -19073,6 +24127,13 @@
     "Tran_Date": "2015-10-31",
     "Tran_NamF": "Dewayne",
     "Tran_NamL": "Gray"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
   },
   {
     "Filer_ID": "892160",
@@ -19246,6 +24307,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Hillesheim"
   },
@@ -19311,6 +24379,13 @@
     "Tran_Date": "2015-10-31",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Hughes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -19414,6 +24489,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
     "Tran_NamF": "Sherman",
     "Tran_NamL": "Jones"
   },
@@ -19463,6 +24545,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Kennedy"
   },
@@ -19472,6 +24561,13 @@
     "Tran_Date": "2015-10-31",
     "Tran_NamF": "Shanah",
     "Tran_NamL": "Keyes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -19575,6 +24671,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
   },
@@ -19612,6 +24722,13 @@
     "Tran_Date": "2015-10-31",
     "Tran_NamF": "Charles",
     "Tran_NamL": "Lightfoot III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -19703,6 +24820,13 @@
     "Tran_Date": "2015-10-31",
     "Tran_NamF": "Tyrone",
     "Tran_NamL": "Mancuso"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
   },
   {
     "Filer_ID": "892160",
@@ -19911,6 +25035,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Navarro"
   },
@@ -20011,6 +25142,13 @@
     "Tran_Date": "2015-10-31",
     "Tran_NamF": "Tracy",
     "Tran_NamL": "Paganelli"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-10-31",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -20933,6 +26071,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Bradley",
     "Tran_NamL": "Arganbright"
   },
@@ -20984,6 +26136,27 @@
     "Tran_Date": "2015-12-07",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
   },
   {
     "Filer_ID": "892160",
@@ -21073,6 +26246,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Bodnar"
   },
@@ -21131,6 +26318,20 @@
     "Tran_Date": "2015-12-07",
     "Tran_NamF": "Percy",
     "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
   },
   {
     "Filer_ID": "892160",
@@ -21297,7 +26498,21 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Conover"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "D'Marcus",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "John",
     "Tran_NamL": "Cooper"
   },
   {
@@ -21346,6 +26561,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Ryan",
     "Tran_NamL": "Davis"
   },
@@ -21360,20 +26582,6 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
-    "Tran_NamF": "Nicholas",
-    "Tran_NamL": "DeLaTorre"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-12-07",
-    "Tran_NamF": "Allison",
-    "Tran_NamL": "DePalma"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Dearborn"
   },
@@ -21381,8 +26589,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Nicholas",
+    "Tran_NamL": "DeLaTorre"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Carl",
     "Tran_NamL": "Denyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Allison",
+    "Tran_NamL": "DePalma"
   },
   {
     "Filer_ID": "892160",
@@ -21402,15 +26624,15 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "DiRegolo"
+    "Tran_NamF": "Bryan",
+    "Tran_NamL": "Dillingham"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
-    "Tran_NamF": "Bryan",
-    "Tran_NamL": "Dillingham"
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "DiRegolo"
   },
   {
     "Filer_ID": "892160",
@@ -21453,6 +26675,20 @@
     "Tran_Date": "2015-12-07",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Durante"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -21682,6 +26918,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Kelley",
     "Tran_NamL": "Hackett"
   },
@@ -21753,6 +27003,27 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
     "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
   },
   {
@@ -21934,8 +27205,36 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Nuronn",
     "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -22095,6 +27394,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Ralph",
     "Tran_NamL": "Martinez"
   },
@@ -22235,6 +27541,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Cameron",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Montes"
   },
@@ -22347,6 +27660,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "O'Neil"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Ronald",
     "Tran_NamL": "Oatis"
   },
@@ -22419,6 +27739,13 @@
     "Tran_Date": "2015-12-07",
     "Tran_NamF": "Robin",
     "Tran_NamL": "Payne"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Chip",
+    "Tran_NamL": "Paynter"
   },
   {
     "Filer_ID": "892160",
@@ -22613,8 +27940,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Hamza",
+    "Tran_NamL": "Sabha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
     "Tran_NamF": "Lupe",
     "Tran_NamL": "Salazar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "DonRick",
+    "Tran_NamL": "Sanderson"
   },
   {
     "Filer_ID": "892160",
@@ -22692,6 +28033,13 @@
     "Tran_Date": "2015-12-07",
     "Tran_NamF": "Rob",
     "Tran_NamL": "Snodgrass"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-07",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Somers"
   },
   {
     "Filer_ID": "892160",
@@ -23173,6 +28521,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Matthew",
+    "Tran_NamL": "Bollinger"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
     "Tran_NamF": "Neptali",
     "Tran_NamL": "Bonifacio"
   },
@@ -23285,6 +28640,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Bruno",
+    "Tran_NamL": "Burgueno"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Edward",
+    "Tran_NamL": "Buttles"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
     "Tran_NamF": "Edward",
     "Tran_NamL": "Buttles"
   },
@@ -23343,6 +28712,13 @@
     "Tran_Date": "2015-12-08",
     "Tran_NamF": "Andre",
     "Tran_NamL": "Chapital"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Chavez"
   },
   {
     "Filer_ID": "892160",
@@ -23511,6 +28887,13 @@
     "Tran_Date": "2015-12-08",
     "Tran_NamF": "Zoraida",
     "Tran_NamL": "Diaz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Anthony",
+    "Tran_NamL": "Dito"
   },
   {
     "Filer_ID": "892160",
@@ -23824,6 +29207,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Miguel",
+    "Tran_NamL": "Gomez"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
     "Tran_NamF": "Scott",
     "Tran_NamL": "Gonsolin"
   },
@@ -23847,6 +29237,13 @@
     "Tran_Date": "2015-12-08",
     "Tran_NamF": "Dewayne",
     "Tran_NamL": "Gray"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "David",
+    "Tran_NamL": "Green"
   },
   {
     "Filer_ID": "892160",
@@ -24020,6 +29417,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Hicks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Hillesheim"
   },
@@ -24085,6 +29489,13 @@
     "Tran_Date": "2015-12-08",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Hughes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Keith",
+    "Tran_NamL": "Hung"
   },
   {
     "Filer_ID": "892160",
@@ -24188,6 +29599,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Mario",
+    "Tran_NamL": "Jones"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
     "Tran_NamF": "Sherman",
     "Tran_NamL": "Jones"
   },
@@ -24237,6 +29655,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "Kelly"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
     "Tran_NamF": "Kevin",
     "Tran_NamL": "Kennedy"
   },
@@ -24246,6 +29671,13 @@
     "Tran_Date": "2015-12-08",
     "Tran_NamF": "Shanah",
     "Tran_NamL": "Keyes"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Michael",
+    "Tran_NamL": "King"
   },
   {
     "Filer_ID": "892160",
@@ -24349,6 +29781,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Adam",
+    "Tran_NamL": "Lauber"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Nathaniel",
+    "Tran_NamL": "Leal"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
     "Tran_NamF": "Nathaniel",
     "Tran_NamL": "Leal"
   },
@@ -24386,6 +29832,13 @@
     "Tran_Date": "2015-12-08",
     "Tran_NamF": "Charles",
     "Tran_NamL": "Lightfoot III"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Kevin",
+    "Tran_NamL": "Lion"
   },
   {
     "Filer_ID": "892160",
@@ -24477,6 +29930,13 @@
     "Tran_Date": "2015-12-08",
     "Tran_NamF": "Tyrone",
     "Tran_NamL": "Mancuso"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Mardakis"
   },
   {
     "Filer_ID": "892160",
@@ -24685,6 +30145,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Chad",
+    "Tran_NamL": "Navarro"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Navarro"
   },
@@ -24785,6 +30252,13 @@
     "Tran_Date": "2015-12-08",
     "Tran_NamF": "Tracy",
     "Tran_NamL": "Paganelli"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-08",
+    "Tran_NamF": "Kai",
+    "Tran_NamL": "Pagani"
   },
   {
     "Filer_ID": "892160",
@@ -25700,6 +31174,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "John",
+    "Tran_NamL": "Arenz"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Bradley",
     "Tran_NamL": "Arganbright"
   },
@@ -25751,6 +31239,27 @@
     "Tran_Date": "2015-12-20",
     "Tran_NamF": "Jason",
     "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Jason",
+    "Tran_NamL": "Beach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Shane",
+    "Tran_NamL": "Bell"
   },
   {
     "Filer_ID": "892160",
@@ -25833,6 +31342,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Dennis",
+    "Tran_NamL": "Bluth"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Rory",
     "Tran_NamL": "Bodnar"
   },
@@ -25884,6 +31407,20 @@
     "Tran_Date": "2015-12-20",
     "Tran_NamF": "Percy",
     "Tran_NamL": "Brown"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Tracy",
+    "Tran_NamL": "Bruner"
   },
   {
     "Filer_ID": "892160",
@@ -26050,7 +31587,21 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Douglas",
+    "Tran_NamL": "Conover"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "D'Marcus",
+    "Tran_NamL": "Cooper"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "John",
     "Tran_NamL": "Cooper"
   },
   {
@@ -26099,6 +31650,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Jerome",
+    "Tran_NamL": "Davis"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Ryan",
     "Tran_NamL": "Davis"
   },
@@ -26113,20 +31671,6 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
-    "Tran_NamF": "Nicholas",
-    "Tran_NamL": "DeLaTorre"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-12-20",
-    "Tran_NamF": "Allison",
-    "Tran_NamL": "DePalma"
-  },
-  {
-    "Filer_ID": "892160",
-    "Tran_Amt1": 10.0,
-    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Michael",
     "Tran_NamL": "Dearborn"
   },
@@ -26134,8 +31678,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Nicholas",
+    "Tran_NamL": "DeLaTorre"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Carl",
     "Tran_NamL": "Denyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Allison",
+    "Tran_NamL": "DePalma"
   },
   {
     "Filer_ID": "892160",
@@ -26155,15 +31713,15 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
-    "Tran_NamF": "Brian",
-    "Tran_NamL": "DiRegolo"
+    "Tran_NamF": "Bryan",
+    "Tran_NamL": "Dillingham"
   },
   {
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
-    "Tran_NamF": "Bryan",
-    "Tran_NamL": "Dillingham"
+    "Tran_NamF": "Brian",
+    "Tran_NamL": "DiRegolo"
   },
   {
     "Filer_ID": "892160",
@@ -26206,6 +31764,20 @@
     "Tran_Date": "2015-12-20",
     "Tran_NamF": "Robert",
     "Tran_NamL": "Durante"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Shannon",
+    "Tran_NamL": "Dwyer"
   },
   {
     "Filer_ID": "892160",
@@ -26435,6 +32007,20 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "James",
+    "Tran_NamL": "Gundlach"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Kelley",
     "Tran_NamL": "Hackett"
   },
@@ -26499,6 +32085,27 @@
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
     "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Cornelius",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Hickey"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Steven",
     "Tran_NamL": "Hickey"
   },
   {
@@ -26680,8 +32287,36 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Patrick",
+    "Tran_NamL": "Kennedy"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Nuronn",
     "Tran_NamL": "King"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Oliver",
+    "Tran_NamL": "Knodel-Sherman"
   },
   {
     "Filer_ID": "892160",
@@ -26841,6 +32476,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "Marks"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Ralph",
     "Tran_NamL": "Martinez"
   },
@@ -26981,6 +32623,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Cameron",
+    "Tran_NamL": "Miller"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Daniel",
     "Tran_NamL": "Montes"
   },
@@ -27093,6 +32742,13 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Steven",
+    "Tran_NamL": "O'Neil"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Ronald",
     "Tran_NamL": "Oatis"
   },
@@ -27165,6 +32821,13 @@
     "Tran_Date": "2015-12-20",
     "Tran_NamF": "Robin",
     "Tran_NamL": "Payne"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Chip",
+    "Tran_NamL": "Paynter"
   },
   {
     "Filer_ID": "892160",
@@ -27359,8 +33022,22 @@
     "Filer_ID": "892160",
     "Tran_Amt1": 10.0,
     "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Hamza",
+    "Tran_NamL": "Sabha"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
     "Tran_NamF": "Lupe",
     "Tran_NamL": "Salazar"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "DonRick",
+    "Tran_NamL": "Sanderson"
   },
   {
     "Filer_ID": "892160",
@@ -27431,6 +33108,13 @@
     "Tran_Date": "2015-12-20",
     "Tran_NamF": "Rob",
     "Tran_NamL": "Snodgrass"
+  },
+  {
+    "Filer_ID": "892160",
+    "Tran_Amt1": 10.0,
+    "Tran_Date": "2015-12-20",
+    "Tran_NamF": "Heather",
+    "Tran_NamL": "Somers"
   },
   {
     "Filer_ID": "892160",

--- a/build/committee/960997/contributions/index.json
+++ b/build/committee/960997/contributions/index.json
@@ -8,10 +8,31 @@
   },
   {
     "Filer_ID": "960997",
+    "Tran_Amt1": 2500.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "AFSCME - Council 57 Issues"
+  },
+  {
+    "Filer_ID": "960997",
     "Tran_Amt1": 5000.0,
     "Tran_Date": "2016-10-07",
     "Tran_NamF": "Gregory",
     "Tran_NamL": "Coxsom"
+  },
+  {
+    "Filer_ID": "960997",
+    "Tran_Amt1": 5000.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": "Gregory",
+    "Tran_NamL": "Coxsom"
+  },
+  {
+    "Filer_ID": "960997",
+    "Tran_Amt1": 49000.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "GO Public Schools Advocates"
   },
   {
     "Filer_ID": "960997",
@@ -29,10 +50,31 @@
   },
   {
     "Filer_ID": "960997",
+    "Tran_Amt1": 3500.0,
+    "Tran_Date": "2016-10-07",
+    "Tran_NamF": null,
+    "Tran_NamL": "Sheet Metal Workers' Local Union 104 Issues Account"
+  },
+  {
+    "Filer_ID": "960997",
     "Tran_Amt1": 45000.0,
     "Tran_Date": "2016-10-13",
     "Tran_NamF": null,
     "Tran_NamL": "CALIFORNIA CHARTER SCHOOLS ASSOCIATIONADVOCATES ISSUES COMMITTEE"
+  },
+  {
+    "Filer_ID": "960997",
+    "Tran_Amt1": 45000.0,
+    "Tran_Date": "2016-10-13",
+    "Tran_NamF": null,
+    "Tran_NamL": "CALIFORNIA CHARTER SCHOOLS ASSOCIATIONADVOCATES ISSUES COMMITTEE"
+  },
+  {
+    "Filer_ID": "960997",
+    "Tran_Amt1": 10000.0,
+    "Tran_Date": "2016-10-20",
+    "Tran_NamF": null,
+    "Tran_NamL": "Service Employees International Union Local 1021"
   },
   {
     "Filer_ID": "960997",

--- a/build/committee/983545/contributions/index.json
+++ b/build/committee/983545/contributions/index.json
@@ -225,6 +225,27 @@
   },
   {
     "Filer_ID": "983545",
+    "Tran_Amt1": 62.5,
+    "Tran_Date": "2016-05-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Marriott - City Center"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 62.5,
+    "Tran_Date": "2016-05-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Marriott - City Center"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 62.5,
+    "Tran_Date": "2016-05-17",
+    "Tran_NamF": null,
+    "Tran_NamL": "Oakland Marriott - City Center"
+  },
+  {
+    "Filer_ID": "983545",
     "Tran_Amt1": 250.0,
     "Tran_Date": "2016-06-09",
     "Tran_NamF": null,
@@ -257,6 +278,13 @@
     "Tran_Date": "2016-07-01",
     "Tran_NamF": null,
     "Tran_NamL": "Horizon Beverage Company"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 145.7,
+    "Tran_Date": "2016-07-06",
+    "Tran_NamF": null,
+    "Tran_NamL": "Clear Channel Outdoor"
   },
   {
     "Filer_ID": "983545",
@@ -341,6 +369,13 @@
     "Tran_Date": "2016-12-15",
     "Tran_NamF": null,
     "Tran_NamL": "Oakland Metropolitan Chamber of Commerce"
+  },
+  {
+    "Filer_ID": "983545",
+    "Tran_Amt1": 20.84,
+    "Tran_Date": "2016-12-22",
+    "Tran_NamF": null,
+    "Tran_NamL": "Hilton Oakland Airport"
   },
   {
     "Filer_ID": "983545",

--- a/build/committee/S10088/contributions/index.json
+++ b/build/committee/S10088/contributions/index.json
@@ -180,5 +180,12 @@
     "Tran_Date": "2017-01-19",
     "Tran_NamF": "Katherine",
     "Tran_NamL": "Rhoades and Katy Kondo"
+  },
+  {
+    "Filer_ID": "S10088",
+    "Tran_Amt1": 75.0,
+    "Tran_Date": "2017-01-19",
+    "Tran_NamF": "Katherine",
+    "Tran_NamL": "Rhoades and Katy Kondo"
   }
 ]

--- a/build/referendum/1/opposing/index.json
+++ b/build/referendum/1/opposing/index.json
@@ -13,19 +13,15 @@
       "amount": 8065162.15
     }
   ],
-  "total_contributions": 7900212.5,
+  "total_contributions": 7913894.640000001,
   "contributions_by_region": [
     {
       "amount": 8391.91,
       "locale": "Out of State"
     },
     {
-      "amount": 7305502.73,
+      "amount": 7905502.73,
       "locale": "Within California"
-    },
-    {
-      "amount": 586317.8599999994,
-      "locale": "Unknown"
     }
   ]
 }

--- a/build/referendum/6/supporting/index.json
+++ b/build/referendum/6/supporting/index.json
@@ -25,14 +25,14 @@
       "amount": 15018.45
     }
   ],
-  "total_contributions": 142500.0,
+  "total_contributions": 257500.0,
   "contributions_by_region": [
     {
-      "amount": 87000.0,
+      "amount": 148000.0,
       "locale": "Within California"
     },
     {
-      "amount": 55500.0,
+      "amount": 109500.0,
       "locale": "Within Oakland"
     }
   ]

--- a/build/stats/index.json
+++ b/build/stats/index.json
@@ -1,3 +1,3 @@
 {
-  "date_processed": "2018-02-07"
+  "date_processed": "2018-02-09"
 }

--- a/calculators/candidate_contributions_by_type.rb
+++ b/calculators/candidate_contributions_by_type.rb
@@ -60,8 +60,14 @@ class CandidateContributionsByType
         FROM combined_contributions
         LEFT OUTER JOIN "oakland_candidates"
           ON "FPPC"::varchar = "Filer_ID"
-          AND (LOWER("Candidate") = LOWER(CONCAT("Tran_NamF", ' ', "Tran_NamL"))
-          OR LOWER("Aliases") LIKE LOWER(CONCAT('%', "Tran_NamF", ' ', "Tran_NamL", '%')))
+          AND (
+            -- Schedules A & C have a "Tran_Self" column we can use, but 497 does not.
+            -- So, we instead do a name match of the receipient. And of course, sometimes
+            --   the candidate's name in the recipient field of the donation is reported
+            --   slightly differently so we have an Aliases table to handle those cases.
+            LOWER("Candidate") = LOWER(CONCAT("Tran_NamF", ' ', "Tran_NamL"))
+            OR LOWER("Aliases") LIKE LOWER(CONCAT('%', "Tran_NamF", ' ', "Tran_NamL", '%'))
+          )
         WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "','"}')
         GROUP BY "Cd", "Filer_ID"
         ORDER BY "Cd", "Filer_ID";

--- a/calculators/candidate_contributions_by_type.rb
+++ b/calculators/candidate_contributions_by_type.rb
@@ -50,22 +50,6 @@ class CandidateContributionsByType
       # Schedule A during a preprocssing script. (See
       # `./../remove_duplicate_transactionts.sh`)
       monetary_results = ActiveRecord::Base.connection.execute <<-SQL
-        WITH combined_contributions AS (
-          SELECT "Filer_ID"::varchar, "Entity_Cd", "Tran_Amt1", "Tran_NamF", "Tran_NamL"
-          FROM "A-Contributions"
-          UNION ALL
-          SELECT "Filer_ID"::varchar, "Entity_Cd", "Tran_Amt1", "Tran_NamF", "Tran_NamL"
-          FROM "C-Contributions"
-          UNION ALL
-          SELECT
-            "Filer_ID"::varchar,
-            "Entity_Cd",
-            "Amount" as "Tran_Amt1",
-            "Enty_NamF" as "Tran_NamF",
-            "Enty_NamL" as "Tran_NamL"
-          FROM "497"
-          WHERE "Form_Type" = 'F497P1'
-        )
         SELECT
           "Filer_ID",
           CASE

--- a/calculators/candidate_expenditures_by_type.rb
+++ b/calculators/candidate_expenditures_by_type.rb
@@ -157,24 +157,33 @@ class CandidateExpendituresByType
       # except those that are already in Schedule E.  Note that
       # Expn_Code is not set in 496 so we use Expn_Dscr instead
       results = ActiveRecord::Base.connection.execute <<-SQL
-        SELECT "Filer_ID", COALESCE("Expn_Code", '') as "Expn_Code", SUM("Amount") AS "Total"
-        FROM
-          (SELECT "FPPC"::varchar AS "Filer_ID", "Expn_Code", "Amount"
+        WITH combined_opposing_expenditures AS (
+          SELECT
+            "FPPC"::varchar AS "Filer_ID",
+            "Expn_Code",
+            "Amount"
           FROM "E-Expenditure", "oakland_candidates"
           WHERE "Sup_Opp_Cd" = 'O'
-          AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
-          AND "Committee_Type" <> 'CTL' AND "Committee_Type" <> 'CAO'
+            AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
+            AND "Committee_Type" <> 'CTL' AND "Committee_Type" <> 'CAO'
           UNION ALL
-          SELECT "FPPC"::varchar AS "Filer_ID", "Expn_Dscr" AS "Expn_Code", "Amount"
+          SELECT
+            "FPPC"::varchar AS "Filer_ID",
+            "Expn_Dscr" AS "Expn_Code",
+            "Amount"
           FROM "496" AS "outer", "oakland_candidates"
           WHERE "Sup_Opp_Cd" = 'O'
-          AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
-          AND NOT EXISTS (SELECT 1 from "E-Expenditure" AS "inner"
+            AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
+            AND NOT EXISTS (
+              SELECT 1 FROM "E-Expenditure" AS "inner"
               WHERE "outer"."Filer_ID"::varchar = "inner"."Filer_ID"
               AND "outer"."Exp_Date" = "inner"."Expn_Date"
               AND "outer"."Amount" = "inner"."Amount"
-              AND "outer"."Cand_NamL" = "inner"."Cand_NamL")
-          ) U
+              AND "outer"."Cand_NamL" = "inner"."Cand_NamL"
+            )
+          )
+        SELECT "Filer_ID", COALESCE("Expn_Code", '') as "Expn_Code", SUM("Amount") AS "Total"
+        FROM combined_opposing_expenditures
         WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "','"}')
         GROUP BY "Expn_Code", "Filer_ID"
         ORDER BY "Expn_Code", "Filer_ID"

--- a/calculators/candidate_expenditures_by_type.rb
+++ b/calculators/candidate_expenditures_by_type.rb
@@ -112,24 +112,33 @@ class CandidateExpendituresByType
       # except those that are already in Schedule E.  Note that
       # Expn_Code is not set in 496 so we use Expn_Dscr instead
       results = ActiveRecord::Base.connection.execute <<-SQL
-        SELECT "Filer_ID", COALESCE("Expn_Code", '') as "Expn_Code", SUM("Amount") AS "Total"
-        FROM
-          (SELECT "FPPC"::varchar AS "Filer_ID", "Expn_Code", "Amount"
+        WITH combined_expenditures AS (
+          SELECT
+            "FPPC"::varchar AS "Filer_ID",
+            "Expn_Code",
+            "Amount"
           FROM "E-Expenditure", "oakland_candidates"
           WHERE "Sup_Opp_Cd" = 'S'
-          AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
-          AND "Committee_Type" <> 'CTL' AND "Committee_Type" <> 'CAO'
+            AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
+            AND "Committee_Type" <> 'CTL' AND "Committee_Type" <> 'CAO'
           UNION ALL
-          SELECT "FPPC"::varchar AS "Filer_ID", "Expn_Dscr" AS "Expn_Code", "Amount"
+          SELECT
+            "FPPC"::varchar AS "Filer_ID",
+            "Expn_Dscr" AS "Expn_Code",
+            "Amount"
           FROM "496" AS "outer", "oakland_candidates"
           WHERE "Sup_Opp_Cd" = 'S'
-          AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
-          AND NOT EXISTS (SELECT 1 from "E-Expenditure" AS "inner"
+            AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
+            AND NOT EXISTS (
+              SELECT 1 from "E-Expenditure" AS "inner"
               WHERE "outer"."Filer_ID"::varchar = "inner"."Filer_ID"
-              AND "outer"."Exp_Date" = "inner"."Expn_Date"
-              AND "outer"."Amount" = "inner"."Amount"
-              AND "outer"."Cand_NamL" = "inner"."Cand_NamL")
-          ) U
+                AND "outer"."Exp_Date" = "inner"."Expn_Date"
+                AND "outer"."Amount" = "inner"."Amount"
+                AND "outer"."Cand_NamL" = "inner"."Cand_NamL"
+            )
+          )
+        SELECT "Filer_ID", COALESCE("Expn_Code", '') as "Expn_Code", SUM("Amount") AS "Total"
+        FROM combined_expenditures
         WHERE "Filer_ID" IN ('#{@candidates_by_filer_id.keys.join "','"}')
         GROUP BY "Expn_Code", "Filer_ID"
         ORDER BY "Expn_Code", "Filer_ID"

--- a/calculators/referendum_expenditures_by_origin.rb
+++ b/calculators/referendum_expenditures_by_origin.rb
@@ -15,22 +15,7 @@ class ReferendumExpendituresByOrigin
     SQL
 
     contributions = ActiveRecord::Base.connection.execute(<<-SQL)
-      WITH combined_contributions AS (
-        SELECT "Filer_ID", "Tran_City", "Tran_State", "Tran_Amt1", "Tran_ID"
-        FROM "A-Contributions"
-        UNION
-        SELECT "Filer_ID"::varchar, "Tran_City", "Tran_State", "Tran_Amt1", "Tran_ID"
-        FROM "C-Contributions"
-        UNION
-        SELECT "Filer_ID"::varchar,
-          "Enty_City" as "Tran_City",
-          "Enty_ST" as "Tran_State",
-          "Amount" as "Tran_Amt1",
-          "Tran_ID"
-        FROM "497"
-        WHERE "Form_Type" = 'F497P1'
-      ),
-      contributions_by_locale AS (
+      WITH contributions_by_locale AS (
         SELECT "Filer_ID",
         CASE
           WHEN LOWER("Tran_City") = 'oakland' THEN 'Within Oakland'

--- a/make_view.sh
+++ b/make_view.sh
@@ -5,39 +5,42 @@ psql disclosure-backend << SQL
 ** do not report their expenditures ass supporting/opposing
 ** The measure
 */
-CREATE VIEW "Measure_Expenditures" AS
--- Map names to numbers as ballot numbers are often missing
-SELECT "Filer_ID"::varchar, "Filer_NamL",
-  "Bal_Name", "Measure_Number", "Sup_Opp_Cd", "Amount"
-FROM
-  "E-Expenditure", oakland_name_to_number
-WHERE LOWER("Bal_Name") = LOWER("Measure_Name")
--- Get IE 
-UNION ALL
-SELECT "Filer_ID"::varchar, "Filer_NamL",
-  "Bal_Name", "Measure_Number", "Sup_Opp_Cd", "Amount"
-FROM
-  "496", oakland_name_to_number
-WHERE LOWER("Bal_Name") = LOWER("Measure_Name")
-AND "Sup_Opp_Cd" IS NOT NULL
-UNION ALL
--- Get support/oppose information from committee
-SELECT expend."Filer_ID"::varchar, expend."Filer_NamL",
-  "Bal_Name",
-  "Ballot_Measure" as "Measure_Number",
-  "Support_Or_Oppose" as "Sup_Opp_Cd", "Amount"
-FROM
-  "E-Expenditure" expend,
-  oakland_committees committee
-WHERE "Bal_Name" IS NULL
-  AND expend."Filer_ID" = committee."Filer_ID"
-  AND "Ballot_Measure" IS NOT NULL
-UNION ALL
--- Get 24hr report expenditures. There is no S/O information!
-SELECT "Filer_ID"::varchar, "Filer_NamL",
-  "Bal_Name", "Measure_Number", 'Unknown' as "Sup_Opp_Cd", "Amount"
-FROM "497" LEFT OUTER JOIN "oakland_name_to_number"
-ON LOWER("Bal_Name") = LOWER("Measure_Name")
-WHERE "Bal_Name" IS NOT NULL
-AND "Form_Type" = 'F497P2'
+CREATE OR REPLACE VIEW "Measure_Expenditures" AS
+  -- Map names to numbers as ballot numbers are often missing
+  SELECT "Filer_ID"::varchar, "Filer_NamL",
+    "Bal_Name", "Measure_Number", "Sup_Opp_Cd", "Amount"
+  FROM
+    "E-Expenditure", oakland_name_to_number
+  WHERE LOWER("Bal_Name") = LOWER("Measure_Name")
+  UNION ALL
+
+  -- Get IE 
+  SELECT "Filer_ID"::varchar, "Filer_NamL",
+    "Bal_Name", "Measure_Number", "Sup_Opp_Cd", "Amount"
+  FROM
+    "496", oakland_name_to_number
+  WHERE LOWER("Bal_Name") = LOWER("Measure_Name")
+  AND "Sup_Opp_Cd" IS NOT NULL
+  UNION ALL
+
+  -- Get support/oppose information from committee
+  SELECT expend."Filer_ID"::varchar, expend."Filer_NamL",
+    "Bal_Name",
+    "Ballot_Measure" as "Measure_Number",
+    "Support_Or_Oppose" as "Sup_Opp_Cd", "Amount"
+  FROM
+    "E-Expenditure" expend,
+    oakland_committees committee
+  WHERE "Bal_Name" IS NULL
+    AND expend."Filer_ID" = committee."Filer_ID"
+    AND "Ballot_Measure" IS NOT NULL
+  UNION ALL
+
+  -- Get 24hr report expenditures. There is no S/O information!
+  SELECT "Filer_ID"::varchar, "Filer_NamL",
+    "Bal_Name", "Measure_Number", 'Unknown' as "Sup_Opp_Cd", "Amount"
+  FROM "497" LEFT OUTER JOIN "oakland_name_to_number"
+  ON LOWER("Bal_Name") = LOWER("Measure_Name")
+  WHERE "Bal_Name" IS NOT NULL
+  AND "Form_Type" = 'F497P2';
 SQL

--- a/make_view.sh
+++ b/make_view.sh
@@ -43,4 +43,25 @@ CREATE OR REPLACE VIEW "Measure_Expenditures" AS
   ON LOWER("Bal_Name") = LOWER("Measure_Name")
   WHERE "Bal_Name" IS NOT NULL
   AND "Form_Type" = 'F497P2';
+
+CREATE OR REPLACE VIEW combined_contributions AS
+  SELECT "Filer_ID"::varchar, "Entity_Cd", "Tran_Amt1", "Tran_NamF",
+    "Tran_NamL", "Tran_Date", "Tran_City", "Tran_State"
+  FROM "A-Contributions"
+  UNION ALL
+  SELECT "Filer_ID"::varchar, "Entity_Cd", "Tran_Amt1", "Tran_NamF",
+    "Tran_NamL", "Tran_Date", "Tran_City", "Tran_State"
+  FROM "C-Contributions"
+  UNION ALL
+  SELECT
+    "Filer_ID"::varchar,
+    "Entity_Cd",
+    "Amount" as "Tran_Amt1",
+    "Enty_NamF" as "Tran_NamF",
+    "Enty_NamL" as "Tran_NamL",
+    "Ctrib_Date" as "Tran_Date",
+    '' as "Tran_City",
+    '' as "Tran_State"
+  FROM "497"
+  WHERE "Form_Type" = 'F497P1';
 SQL


### PR DESCRIPTION
This is an attempt to make the SQL code we have more readable -- by hoisting the inner queries to the top as Common Table Expressions, they are easier to maintain and understand. One was even repeated in a couple places verbatim, and so I extracted it into a new view ("combined_contributions").

Ideally this would have no effect on the built files... however, switching to using the `UNION ALL` in the view from the `UNION` in the previous queries surfaced a couple bugs - that we were accidentally deduping legitimately-duplicate transactions.

My looking into the raw data seems to imply that these duplicate transactions are correct. For example, Jill Habig typically gives $50/mo to that one PAC, but one transaction is repeated twice. It's followed the next day by a transaction refunding her $50. In other cases, the transaction IDs are different between the duplicate transactions (which leads me to believe that our duplicate transaction deletion process works as intended).