### PR TITLE
Add SF Candidates to Candidates Spreadsheet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,16 +56,10 @@ createdb:
 downloads/csv/oakland_candidates.csv: bin/auto-detect-candidates
 	mkdir -p downloads/csv downloads/raw
 	# 2016 candidates
-	wget -q -O- \
-		'https://docs.google.com/spreadsheets/d/e/2PACX-1vSeuPY8huhnstJAKOoFNzwGCuTXMX6DhBU5hVVPIYmIBRLzHMGAPC2N7665gsT3F9LuLaRcBGDP4jm5/pub?gid=0&single=true&output=csv' | \
-	sed -e '1s/ /_/g' | \
-	sed -e '1s/[^a-zA-Z,_]//g' > downloads/raw/oakland_candidates_2016.csv
+	bin/auto-detect-candidates oakland-2016 > downloads/raw/oakland_candidates_2016.csv
 	# 2018 candidates
-	wget -q -O- \
-		'https://docs.google.com/spreadsheets/d/e/2PACX-1vSeuPY8huhnstJAKOoFNzwGCuTXMX6DhBU5hVVPIYmIBRLzHMGAPC2N7665gsT3F9LuLaRcBGDP4jm5/pub?gid=222087091&single=true&output=csv' | \
-	sed -e '1s/ /_/g' | \
-	sed -e '1s/[^a-zA-Z,_]//g' > downloads/raw/oakland_candidates_2018.csv
-	# make a fake entry for SF candidates
+	bin/auto-detect-candidates oakland-2018 > downloads/raw/oakland_candidates_2018.csv
+	# make a fake entry for SF candidates until they're added to the spreadsheet
 	bin/auto-detect-candidates sf-june-2018 > downloads/raw/sf_candidates_june_2018.csv
 	# combine the two years' candidates, adding an "election_name" column so we
 	#   can differentiate later.

--- a/bin/auto-detect-candidates
+++ b/bin/auto-detect-candidates
@@ -11,46 +11,8 @@ HEADERS = %i[
   Accepted_expenditure_ceiling Website Twitter Party_Affiliation Occupation Bio
   Photo VotersEdge Internal_Notes
 ]
-STUBBED_ELECTIONS = %w[sf-june-2018]
-SPREADSHEET_ELECTIONS = %w[oakland-2016 oakland-2018]
-SUPPORTED_ELECTIONS = STUBBED_ELECTIONS + SPREADSHEET_ELECTIONS
-
+SPREADSHEET_ELECTIONS = %w[oakland-2016 oakland-2018 sf-june-2018]
 SPREADSHEET_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSeuPY8huhnstJAKOoFNzwGCuTXMX6DhBU5hVVPIYmIBRLzHMGAPC2N7665gsT3F9LuLaRcBGDP4jm5/pub?gid=307879638&single=true&output=csv'
-
-def print_stubbed_election(_election)
-  # for now, don't do any autodetection and just output a static CSV.
-  require 'csv'
-
-  puts(CSV.generate(headers: HEADERS, write_headers: true) do |csv|
-    csv << {
-      FPPC: '1395306',
-      Committee_Name: 'JEFF SHEEHY FOR SUPERVISOR JUNE 2018',
-      Candidate: 'Jeff Sheehy',
-      Office: 'Supervisor District 8',
-    }
-
-    csv << {
-      FPPC: '1395947',
-      Committee_Name: 'Rafael Mandelman for Supervisor 2018 Primary',
-      Candidate: 'Rafael Mandelman',
-      Office: 'Supervisor District 8',
-    }
-
-    csv << {
-      FPPC: '1400832',
-      Committee_Name: 'Jane Kim for Mayor 2018',
-      Candidate: 'Jane Kim',
-      Office: 'Mayor',
-    }
-
-    csv << {
-      FPPC: '1396338',
-      Committee_Name: 'Mark Leno for Mayor 2018',
-      Candidate: 'Mark Leno',
-      Office: 'Mayor',
-    }
-  end)
-end
 
 def print_spreadsheet_election(election)
   puts(CSV.generate(headers: HEADERS, write_headers: true) do |out|
@@ -66,22 +28,20 @@ def print_spreadsheet_election(election)
 end
 
 election_name = ARGV.shift
-unless election_name && SUPPORTED_ELECTIONS.include?(election_name)
+unless election_name && SPREADSHEET_ELECTIONS.include?(election_name)
   puts 'Outputs a CSV of candidates for an election'
 
   puts "Usage: #{$0} [election name]"
   puts
   puts 'Supported Elections:'
-  SUPPORTED_ELECTIONS.each do |e|
+  SPREADSHEET_ELECTIONS.each do |e|
     puts "  #{e}"
   end
 
   exit 1
 end
 
-if STUBBED_ELECTIONS.include?(election_name)
-  print_stubbed_election(election_name)
-elsif SPREADSHEET_ELECTIONS.include?(election_name)
+if SPREADSHEET_ELECTIONS.include?(election_name)
   print_spreadsheet_election(election_name)
 end
 

--- a/bin/auto-detect-candidates
+++ b/bin/auto-detect-candidates
@@ -2,8 +2,68 @@
 #
 # frozen_string_literal: true
 
-HEADERS = %i[FPPC Committee_Name Candidate Aliases Office Incumbent Accepted_expenditure_ceiling Website Twitter Party_Affiliation Occupation Bio Photo VotersEdge Internal_Notes]
-SUPPORTED_ELECTIONS = %w[sf-june-2018]
+require 'csv'
+require 'open-uri'
+require 'active_support/core_ext/hash/keys'
+
+HEADERS = %i[
+  FPPC Committee_Name Candidate Aliases Office Incumbent
+  Accepted_expenditure_ceiling Website Twitter Party_Affiliation Occupation Bio
+  Photo VotersEdge Internal_Notes
+]
+STUBBED_ELECTIONS = %w[sf-june-2018]
+SPREADSHEET_ELECTIONS = %w[oakland-2016 oakland-2018]
+SUPPORTED_ELECTIONS = STUBBED_ELECTIONS + SPREADSHEET_ELECTIONS
+
+SPREADSHEET_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSeuPY8huhnstJAKOoFNzwGCuTXMX6DhBU5hVVPIYmIBRLzHMGAPC2N7665gsT3F9LuLaRcBGDP4jm5/pub?gid=307879638&single=true&output=csv'
+
+def print_stubbed_election(_election)
+  # for now, don't do any autodetection and just output a static CSV.
+  require 'csv'
+
+  puts(CSV.generate(headers: HEADERS, write_headers: true) do |csv|
+    csv << {
+      FPPC: '1395306',
+      Committee_Name: 'JEFF SHEEHY FOR SUPERVISOR JUNE 2018',
+      Candidate: 'Jeff Sheehy',
+      Office: 'Supervisor District 8',
+    }
+
+    csv << {
+      FPPC: '1395947',
+      Committee_Name: 'Rafael Mandelman for Supervisor 2018 Primary',
+      Candidate: 'Rafael Mandelman',
+      Office: 'Supervisor District 8',
+    }
+
+    csv << {
+      FPPC: '1400832',
+      Committee_Name: 'Jane Kim for Mayor 2018',
+      Candidate: 'Jane Kim',
+      Office: 'Mayor',
+    }
+
+    csv << {
+      FPPC: '1396338',
+      Committee_Name: 'Mark Leno for Mayor 2018',
+      Candidate: 'Mark Leno',
+      Office: 'Mayor',
+    }
+  end)
+end
+
+def print_spreadsheet_election(election)
+  puts(CSV.generate(headers: HEADERS, write_headers: true) do |out|
+    CSV.parse(open(SPREADSHEET_URL), headers: :first_row) do |row|
+      next unless row['Election'] == election
+
+      out << row
+        .to_hash
+        .transform_keys { |k| k.gsub(' ', '_').gsub(/[^a-zA-Z_]/, '') }
+        .symbolize_keys
+    end
+  end)
+end
 
 election_name = ARGV.shift
 unless election_name && SUPPORTED_ELECTIONS.include?(election_name)
@@ -19,36 +79,9 @@ unless election_name && SUPPORTED_ELECTIONS.include?(election_name)
   exit 1
 end
 
-# for now, don't do any autodetection and just output a static CSV.
-require 'csv'
+if STUBBED_ELECTIONS.include?(election_name)
+  print_stubbed_election(election_name)
+elsif SPREADSHEET_ELECTIONS.include?(election_name)
+  print_spreadsheet_election(election_name)
+end
 
-
-puts(CSV.generate(headers: HEADERS, write_headers: true) do |csv|
-  csv << {
-    FPPC: '1395306',
-    Committee_Name: 'JEFF SHEEHY FOR SUPERVISOR JUNE 2018',
-    Candidate: 'Jeff Sheehy',
-    Office: 'Supervisor District 8',
-  }
-
-  csv << {
-    FPPC: '1395947',
-    Committee_Name: 'Rafael Mandelman for Supervisor 2018 Primary',
-    Candidate: 'Rafael Mandelman',
-    Office: 'Supervisor District 8',
-  }
-
-  csv << {
-    FPPC: '1400832',
-    Committee_Name: 'Jane Kim for Mayor 2018',
-    Candidate: 'Jane Kim',
-    Office: 'Mayor',
-  }
-
-  csv << {
-    FPPC: '1396338',
-    Committee_Name: 'Mark Leno for Mayor 2018',
-    Candidate: 'Mark Leno',
-    Office: 'Mayor',
-  }
-end)


### PR DESCRIPTION
This updates the downloading logic to use only the "all candidates" tab in the candidates spreadsheet, which includes a column for the election name.

The `auto-detect-candidates` script fetches the spreadsheet and returns only the rows for a given election.