### PR TITLE
Fix ballot and locality Ids for non-Oakland OfficeElections and Referendums

### DIFF
--- a/process.rb
+++ b/process.rb
@@ -140,8 +140,11 @@ OaklandCommittee.includes(:calculations).find_each do |committee|
 end
 
 OaklandReferendum.find_each do |referendum|
+  ballot = (ELECTIONS.select { |e| e[:election_name] == referendum[:election_name] }).first
+  raise "Unknown ballot for election_name=#{referendum[:election_name]}" if ballot.nil?
+
   build_file("/referendum/#{referendum.id}") do |f|
-    f.puts JSON.pretty_generate(referendum.as_json.merge(ballot_id: 1))
+    f.puts JSON.pretty_generate(referendum.as_json.merge(ballot_id: ballot[:id]))
   end
 
   build_file("/referendum/#{referendum.id}/supporting") do |f|

--- a/process.rb
+++ b/process.rb
@@ -57,6 +57,7 @@ ELECTIONS = [
   { id: 4, date: '2018-11-06', election_name: 'berkeley-2018', locality_id: BERKELEY_LOCALITY_ID },
   { id: 5, date: '2018-06-05', election_name: 'sf-june-2018', locality_id: SAN_FRANCISCO_LOCALITY_ID },
   { id: 6, date: '2018-11-06', election_name: 'sf-2018', locality_id: SAN_FRANCISCO_LOCALITY_ID },
+  { id: 7, date: '2016-11-08', election_name: 'sf-2016', locality_id: SAN_FRANCISCO_LOCALITY_ID },
 ]
 
 build_file('/locality/search') do |f|

--- a/process.rb
+++ b/process.rb
@@ -48,26 +48,32 @@ end
 
 # third, write everything out to the build files
 OAKLAND_LOCALITY_ID = 2
+BERKELEY_LOCALITY_ID = 3
+SAN_FRANCISCO_LOCALITY_ID = 4
 ELECTIONS = [
   { id: 1, date: '2016-11-08', election_name: 'oakland-2016', locality_id: OAKLAND_LOCALITY_ID, is_current: true },
+  { id: 2, date: '2018-06-05', election_name: 'oakland-june-2018', locality_id: OAKLAND_LOCALITY_ID },
   { id: 3, date: '2018-11-06', election_name: 'oakland-2018', locality_id: OAKLAND_LOCALITY_ID },
-  { id: 3, date: '2018-11-06', election_name: 'berkeley-2018', locality_id: 4 },
+  { id: 4, date: '2018-11-06', election_name: 'berkeley-2018', locality_id: BERKELEY_LOCALITY_ID },
+  { id: 5, date: '2018-06-05', election_name: 'sf-june-2018', locality_id: SAN_FRANCISCO_LOCALITY_ID },
+  { id: 6, date: '2018-11-06', election_name: 'sf-2018', locality_id: SAN_FRANCISCO_LOCALITY_ID },
 ]
 
 build_file('/locality/search') do |f|
   f.puts JSON.pretty_generate([{ name: 'Oakland', type: 'city', id: OAKLAND_LOCALITY_ID }])
 end
 
+# TODO these should be objects, not arrays
 build_file("/locality/#{OAKLAND_LOCALITY_ID}") do |f|
   f.puts JSON.pretty_generate([{ name: 'Oakland', type: 'city', id: OAKLAND_LOCALITY_ID }])
 end
 
-build_file("/locality/3") do |f|
-  f.puts JSON.pretty_generate([{ name: 'San Francisco', type: 'city', id: 3 }])
+build_file("/locality/#{BERKELEY_LOCALITY_ID}") do |f|
+  f.puts JSON.pretty_generate([{ name: 'Berkeley', type: 'city', id: BERKELEY_LOCALITY_ID }])
 end
 
-build_file("/locality/4") do |f|
-  f.puts JSON.pretty_generate([{ name: 'Berkeley', type: 'city', id: 4 }])
+build_file("/locality/#{SAN_FRANCISCO_LOCALITY_ID}") do |f|
+  f.puts JSON.pretty_generate([{ name: 'San Francisco', type: 'city', id: SAN_FRANCISCO_LOCALITY_ID }])
 end
 
 


### PR DESCRIPTION
We've been hardcoding ballot_id and locality_id to Oakland. This adds the missing ballots and localities and then uses `election_name` to find the right entities to link to.