### PR TITLE
Transliterate to ascii in slugify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'activesupport', '5.2.0'
 gem 'activerecord', '5.2.0'
+gem 'i18n'
 gem 'sinatra'
 gem 'pg'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (= 5.2.0)
   activesupport (= 5.2.0)
+  i18n
   pg
   puma
   roo

--- a/process.rb
+++ b/process.rb
@@ -1,6 +1,7 @@
 require_relative './environment.rb'
 
 require 'fileutils'
+require 'i18n'
 require 'open-uri'
 
 # map of election_name => { hash including date }
@@ -22,10 +23,13 @@ def build_file(filename, &block)
   File.open(filename, 'w', &block)
 end
 
-# keep this logic in-sync with the frontend (_plugins/odca_slugify.rb)
-# (text || '').toLowerCase().replace(/[\._~!$&'()+,;=@]+/g, '').replace(/[^a-z0-9-]+/g, '-');
+# keep this logic in-sync with the frontend (Jekyll's slugify filter)
+# https://github.com/jekyll/jekyll/blob/035ea729ff5668dfc96e7f56a86d214e5a633291/lib/jekyll/utils.rb#L204
+# We add transliteration to convert non-latin characters to ascii, especially
+# for candidate names. e.g. Guillén -> guillen.
 def slugify(word)
-  (word || '').downcase.gsub(/[\._~!$&'()+,;=@]+/, '').gsub(/[^a-z0-9-]+/, '-')
+  I18n.transliterate(word || '')
+    .downcase.gsub(/[^a-z0-9-]+/, '-')
 end
 
 # Sort like:


### PR DESCRIPTION
Transliterate non-latin characters to ascii instead of dropping them entirely.
E.g Guillén -> guillen instead of guill-n

This is consistent with Jekyll's `slugify:'latin'` filter.