### PR TITLE
Fix #129

### DIFF
--- a/bin/remove_duplicate_transactions
+++ b/bin/remove_duplicate_transactions
@@ -3,6 +3,10 @@ set -euo pipefail
 
 # 1. delete duplicate 497 summary
 cat <<-QUERY | psql disclosure-backend
+DELETE FROM "496" late
+WHERE EXISTS (
+  SELECT * FROM "Summary" summary
+      WHERE summary."Filer_ID"::varchar = late."Filer_ID" AND late."Rpt_Date" <= summary."Thru_Date");
 DELETE FROM "497" late
 WHERE EXISTS (
   SELECT * FROM "Summary" summary

--- a/build/_candidates/oakland/2018-11-06/aimee-eng.md
+++ b/build/_candidates/oakland/2018-11-06/aimee-eng.md
@@ -2,7 +2,7 @@
 ballot: _ballots/oakland/2018-11-06.md
 committee_name: Aimee Eng for School Board 2018
 data_warning: |-
-  There are errors in the contribution and experditure calculations for this candidate because the finance data includes money raised for and spent on previous elections. We are working on a resolution. <span class="hover-info-container"><img src="/odca-jekyll/assets/images/icon_more_info.png" alt="Question mark in a circle">
+  This data reflects information from 2018 and prior campaign filings because the candidate is using the same campaign account for multiple elections. Therefore contribution and experditure calculations include money raised for and spent on prior elections. We are working on a resolution. <span class="hover-info-container"><img src="/odca-jekyll/assets/images/icon_more_info.png" alt="Question mark in a circle">
                        <span class="hover-info">For more detail on voluntary spending limits, see the <a href="/odca-jekyll/faq">FAQ article</a>.</span>
                 </span>
 filer_id: '1368984'

--- a/build/_candidates/oakland/2018-11-06/desley-brooks.md
+++ b/build/_candidates/oakland/2018-11-06/desley-brooks.md
@@ -2,7 +2,7 @@
 ballot: _ballots/oakland/2018-11-06.md
 committee_name: Desley Brooks for City Council 2018
 data_warning: |-
-  There are errors in the contribution and experditure calculations for this candidate because the finance data includes money raised for and spent on previous elections. We are working on a resolution.
+  This data reflects information from 2018 and prior campaign filings because the candidate is using the same campaign account for multiple elections. Therefore contribution and experditure calculations include money raised for and spent on prior elections. We are working on a resolution.
   <span class="hover-info-container"><img src="/odca-jekyll/assets/images/icon_more_info.png" alt="Question mark in a circle">
                        <span class="hover-info">For more detail on voluntary spending limits, see the <a href="/odca-jekyll/faq">FAQ article</a>.</span>
                 </span>

--- a/build/_data/candidates/berkeley/2018-11-06/kate-harrison.json
+++ b/build/_data/candidates/berkeley/2018-11-06/kate-harrison.json
@@ -21,7 +21,7 @@
     "total_contributions": 33885.86,
     "total_expenditures": 40398.84,
     "total_loans_received": -300.0,
-    "total_supporting_independent": 16064.27,
+    "total_supporting_independent": 8157.27,
     "contributions_by_type": {
       "Committee": 350.0,
       "Individual": 29454.53,
@@ -48,7 +48,7 @@
       "Information Technology Costs (Internet, E-mail)": 340.0
     },
     "supporting_by_type": {
-      "Mailer": 7907.0
+      "Independent Expenditure Supporting/Opposing Others": 7907.27
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/barbara-parker.json
+++ b/build/_data/candidates/oakland/2016-11-08/barbara-parker.json
@@ -39,6 +39,7 @@
       "Campaign Literature and Mailings": 1559.56
     },
     "supporting_by_type": {
+      "MON": 700.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/benjamin-lang.json
+++ b/build/_data/candidates/oakland/2016-11-08/benjamin-lang.json
@@ -1,5 +1,5 @@
 {
-  "id": 27,
+  "id": 28,
   "name": "Benjamin Lang",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Ben-Lang.png",
   "website_url": "http://www.benlang.com/",

--- a/build/_data/candidates/oakland/2016-11-08/chris-jackson.json
+++ b/build/_data/candidates/oakland/2016-11-08/chris-jackson.json
@@ -1,5 +1,5 @@
 {
-  "id": 35,
+  "id": 36,
   "name": "Chris Jackson",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/chris-jackson.png",
   "website_url": "http://www.chrisjacksonforoakland.org/",
@@ -40,12 +40,14 @@
       "Professional Services (Legal, Accounting)": 3020.47
     },
     "supporting_by_type": {
+      "IKD": 5924.0,
+      "MON": 1500.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 13975.5,
+    "opposing_expenditures": 6987.5,
     "opposing_by_type": {
-      "Campaign Literature and Mailings": 6988.0
+      "Independent Expenditure Supporting/Opposing Others": 6987.5
     }
   },
   "contributions_received": 14562.0,

--- a/build/_data/candidates/oakland/2016-11-08/dan-kalb.json
+++ b/build/_data/candidates/oakland/2016-11-08/dan-kalb.json
@@ -1,5 +1,5 @@
 {
-  "id": 16,
+  "id": 17,
   "name": "Dan Kalb",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/dan-kalb2.png",
   "website_url": "https://dankalb.net",
@@ -51,14 +51,14 @@
       "Transfer Between Committees of the Same Candidate/sponsor": 13500.0
     },
     "supporting_by_type": {
+      "IKD": 300.0,
+      "MON": 2200.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 24008.65,
+    "opposing_expenditures": 13241.65,
     "opposing_by_type": {
-      "Design of mailer in opposition of Dan Kalb.": 1650.0,
-      "Printing of mailer in opposition to Dan Kalb": 2917.0,
-      "Mailing and Postage in opposition to Dan Kalb": 7850.0
+      "Independent Expenditure Supporting/Opposing Others": 13241.65
     }
   },
   "contributions_received": 111576.66,

--- a/build/_data/candidates/oakland/2016-11-08/donald-macleay.json
+++ b/build/_data/candidates/oakland/2016-11-08/donald-macleay.json
@@ -1,5 +1,5 @@
 {
-  "id": 24,
+  "id": 25,
   "name": "Donald Macleay",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Donald-Macleay1.png",
   "website_url": "http://www.don4ousd.org/",

--- a/build/_data/candidates/oakland/2016-11-08/huber-trenado.json
+++ b/build/_data/candidates/oakland/2016-11-08/huber-trenado.json
@@ -1,5 +1,5 @@
 {
-  "id": 33,
+  "id": 34,
   "name": "Huber Trenado",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Huber-Trenado.png",
   "website_url": "http://www.votetrenadoousd.com/",
@@ -21,7 +21,7 @@
     "total_contributions": 21685.48,
     "total_expenditures": 23562.66,
     "total_loans_received": 0.0,
-    "total_supporting_independent": 159759.96,
+    "total_supporting_independent": 87932.96,
     "contributions_by_type": {
       "Individual": 16163.31,
       "Unitemized": 1798.0,
@@ -45,16 +45,8 @@
       "Information Technology Costs (Internet, E-mail)": 833.57
     },
     "supporting_by_type": {
-      "CANVASSING": 5000.0,
-      "STAFF TIME": 18880.0,
-      "Phone Banks": 360.0,
-      "ESTIMATE OF LIT": 8981.0,
-      "CMP; SEE SCHEDULE G": 2702.0,
-      "ESTIMATE OF STAFF TIME": 7100.0,
-      "Campaign Paraphernalia/Misc.": 2702.0,
-      "Campaign Literature and Mailings": 41137.0,
-      "STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 8427.0,
-      "Information Technology Costs (Internet, E-mail)": 6050.0
+      "MON": 1500.0,
+      "Independent Expenditure Supporting/Opposing Others": 99288.96
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/james-harris.json
+++ b/build/_data/candidates/oakland/2016-11-08/james-harris.json
@@ -1,5 +1,5 @@
 {
-  "id": 34,
+  "id": 35,
   "name": "James Harris",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/james-harris.png",
   "website_url": "http://harrisforeastoakland.com/about-james/",
@@ -21,7 +21,7 @@
     "total_contributions": 27586.0,
     "total_expenditures": 26950.43,
     "total_loans_received": 0.0,
-    "total_supporting_independent": 230970.0,
+    "total_supporting_independent": 115082.0,
     "contributions_by_type": {
       "Committee": 5700.0,
       "Individual": 21536.0,
@@ -44,17 +44,8 @@
       "Professional Services (Legal, Accounting)": 4542.81
     },
     "supporting_by_type": {
-      "Print Ads": 2000.0,
-      "CANVASSING": 5000.0,
-      "STAFF TIME": 27904.0,
-      "Phone Banks": 759.0,
-      "ESTIMATE OF LIT": 7915.0,
-      "CMP; SEE SCHEDULE G": 2702.0,
-      "ESTIMATE OF STAFF TIME": 11278.0,
-      "Campaign Paraphernalia/Misc.": 2702.0,
-      "Campaign Literature and Mailings": 79635.0,
-      "STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 10414.0,
-      "Information Technology Costs (Internet, E-mail)": 8725.0
+      "MON": 2500.0,
+      "Independent Expenditure Supporting/Opposing Others": 122967.01
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/jody-london.json
+++ b/build/_data/candidates/oakland/2016-11-08/jody-london.json
@@ -1,5 +1,5 @@
 {
-  "id": 25,
+  "id": 26,
   "name": "Jody London",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Jody-London2.jpg.png",
   "website_url": "http://www.votejody.com/",
@@ -21,7 +21,7 @@
     "total_contributions": 22344.0,
     "total_expenditures": 23891.0,
     "total_loans_received": 0.0,
-    "total_supporting_independent": 6572.73,
+    "total_supporting_independent": 2690.73,
     "contributions_by_type": {
       "Committee": 500.0,
       "Individual": 15485.0,
@@ -43,9 +43,7 @@
       "Campaign Literature and Mailings": 15150.0
     },
     "supporting_by_type": {
-      "STAFF TIME": 1977.0,
-      "Campaign Literature and Mailings": 48.0,
-      "ESTIMATE OF STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 1905.0
+      "Independent Expenditure Supporting/Opposing Others": 2690.73
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/jumoke-hinton-hodge.json
+++ b/build/_data/candidates/oakland/2016-11-08/jumoke-hinton-hodge.json
@@ -1,5 +1,5 @@
 {
-  "id": 26,
+  "id": 27,
   "name": "Jumoke Hinton Hodge",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Hinton-Hodge.png",
   "website_url": "https://hintonhodge.nationbuilder.com/",
@@ -21,7 +21,7 @@
     "total_contributions": 25041.85,
     "total_expenditures": 25486.04,
     "total_loans_received": 7125.0,
-    "total_supporting_independent": 203262.03,
+    "total_supporting_independent": 91923.03,
     "contributions_by_type": {
       "Committee": 1500.0,
       "Individual": 15788.0,
@@ -42,16 +42,8 @@
       "Information Technology Costs (Internet, E-mail)": 2056.29
     },
     "supporting_by_type": {
-      "Print Ads": 2000.0,
-      "STAFF TIME": 15112.0,
-      "Phone Banks": 373.0,
-      "ESTIMATE OF LIT": 1800.0,
-      "CMP; SEE SCHEDULE G": 2702.0,
-      "ESTIMATE OF STAFF TIME": 7844.0,
-      "Campaign Paraphernalia/Misc.": 2702.0,
-      "Campaign Literature and Mailings": 77957.0,
-      "STAFF TIME COVERING 11/1/16 THROUGH 11/8/16": 6256.0,
-      "Information Technology Costs (Internet, E-mail)": 1050.0
+      "MON": 1500.0,
+      "Independent Expenditure Supporting/Opposing Others": 90423.03
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/kevin-corbett.json
+++ b/build/_data/candidates/oakland/2016-11-08/kevin-corbett.json
@@ -1,5 +1,5 @@
 {
-  "id": 15,
+  "id": 16,
   "name": "Kevin Corbett",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Kevin-Corbett.png",
   "website_url": "http://www.corbett4oakland.com/meet-kevin/",

--- a/build/_data/candidates/oakland/2016-11-08/kharyshi-wiginton.json
+++ b/build/_data/candidates/oakland/2016-11-08/kharyshi-wiginton.json
@@ -1,5 +1,5 @@
 {
-  "id": 28,
+  "id": 29,
   "name": "Kharyshi Wiginton",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Kharyshi-Wiginton.png",
   "website_url": "http://www.mskfordistrict3sb.com/",
@@ -44,6 +44,8 @@
       "Information Technology Costs (Internet, E-mail)": 381.89
     },
     "supporting_by_type": {
+      "IKD": 5924.0,
+      "MON": 250.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/larry-reid.json
+++ b/build/_data/candidates/oakland/2016-11-08/larry-reid.json
@@ -1,5 +1,5 @@
 {
-  "id": 23,
+  "id": 24,
   "name": "Larry Reid",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/larry-reid.png",
   "website_url": "https://www.facebook.com/LarryReid4District7/",
@@ -48,6 +48,8 @@
       "Information Technology Costs (Internet, E-mail)": 2575.69
     },
     "supporting_by_type": {
+      "IKD": 530.0,
+      "MON": 2100.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/lucky-narain.json
+++ b/build/_data/candidates/oakland/2016-11-08/lucky-narain.json
@@ -1,5 +1,5 @@
 {
-  "id": 29,
+  "id": 30,
   "name": "Lucky Narain",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Lucky-Narain.png",
   "website_url": null,

--- a/build/_data/candidates/oakland/2016-11-08/lynette-gibson-mcelhaney.json
+++ b/build/_data/candidates/oakland/2016-11-08/lynette-gibson-mcelhaney.json
@@ -1,5 +1,5 @@
 {
-  "id": 17,
+  "id": 18,
   "name": "Lynette Gibson McElhaney",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Lynette-Gibson-McElhaney.png",
   "website_url": "http://www.lynettemcelhaney.com/",
@@ -50,6 +50,7 @@
       "Information Technology Costs (Internet, E-mail)": 4228.5
     },
     "supporting_by_type": {
+      "MON": 3150.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/marcie-hodge.json
+++ b/build/_data/candidates/oakland/2016-11-08/marcie-hodge.json
@@ -1,5 +1,5 @@
 {
-  "id": 21,
+  "id": 22,
   "name": "Marcie Hodge",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Marcie-Hodge.png",
   "website_url": "http://hodge4oaklandcitycouncil.com/",

--- a/build/_data/candidates/oakland/2016-11-08/michael-hassid.json
+++ b/build/_data/candidates/oakland/2016-11-08/michael-hassid.json
@@ -1,5 +1,5 @@
 {
-  "id": 30,
+  "id": 31,
   "name": "Michael Hassid",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Michael-Hassid.png",
   "website_url": "http://www.mikehassidforschoolboard.com/",

--- a/build/_data/candidates/oakland/2016-11-08/michael-hutchinson.json
+++ b/build/_data/candidates/oakland/2016-11-08/michael-hutchinson.json
@@ -1,5 +1,5 @@
 {
-  "id": 31,
+  "id": 32,
   "name": "Michael Hutchinson",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Mike-Hutchinson.png",
   "website_url": "https://mikehutchinsonforschoolboard.wordpress.com/",

--- a/build/_data/candidates/oakland/2016-11-08/nehanda-imara.json
+++ b/build/_data/candidates/oakland/2016-11-08/nehanda-imara.json
@@ -1,5 +1,5 @@
 {
-  "id": 22,
+  "id": 23,
   "name": "Nehanda Imara",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Nehanda_Imara.png",
   "website_url": "http://www.nehandafordistrict7.com/",
@@ -43,6 +43,7 @@
       "Professional Services (Legal, Accounting)": 3147.37
     },
     "supporting_by_type": {
+      "MON": 1500.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/noel-gallo.json
+++ b/build/_data/candidates/oakland/2016-11-08/noel-gallo.json
@@ -1,5 +1,5 @@
 {
-  "id": 19,
+  "id": 20,
   "name": "Noel Gallo",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Noel-Gallo.png",
   "website_url": "http://galloforoakland.com/",
@@ -47,20 +47,13 @@
       "Professional Services (Legal, Accounting)": 21788.0
     },
     "supporting_by_type": {
+      "MON": 700.0
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 63479.35,
+    "opposing_expenditures": 39316.35,
     "opposing_by_type": {
-      "Postage": 4714.0,
-      "Mailer Design": 1650.0,
-      "Mailer Printing": 2438.0,
-      "Mailhouse \u0026 Postage": 3699.0,
-      "Digital Ad in opposition to Noel Gallo": 9250.0,
-      "Design of mailer in opposition to Noel Gallo": 3300.0,
-      "Design of mailer in opposition of Noel Gallo.": 1650.0,
-      "Printing of mailer in opposition to Noel Gallo": 5914.0,
-      "Mailing and Postage in opposition to Noel Gallo": 7398.0
+      "Independent Expenditure Supporting/Opposing Others": 39316.35
     }
   },
   "contributions_received": 79310.69,

--- a/build/_data/candidates/oakland/2016-11-08/noni-session.json
+++ b/build/_data/candidates/oakland/2016-11-08/noni-session.json
@@ -1,5 +1,5 @@
 {
-  "id": 18,
+  "id": 19,
   "name": "Noni Session",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Noni-Session2.png",
   "website_url": "http://www.nonifordistrict3.com/",
@@ -43,6 +43,7 @@
       "Information Technology Costs (Internet, E-mail)": 387.0
     },
     "supporting_by_type": {
+      "MON": 700.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/peggy-moore.json
+++ b/build/_data/candidates/oakland/2016-11-08/peggy-moore.json
@@ -1,5 +1,5 @@
 {
-  "id": 14,
+  "id": 15,
   "name": "Peggy Moore",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Margaret-Moore.png",
   "website_url": "http://www.mooreforoakland.com/",
@@ -48,6 +48,7 @@
       "Information Technology Costs (Internet, E-mail)": 9961.9
     },
     "supporting_by_type": {
+      "MON": 1400.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/rebecca-kaplan.json
+++ b/build/_data/candidates/oakland/2016-11-08/rebecca-kaplan.json
@@ -51,6 +51,7 @@
       "Information Technology Costs (Internet, E-mail)": 4170.18
     },
     "supporting_by_type": {
+      "MON": 2100.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2016-11-08/roseann-torres.json
+++ b/build/_data/candidates/oakland/2016-11-08/roseann-torres.json
@@ -1,5 +1,5 @@
 {
-  "id": 32,
+  "id": 33,
   "name": "Roseann Torres",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Roseann-Torres.png",
   "website_url": "https://www.facebook.com/torresforschoolboard/home?ref=page_internal",
@@ -46,12 +46,13 @@
       "Information Technology Costs (Internet, E-mail)": 400.0
     },
     "supporting_by_type": {
+      "IKD": 5924.0,
+      "Independent Expenditure Supporting/Opposing Others": 6987.5
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 6988.0,
+    "opposing_expenditures": null,
     "opposing_by_type": {
-      "Campaign Literature and Mailings": 6988.0
     }
   },
   "contributions_received": 36273.01,

--- a/build/_data/candidates/oakland/2016-11-08/viola-gonzales.json
+++ b/build/_data/candidates/oakland/2016-11-08/viola-gonzales.json
@@ -1,5 +1,5 @@
 {
-  "id": 20,
+  "id": 21,
   "name": "Viola Gonzales",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/Viola-Gonzales.png",
   "website_url": "http://www.voteviola.com/",
@@ -44,6 +44,7 @@
       "Information Technology Costs (Internet, E-mail)": 3150.0
     },
     "supporting_by_type": {
+      "MON": 1400.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2018-11-06/abel-guillen.json
+++ b/build/_data/candidates/oakland/2018-11-06/abel-guillen.json
@@ -1,5 +1,5 @@
 {
-  "id": 39,
+  "id": 40,
   "name": "Abel Guillén",
   "photo_url": "abel_guillen-600x600.png",
   "website_url": "http://www.voteabelguillen.com/",

--- a/build/_data/candidates/oakland/2018-11-06/ahmad-anderson.json
+++ b/build/_data/candidates/oakland/2018-11-06/ahmad-anderson.json
@@ -1,5 +1,5 @@
 {
-  "id": 59,
+  "id": 60,
   "name": "Ahmad Anderson",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/aimee-eng.json
+++ b/build/_data/candidates/oakland/2018-11-06/aimee-eng.json
@@ -1,5 +1,5 @@
 {
-  "id": 37,
+  "id": 38,
   "name": "Aimee Eng",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/annie-campbell-washington.json
+++ b/build/_data/candidates/oakland/2018-11-06/annie-campbell-washington.json
@@ -1,5 +1,5 @@
 {
-  "id": 38,
+  "id": 39,
   "name": "Annie Campbell Washington",
   "photo_url": "anne_campbell-washington-600x600.png",
   "website_url": null,
@@ -40,6 +40,7 @@
       "Information Technology Costs (Internet, E-mail)": 3131.38
     },
     "supporting_by_type": {
+      "MON": 700.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2018-11-06/brenda-roberts.json
+++ b/build/_data/candidates/oakland/2018-11-06/brenda-roberts.json
@@ -1,5 +1,5 @@
 {
-  "id": 46,
+  "id": 47,
   "name": "Brenda Roberts",
   "photo_url": "brenda_roberts-600x600.png",
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/cedric-anthony-troupe.json
+++ b/build/_data/candidates/oakland/2018-11-06/cedric-anthony-troupe.json
@@ -1,5 +1,5 @@
 {
-  "id": 63,
+  "id": 64,
   "name": "Cedric Anthony Troupe",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/chris-young.json
+++ b/build/_data/candidates/oakland/2018-11-06/chris-young.json
@@ -1,5 +1,5 @@
 {
-  "id": 54,
+  "id": 55,
   "name": "Chris Young",
   "photo_url": null,
   "website_url": "https://www.chris4oakland.com/",

--- a/build/_data/candidates/oakland/2018-11-06/clarissa-doutherd.json
+++ b/build/_data/candidates/oakland/2018-11-06/clarissa-doutherd.json
@@ -1,5 +1,5 @@
 {
-  "id": 66,
+  "id": 67,
   "name": "Clarissa Doutherd",
   "photo_url": null,
   "website_url": "https://www.clarissaforoaklandschools.com/",

--- a/build/_data/candidates/oakland/2018-11-06/desley-brooks.json
+++ b/build/_data/candidates/oakland/2018-11-06/desley-brooks.json
@@ -1,5 +1,5 @@
 {
-  "id": 36,
+  "id": 37,
   "name": "Desley Brooks",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/ebony-edgerson.json
+++ b/build/_data/candidates/oakland/2018-11-06/ebony-edgerson.json
@@ -1,5 +1,5 @@
 {
-  "id": 49,
+  "id": 50,
   "name": "Ebony Edgerson",
   "photo_url": null,
   "website_url": "http://www.ebony4district6.com/",

--- a/build/_data/candidates/oakland/2018-11-06/jesse-a-j-smith.json
+++ b/build/_data/candidates/oakland/2018-11-06/jesse-a-j-smith.json
@@ -1,5 +1,5 @@
 {
-  "id": 62,
+  "id": 63,
   "name": "Jesse A.J. Smith",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/jonathan-selsley.json
+++ b/build/_data/candidates/oakland/2018-11-06/jonathan-selsley.json
@@ -1,5 +1,5 @@
 {
-  "id": 58,
+  "id": 59,
   "name": "Jonathan Selsley",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/joseph-tanios.json
+++ b/build/_data/candidates/oakland/2018-11-06/joseph-tanios.json
@@ -1,5 +1,5 @@
 {
-  "id": 55,
+  "id": 56,
   "name": "Joseph Tanios",
   "photo_url": null,
   "website_url": "https://www.joetanios.com/",

--- a/build/_data/candidates/oakland/2018-11-06/ken-houston.json
+++ b/build/_data/candidates/oakland/2018-11-06/ken-houston.json
@@ -1,5 +1,5 @@
 {
-  "id": 60,
+  "id": 61,
   "name": "Ken Houston",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/libby-schaaf.json
+++ b/build/_data/candidates/oakland/2018-11-06/libby-schaaf.json
@@ -1,5 +1,5 @@
 {
-  "id": 40,
+  "id": 41,
   "name": "Libby Schaaf",
   "photo_url": null,
   "website_url": "https://libbyformayor.wordpress.com/",
@@ -42,6 +42,7 @@
       "Information Technology Costs (Internet, E-mail)": 975.0
     },
     "supporting_by_type": {
+      "MON": 3400.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2018-11-06/loren-taylor.json
+++ b/build/_data/candidates/oakland/2018-11-06/loren-taylor.json
@@ -1,5 +1,5 @@
 {
-  "id": 42,
+  "id": 43,
   "name": "Loren Taylor",
   "photo_url": null,
   "website_url": "https://www.lorentaylor.org/",

--- a/build/_data/candidates/oakland/2018-11-06/marchon-tatmon.json
+++ b/build/_data/candidates/oakland/2018-11-06/marchon-tatmon.json
@@ -1,5 +1,5 @@
 {
-  "id": 45,
+  "id": 46,
   "name": "Marchon Tatmon",
   "photo_url": null,
   "website_url": "http://votemarchon.com/",

--- a/build/_data/candidates/oakland/2018-11-06/maria-marlo-rodriguez.json
+++ b/build/_data/candidates/oakland/2018-11-06/maria-marlo-rodriguez.json
@@ -1,5 +1,5 @@
 {
-  "id": 48,
+  "id": 49,
   "name": "Maria \"Marlo\" Rodriguez",
   "photo_url": null,
   "website_url": "https://www.marlo4oakland.com/",

--- a/build/_data/candidates/oakland/2018-11-06/mya-whitaker.json
+++ b/build/_data/candidates/oakland/2018-11-06/mya-whitaker.json
@@ -1,5 +1,5 @@
 {
-  "id": 51,
+  "id": 52,
   "name": "Mya Whitaker",
   "photo_url": null,
   "website_url": "https://whitakerforoakland.com",

--- a/build/_data/candidates/oakland/2018-11-06/nancy-sidebotham.json
+++ b/build/_data/candidates/oakland/2018-11-06/nancy-sidebotham.json
@@ -1,5 +1,5 @@
 {
-  "id": 61,
+  "id": 62,
   "name": "Nancy Sidebotham",
   "photo_url": "https://s3-us-west-1.amazonaws.com/odca-candidate-photos/nancy-sidebotham2.png",
   "website_url": "http://nancysidebotham.com/",

--- a/build/_data/candidates/oakland/2018-11-06/natasha-middleton.json
+++ b/build/_data/candidates/oakland/2018-11-06/natasha-middleton.json
@@ -1,5 +1,5 @@
 {
-  "id": 44,
+  "id": 45,
   "name": "Natasha Middleton",
   "photo_url": null,
   "website_url": "https://www.natashaforoakland.com/",

--- a/build/_data/candidates/oakland/2018-11-06/nayeli-maxson.json
+++ b/build/_data/candidates/oakland/2018-11-06/nayeli-maxson.json
@@ -1,5 +1,5 @@
 {
-  "id": 50,
+  "id": 51,
   "name": "Nayeli Maxson",
   "photo_url": "Nayeli-Maxson-600x600.png",
   "website_url": "https://nayeliforoakland.com/",

--- a/build/_data/candidates/oakland/2018-11-06/nikki-fortunato-bas.json
+++ b/build/_data/candidates/oakland/2018-11-06/nikki-fortunato-bas.json
@@ -1,5 +1,5 @@
 {
-  "id": 41,
+  "id": 42,
   "name": "Nikki Fortunato Bas",
   "photo_url": "nikki_fortunato_bas-600x600.png",
   "website_url": "http://www.nikki4oakland.com/launch",

--- a/build/_data/candidates/oakland/2018-11-06/pamela-harris.json
+++ b/build/_data/candidates/oakland/2018-11-06/pamela-harris.json
@@ -1,5 +1,5 @@
 {
-  "id": 57,
+  "id": 58,
   "name": "Pamela Harris",
   "photo_url": null,
   "website_url": "https://www.pamharris4oakland.com/",

--- a/build/_data/candidates/oakland/2018-11-06/randolph-wilkins.json
+++ b/build/_data/candidates/oakland/2018-11-06/randolph-wilkins.json
@@ -1,5 +1,5 @@
 {
-  "id": 65,
+  "id": 66,
   "name": "Randolph Wilkins",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/rebecca-kaplan.json
+++ b/build/_data/candidates/oakland/2018-11-06/rebecca-kaplan.json
@@ -1,5 +1,5 @@
 {
-  "id": 56,
+  "id": 57,
   "name": "Rebecca Kaplan",
   "photo_url": null,
   "website_url": "http://kaplanforoakland.org/",
@@ -29,6 +29,7 @@
     "expenditures_by_type": {
     },
     "supporting_by_type": {
+      "MON": 2100.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2018-11-06/saied-karamooz.json
+++ b/build/_data/candidates/oakland/2018-11-06/saied-karamooz.json
@@ -1,5 +1,5 @@
 {
-  "id": 43,
+  "id": 44,
   "name": "Saied Karamooz",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/shanthi-gonzales.json
+++ b/build/_data/candidates/oakland/2018-11-06/shanthi-gonzales.json
@@ -1,5 +1,5 @@
 {
-  "id": 47,
+  "id": 48,
   "name": "Shanthi Gonzales",
   "photo_url": null,
   "website_url": "http://gonzalesforschools.nationbuilder.com/",
@@ -36,6 +36,7 @@
       "Professional Services (Legal, Accounting)": 457.51
     },
     "supporting_by_type": {
+      "MON": 250.0
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/oakland/2018-11-06/sheilagh-cat-brooks-polk.json
+++ b/build/_data/candidates/oakland/2018-11-06/sheilagh-cat-brooks-polk.json
@@ -1,5 +1,5 @@
 {
-  "id": 53,
+  "id": 54,
   "name": "Sheilagh \"Cat Brooks\" Polk",
   "photo_url": null,
   "website_url": "https://www.catbrooksforoakland.com/",

--- a/build/_data/candidates/oakland/2018-11-06/shelton-dunson.json
+++ b/build/_data/candidates/oakland/2018-11-06/shelton-dunson.json
@@ -1,5 +1,5 @@
 {
-  "id": 64,
+  "id": 65,
   "name": "Shelton Dunson",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/oakland/2018-11-06/sheng-thao.json
+++ b/build/_data/candidates/oakland/2018-11-06/sheng-thao.json
@@ -1,5 +1,5 @@
 {
-  "id": 52,
+  "id": 53,
   "name": "Sheng Thao",
   "photo_url": "Sheng-Thao-600x600.png",
   "website_url": "https://www.shengforoakland.com/",

--- a/build/_data/candidates/sf/2018-06-05/jane-kim.json
+++ b/build/_data/candidates/sf/2018-06-05/jane-kim.json
@@ -1,5 +1,5 @@
 {
-  "id": 11,
+  "id": 12,
   "name": "Jane Kim",
   "photo_url": null,
   "website_url": null,
@@ -21,7 +21,7 @@
     "total_contributions": 545499.29,
     "total_expenditures": 1006669.74,
     "total_loans_received": 0.0,
-    "total_supporting_independent": 234651.83,
+    "total_supporting_independent": 178260.83,
     "contributions_by_type": {
       "PTY": 496.52,
       "Committee": 6850.0,
@@ -57,49 +57,34 @@
       "Information Technology Costs (Internet, E-mail)": 81421.72
     },
     "supporting_by_type": {
-      "Signs": 784.0,
-      "Payroll": 5004.0,
-      "Palmcard": 4448.0,
+      "MON": 4700.0,
       "Print Ad": 1275.0,
       "Print ad": 6460.0,
       "Radio ad": 2340.0,
       "WEB; CNS": 845.0,
-      "Postcards": 923.0,
-      "Print Ads": 3326.0,
-      "Radio Ads": 9640.0,
+      "Radio Ads": 1000.0,
       "Digital Ad": 5642.0,
-      "Doorhanger": 7654.0,
-      "Walk Piece": 469.0,
+      "Doorhanger": 286.0,
       "Digital Ads": 3150.0,
       "Doorhangers": 993.0,
       "Email blast": 1853.0,
-      "Newspaper Ad": 29439.0,
-      "Window Signs": 1047.0,
-      "Television Ad": 41300.0,
-      "Civic Donations": 387.38,
+      "Newspaper Ad": 5484.0,
+      "Television Ad": 6400.0,
       "Estimated Payroll": 11705.0,
-      "Campaign Consultants": 8153.0,
-      "Print Ads - Estimated": 6419.0,
       "Doorhanger Photography": 125.0,
-      "Meetings and Appearances": 756.0,
-      "Social Media Advertising": 2500.0,
-      "Radio Airtime and Production Costs": 2648.0,
-      "Professional Services (Legal, Accounting)": 2619.62,
       "T.V. or Cable Airtime and Production Costs": 3750.0,
-      "Information Technology Costs (Internet, E-mail)": 28820.0
+      "Information Technology Costs (Internet, E-mail)": 13975.0,
+      "Independent Expenditure Supporting/Opposing Others": 110777.83
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 315354.67000000004,
+    "opposing_expenditures": 265195.67,
     "opposing_by_type": {
-      "Mailer (Estimated Costs)": 49632.0,
       "Digital Ad (Estimated Costs)": 2000.0,
-      "Online Ads (Estimated Costs)": 129500.0,
       "Campaign Literature and Mailings": 25063.0,
-      "Bay Area Reporter Print Advertisement": 527.0,
-      "San Francisco Media Co.Print Advertisement": 527.0,
       "T.V. or Cable Airtime and Production Costs": 40000.0,
-      "Information Technology Costs (Internet, E-mail)": 19000.0
+      "Information Technology Costs (Internet, E-mail)": 19000.0,
+      "Independent Expenditure Supporting/Opposing Others": 179132.67
     }
   },
   "contributions_received": 545499.29,

--- a/build/_data/candidates/sf/2018-06-05/jeff-sheehy.json
+++ b/build/_data/candidates/sf/2018-06-05/jeff-sheehy.json
@@ -1,5 +1,5 @@
 {
-  "id": 67,
+  "id": 68,
   "name": "Jeff Sheehy",
   "photo_url": null,
   "website_url": "http://jeffsheehy.org/",
@@ -21,7 +21,7 @@
     "total_contributions": 197968.97,
     "total_expenditures": 314831.36,
     "total_loans_received": 0.0,
-    "total_supporting_independent": 82777.16,
+    "total_supporting_independent": 70762.16,
     "contributions_by_type": {
       "Committee": 8417.0,
       "Individual": 177705.17,
@@ -48,10 +48,11 @@
       "Information Technology Costs (Internet, E-mail)": 2350.0
     },
     "supporting_by_type": {
+      "MON": 1500.0,
       "Phone Banks": 1999.0,
-      "WEB (ESTIMATE)": 5000.0,
-      "Campaign Literature and Mailings": 54366.0,
-      "Information Technology Costs (Internet, E-mail)": 12000.0
+      "Campaign Literature and Mailings": 42351.0,
+      "Information Technology Costs (Internet, E-mail)": 7000.0,
+      "Independent Expenditure Supporting/Opposing Others": 34049.16
     }
   },
   "opposing_money": {

--- a/build/_data/candidates/sf/2018-06-05/london-breed.json
+++ b/build/_data/candidates/sf/2018-06-05/london-breed.json
@@ -1,5 +1,5 @@
 {
-  "id": 13,
+  "id": 14,
   "name": "London Breed",
   "photo_url": null,
   "website_url": null,

--- a/build/_data/candidates/sf/2018-06-05/mark-leno.json
+++ b/build/_data/candidates/sf/2018-06-05/mark-leno.json
@@ -1,5 +1,5 @@
 {
-  "id": 12,
+  "id": 13,
   "name": "Mark Leno",
   "photo_url": null,
   "website_url": null,
@@ -21,7 +21,7 @@
     "total_contributions": 1282488.19,
     "total_expenditures": 2465120.9,
     "total_loans_received": 0.0,
-    "total_supporting_independent": 205511.42,
+    "total_supporting_independent": 131842.42,
     "contributions_by_type": {
       "Committee": 16000.0,
       "Individual": 868916.96,
@@ -54,45 +54,28 @@
       "Information Technology Costs (Internet, E-mail)": 36975.79
     },
     "supporting_by_type": {
-      "Data": 102.0,
-      "Signs": 784.0,
+      "MON": 1000.0,
       "Print Ad": 1275.0,
       "Print ad": 6590.0,
       "Radio ad": 2210.0,
       "WEB; CNS": 845.0,
-      "Billboard": 960.0,
-      "Postcards": 923.0,
-      "Print Ads": 3326.0,
-      "Doorhanger": 1177.0,
-      "Online Ads": 488.0,
-      "Walk Piece": 469.0,
+      "Doorhanger": 286.0,
       "Doorhangers": 993.0,
       "Email blast": 1853.0,
-      "Newspaper Ad": 5995.0,
+      "Newspaper Ad": 4748.0,
       "Text Messages": 5971.0,
-      "Google Adwords": 750.0,
-      "Postcard - ESTIMATE": 413.0,
-      "Walkcard - ESTIMATE": 304.0,
-      "Newspaper Ads Design": 120.0,
-      "Print Ads - Estimated": 6419.0,
       "Doorhanger Photography": 125.0,
-      "Social Media Advertising": 2500.0,
-      "Social Media Ads - ESTIMATE": 1500.0,
-      "Online Ads (Estimated Costs)": 54575.0,
-      "Radio Airtime and Production Costs": 2648.0,
       "T.V. or Cable Airtime and Production Costs": 3750.0,
-      "Information Technology Costs (Internet, E-mail)": 21475.0
+      "Information Technology Costs (Internet, E-mail)": 13975.0,
+      "Independent Expenditure Supporting/Opposing Others": 90721.42
     }
   },
   "opposing_money": {
-    "opposing_expenditures": 136309.37,
+    "opposing_expenditures": 108891.37,
     "opposing_by_type": {
-      "Mailer (Estimated Costs)": 26891.0,
-      "Website (Estimated Costs)": 2500.0,
       "Digital Ad (Estimated Costs)": 2000.0,
-      "Online Ads (Estimated Costs)": 77500.0,
-      "Bay Area Reporter Print Advertisement": 527.0,
-      "San Francisco Media Co.Print Advertisement": 527.0
+      "Online Ads (Estimated Costs)": 5000.0,
+      "Independent Expenditure Supporting/Opposing Others": 101891.37
     }
   },
   "contributions_received": 1282488.19,

--- a/build/_data/candidates/sf/2018-06-05/rafael-mandelman.json
+++ b/build/_data/candidates/sf/2018-06-05/rafael-mandelman.json
@@ -1,5 +1,5 @@
 {
-  "id": 68,
+  "id": 11,
   "name": "Rafael Mandelman",
   "photo_url": null,
   "website_url": "http://www.rafaelmandelman.com/",
@@ -21,7 +21,7 @@
     "total_contributions": 272184.67,
     "total_expenditures": 379945.38,
     "total_loans_received": 0.0,
-    "total_supporting_independent": 8864.82,
+    "total_supporting_independent": 7469.82,
     "contributions_by_type": {
       "Committee": 3281.2,
       "Individual": 245091.01,
@@ -49,16 +49,10 @@
       "Information Technology Costs (Internet, E-mail)": 12576.01
     },
     "supporting_by_type": {
-      "Data": 62.0,
-      "Billboard": 251.0,
-      "Online Ads": 206.0,
-      "Newspaper Ad": 1335.0,
+      "MON": 1000.0,
+      "Newspaper Ad": 943.0,
       "Text Messages": 1492.0,
-      "Google Adwords": 375.0,
-      "Postcard - ESTIMATE": 235.0,
-      "Walkcard - ESTIMATE": 202.0,
-      "Newspaper Ads Design": 47.0,
-      "Social Media Ads - ESTIMATE": 1200.0
+      "Independent Expenditure Supporting/Opposing Others": 4034.82
     }
   },
   "opposing_money": {

--- a/build/_data/committees/1307016.json
+++ b/build/_data/committees/1307016.json
@@ -72,17 +72,17 @@
     },
     {
       "Filer_ID": "1307016",
-      "Tran_Amt1": 9499.5,
-      "Tran_Date": "2016-09-21",
-      "Tran_NamF": null,
-      "Tran_NamL": "CP VI Franklin, LLC"
-    },
-    {
-      "Filer_ID": "1307016",
       "Tran_Amt1": 5500.5,
       "Tran_Date": "2016-09-21",
       "Tran_NamF": null,
       "Tran_NamL": "CP V JLS, LLC"
+    },
+    {
+      "Filer_ID": "1307016",
+      "Tran_Amt1": 9499.5,
+      "Tran_Date": "2016-09-21",
+      "Tran_NamF": null,
+      "Tran_NamL": "CP VI Franklin, LLC"
     },
     {
       "Filer_ID": "1307016",

--- a/build/_data/committees/1310647.json
+++ b/build/_data/committees/1310647.json
@@ -166,14 +166,14 @@
       "Tran_Amt1": 12500.0,
       "Tran_Date": "2018-06-29",
       "Tran_NamF": null,
-      "Tran_NamL": "Carmel Partners VI Franklin  LLC"
+      "Tran_NamL": "Carmel Partners V JLS  LLC"
     },
     {
       "Filer_ID": "1310647",
       "Tran_Amt1": 12500.0,
       "Tran_Date": "2018-06-29",
       "Tran_NamF": null,
-      "Tran_NamL": "Carmel Partners V JLS  LLC"
+      "Tran_NamL": "Carmel Partners VI Franklin  LLC"
     },
     {
       "Filer_ID": "1310647",

--- a/build/_data/committees/1331137.json
+++ b/build/_data/committees/1331137.json
@@ -8563,17 +8563,17 @@
     },
     {
       "Filer_ID": "1331137",
-      "Tran_Amt1": 8.58,
-      "Tran_Date": "2017-09-09",
-      "Tran_NamF": "JULIE",
-      "Tran_NamL": "OBBARD"
-    },
-    {
-      "Filer_ID": "1331137",
       "Tran_Amt1": 4.0,
       "Tran_Date": "2017-09-09",
       "Tran_NamF": "TESS",
       "Tran_NamL": "O'BRIEN"
+    },
+    {
+      "Filer_ID": "1331137",
+      "Tran_Amt1": 8.58,
+      "Tran_Date": "2017-09-09",
+      "Tran_NamF": "JULIE",
+      "Tran_NamL": "OBBARD"
     },
     {
       "Filer_ID": "1331137",
@@ -9347,17 +9347,17 @@
     },
     {
       "Filer_ID": "1331137",
-      "Tran_Amt1": 8.58,
-      "Tran_Date": "2017-10-12",
-      "Tran_NamF": "JULIE",
-      "Tran_NamL": "OBBARD"
-    },
-    {
-      "Filer_ID": "1331137",
       "Tran_Amt1": 4.0,
       "Tran_Date": "2017-10-12",
       "Tran_NamF": "TESS",
       "Tran_NamL": "O'BRIEN"
+    },
+    {
+      "Filer_ID": "1331137",
+      "Tran_Amt1": 8.58,
+      "Tran_Date": "2017-10-12",
+      "Tran_NamF": "JULIE",
+      "Tran_NamL": "OBBARD"
     },
     {
       "Filer_ID": "1331137",
@@ -9893,6 +9893,13 @@
     },
     {
       "Filer_ID": "1331137",
+      "Tran_Amt1": 0.0,
+      "Tran_Date": "2017-11-06",
+      "Tran_NamF": null,
+      "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
+    },
+    {
+      "Filer_ID": "1331137",
       "Tran_Amt1": 4.46,
       "Tran_Date": "2017-11-06",
       "Tran_NamF": "ODIAKA",
@@ -9904,13 +9911,6 @@
       "Tran_Date": "2017-11-06",
       "Tran_NamF": "ANDRE",
       "Tran_NamL": "GOODE"
-    },
-    {
-      "Filer_ID": "1331137",
-      "Tran_Amt1": 0.0,
-      "Tran_Date": "2017-11-06",
-      "Tran_NamF": null,
-      "Tran_NamL": "GO PUBLIC SCHOOLS ADVOCATES"
     },
     {
       "Filer_ID": "1331137",
@@ -10138,17 +10138,17 @@
     },
     {
       "Filer_ID": "1331137",
-      "Tran_Amt1": 8.58,
-      "Tran_Date": "2017-11-06",
-      "Tran_NamF": "JULIE",
-      "Tran_NamL": "OBBARD"
-    },
-    {
-      "Filer_ID": "1331137",
       "Tran_Amt1": 4.0,
       "Tran_Date": "2017-11-06",
       "Tran_NamF": "TESS",
       "Tran_NamL": "O'BRIEN"
+    },
+    {
+      "Filer_ID": "1331137",
+      "Tran_Amt1": 8.58,
+      "Tran_Date": "2017-11-06",
+      "Tran_NamF": "JULIE",
+      "Tran_NamL": "OBBARD"
     },
     {
       "Filer_ID": "1331137",

--- a/build/_data/committees/1362261.json
+++ b/build/_data/committees/1362261.json
@@ -51,17 +51,17 @@
     },
     {
       "Filer_ID": "1362261",
-      "Tran_Amt1": 100.0,
-      "Tran_Date": "2015-09-08",
-      "Tran_NamF": "Sabrina",
-      "Tran_NamL": "Aery"
-    },
-    {
-      "Filer_ID": "1362261",
       "Tran_Amt1": 250.0,
       "Tran_Date": "2015-09-08",
       "Tran_NamF": null,
       "Tran_NamL": "AJE Partners"
+    },
+    {
+      "Filer_ID": "1362261",
+      "Tran_Amt1": 100.0,
+      "Tran_Date": "2015-09-08",
+      "Tran_NamF": "Sabrina",
+      "Tran_NamL": "Aery"
     },
     {
       "Filer_ID": "1362261",
@@ -142,17 +142,17 @@
     },
     {
       "Filer_ID": "1362261",
-      "Tran_Amt1": 100.0,
-      "Tran_Date": "2015-09-08",
-      "Tran_NamF": "Darlene",
-      "Tran_NamL": "Demanicor"
-    },
-    {
-      "Filer_ID": "1362261",
       "Tran_Amt1": 700.0,
       "Tran_Date": "2015-09-08",
       "Tran_NamF": "Francisco",
       "Tran_NamL": "DeVries"
+    },
+    {
+      "Filer_ID": "1362261",
+      "Tran_Amt1": 100.0,
+      "Tran_Date": "2015-09-08",
+      "Tran_NamF": "Darlene",
+      "Tran_NamL": "Demanicor"
     },
     {
       "Filer_ID": "1362261",
@@ -296,17 +296,17 @@
     },
     {
       "Filer_ID": "1362261",
-      "Tran_Amt1": 700.0,
-      "Tran_Date": "2015-09-08",
-      "Tran_NamF": "Christian",
-      "Tran_NamL": "Marsh"
-    },
-    {
-      "Filer_ID": "1362261",
       "Tran_Amt1": 100.0,
       "Tran_Date": "2015-09-08",
       "Tran_NamF": null,
       "Tran_NamL": "M.B.C. Construction Company"
+    },
+    {
+      "Filer_ID": "1362261",
+      "Tran_Amt1": 700.0,
+      "Tran_Date": "2015-09-08",
+      "Tran_NamF": "Christian",
+      "Tran_NamL": "Marsh"
     },
     {
       "Filer_ID": "1362261",
@@ -1465,6 +1465,13 @@
     },
     {
       "Filer_ID": "1362261",
+      "Tran_Amt1": 300.0,
+      "Tran_Date": "2016-05-24",
+      "Tran_NamF": null,
+      "Tran_NamL": "The Next Generation"
+    },
+    {
+      "Filer_ID": "1362261",
       "Tran_Amt1": 700.0,
       "Tran_Date": "2016-05-24",
       "Tran_NamF": "Alexandra Yolles",
@@ -1476,13 +1483,6 @@
       "Tran_Date": "2016-05-24",
       "Tran_NamF": "Christian",
       "Tran_NamL": "Thede"
-    },
-    {
-      "Filer_ID": "1362261",
-      "Tran_Amt1": 300.0,
-      "Tran_Date": "2016-05-24",
-      "Tran_NamF": null,
-      "Tran_NamL": "The Next Generation"
     },
     {
       "Filer_ID": "1362261",

--- a/build/_data/committees/1364278.json
+++ b/build/_data/committees/1364278.json
@@ -32,15 +32,15 @@
       "Filer_ID": "1364278",
       "Tran_Amt1": 100.0,
       "Tran_Date": "2015-01-27",
-      "Tran_NamF": "Kevin",
-      "Tran_NamL": "Leader"
+      "Tran_NamF": "Paula",
+      "Tran_NamL": "LeDuc"
     },
     {
       "Filer_ID": "1364278",
       "Tran_Amt1": 100.0,
       "Tran_Date": "2015-01-27",
-      "Tran_NamF": "Paula",
-      "Tran_NamL": "LeDuc"
+      "Tran_NamF": "Kevin",
+      "Tran_NamL": "Leader"
     },
     {
       "Filer_ID": "1364278",

--- a/build/_data/committees/1374343.json
+++ b/build/_data/committees/1374343.json
@@ -37,17 +37,17 @@
     },
     {
       "Filer_ID": "1374343",
-      "Tran_Amt1": 700.0,
-      "Tran_Date": "2015-01-28",
-      "Tran_NamF": null,
-      "Tran_NamL": "Schnitzer Steel Industries"
-    },
-    {
-      "Filer_ID": "1374343",
       "Tran_Amt1": 500.0,
       "Tran_Date": "2015-01-28",
       "Tran_NamF": null,
       "Tran_NamL": "SK Builders"
+    },
+    {
+      "Filer_ID": "1374343",
+      "Tran_Amt1": 700.0,
+      "Tran_Date": "2015-01-28",
+      "Tran_NamF": null,
+      "Tran_NamL": "Schnitzer Steel Industries"
     },
     {
       "Filer_ID": "1374343",

--- a/build/_data/committees/1375179.json
+++ b/build/_data/committees/1375179.json
@@ -170,17 +170,17 @@
     },
     {
       "Filer_ID": "1375179",
-      "Tran_Amt1": 250.0,
-      "Tran_Date": "2015-02-12",
-      "Tran_NamF": null,
-      "Tran_NamL": "Showtime Construction"
-    },
-    {
-      "Filer_ID": "1375179",
       "Tran_Amt1": 500.0,
       "Tran_Date": "2015-02-12",
       "Tran_NamF": null,
       "Tran_NamL": "SK Builders"
+    },
+    {
+      "Filer_ID": "1375179",
+      "Tran_Amt1": 250.0,
+      "Tran_Date": "2015-02-12",
+      "Tran_NamF": null,
+      "Tran_NamL": "Showtime Construction"
     },
     {
       "Filer_ID": "1375179",

--- a/build/_data/committees/1379188.json
+++ b/build/_data/committees/1379188.json
@@ -312,15 +312,15 @@
       "Filer_ID": "1379188",
       "Tran_Amt1": 1000.0,
       "Tran_Date": "2016-08-01",
-      "Tran_NamF": "Pamela",
-      "Tran_NamL": "Jones"
+      "Tran_NamF": null,
+      "Tran_NamL": "JT2 Integrated Resources"
     },
     {
       "Filer_ID": "1379188",
       "Tran_Amt1": 1000.0,
       "Tran_Date": "2016-08-01",
-      "Tran_NamF": null,
-      "Tran_NamL": "JT2 Integrated Resources"
+      "Tran_NamF": "Pamela",
+      "Tran_NamL": "Jones"
     },
     {
       "Filer_ID": "1379188",

--- a/build/_data/committees/1381041.json
+++ b/build/_data/committees/1381041.json
@@ -989,17 +989,17 @@
     },
     {
       "Filer_ID": "1381041",
-      "Tran_Amt1": 1000.0,
-      "Tran_Date": "2016-10-24",
-      "Tran_NamF": "Thomas J.",
-      "Tran_NamL": "Higgins"
-    },
-    {
-      "Filer_ID": "1381041",
       "Tran_Amt1": 250.0,
       "Tran_Date": "2016-10-24",
       "Tran_NamF": "DANA",
       "Tran_NamL": "HUGHES"
+    },
+    {
+      "Filer_ID": "1381041",
+      "Tran_Amt1": 1000.0,
+      "Tran_Date": "2016-10-24",
+      "Tran_NamF": "Thomas J.",
+      "Tran_NamL": "Higgins"
     },
     {
       "Filer_ID": "1381041",

--- a/build/_data/committees/1382408.json
+++ b/build/_data/committees/1382408.json
@@ -387,17 +387,17 @@
     },
     {
       "Filer_ID": "1382408",
-      "Tran_Amt1": 250.0,
-      "Tran_Date": "2016-06-16",
-      "Tran_NamF": "Sue",
-      "Tran_NamL": "Piper"
-    },
-    {
-      "Filer_ID": "1382408",
       "Tran_Amt1": 700.0,
       "Tran_Date": "2016-06-16",
       "Tran_NamF": null,
       "Tran_NamL": "PMACC dba Harborside Health Center"
+    },
+    {
+      "Filer_ID": "1382408",
+      "Tran_Amt1": 250.0,
+      "Tran_Date": "2016-06-16",
+      "Tran_NamF": "Sue",
+      "Tran_NamL": "Piper"
     },
     {
       "Filer_ID": "1382408",

--- a/build/_data/committees/1387267.json
+++ b/build/_data/committees/1387267.json
@@ -604,17 +604,17 @@
     },
     {
       "Filer_ID": "1387267",
-      "Tran_Amt1": 150.0,
-      "Tran_Date": "2016-10-03",
-      "Tran_NamF": "Duane",
-      "Tran_NamL": "Baughman"
-    },
-    {
-      "Filer_ID": "1387267",
       "Tran_Amt1": 100.0,
       "Tran_Date": "2016-10-03",
       "Tran_NamF": null,
       "Tran_NamL": "B C Realty"
+    },
+    {
+      "Filer_ID": "1387267",
+      "Tran_Amt1": 150.0,
+      "Tran_Date": "2016-10-03",
+      "Tran_NamF": "Duane",
+      "Tran_NamL": "Baughman"
     },
     {
       "Filer_ID": "1387267",

--- a/build/_data/committees/1387983.json
+++ b/build/_data/committees/1387983.json
@@ -513,17 +513,17 @@
     },
     {
       "Filer_ID": "1387983",
-      "Tran_Amt1": 1500.0,
-      "Tran_Date": "2016-10-24",
-      "Tran_NamF": null,
-      "Tran_NamL": "Beci Electric, Inc."
-    },
-    {
-      "Filer_ID": "1387983",
       "Tran_Amt1": 2000.0,
       "Tran_Date": "2016-10-24",
       "Tran_NamF": null,
       "Tran_NamL": "BKF Engineers"
+    },
+    {
+      "Filer_ID": "1387983",
+      "Tran_Amt1": 1500.0,
+      "Tran_Date": "2016-10-24",
+      "Tran_NamF": null,
+      "Tran_NamL": "Beci Electric, Inc."
     },
     {
       "Filer_ID": "1387983",

--- a/build/_data/committees/1388168.json
+++ b/build/_data/committees/1388168.json
@@ -5525,20 +5525,6 @@
     },
     {
       "Filer_ID": "1388168",
-      "Tran_Amt1": 250.0,
-      "Tran_Date": "2016-10-26",
-      "Tran_NamF": "Dana",
-      "Tran_NamL": "Parry"
-    },
-    {
-      "Filer_ID": "1388168",
-      "Tran_Amt1": 250.0,
-      "Tran_Date": "2016-10-26",
-      "Tran_NamF": "Dana",
-      "Tran_NamL": "Parry"
-    },
-    {
-      "Filer_ID": "1388168",
       "Tran_Amt1": 700.0,
       "Tran_Date": "2016-10-26",
       "Tran_NamF": null,
@@ -5550,6 +5536,20 @@
       "Tran_Date": "2016-10-26",
       "Tran_NamF": null,
       "Tran_NamL": "PMACC"
+    },
+    {
+      "Filer_ID": "1388168",
+      "Tran_Amt1": 250.0,
+      "Tran_Date": "2016-10-26",
+      "Tran_NamF": "Dana",
+      "Tran_NamL": "Parry"
+    },
+    {
+      "Filer_ID": "1388168",
+      "Tran_Amt1": 250.0,
+      "Tran_Date": "2016-10-26",
+      "Tran_NamF": "Dana",
+      "Tran_NamL": "Parry"
     },
     {
       "Filer_ID": "1388168",

--- a/build/_data/committees/1388641.json
+++ b/build/_data/committees/1388641.json
@@ -296,6 +296,13 @@
     },
     {
       "Filer_ID": "1388641",
+      "Tran_Amt1": 250.0,
+      "Tran_Date": "2016-09-28",
+      "Tran_NamF": null,
+      "Tran_NamL": "Raphael & associates"
+    },
+    {
+      "Filer_ID": "1388641",
       "Tran_Amt1": 700.0,
       "Tran_Date": "2016-09-28",
       "Tran_NamF": "eduardo",
@@ -314,13 +321,6 @@
       "Tran_Date": "2016-09-28",
       "Tran_NamF": "robert",
       "Tran_NamL": "raich"
-    },
-    {
-      "Filer_ID": "1388641",
-      "Tran_Amt1": 250.0,
-      "Tran_Date": "2016-09-28",
-      "Tran_NamF": null,
-      "Tran_NamL": "Raphael & associates"
     },
     {
       "Filer_ID": "1388641",
@@ -387,17 +387,17 @@
     },
     {
       "Filer_ID": "1388641",
-      "Tran_Amt1": 700.0,
-      "Tran_Date": "2016-10-11",
-      "Tran_NamF": null,
-      "Tran_NamL": "best bay apartments inc"
-    },
-    {
-      "Filer_ID": "1388641",
       "Tran_Amt1": 1400.0,
       "Tran_Date": "2016-10-11",
       "Tran_NamF": null,
       "Tran_NamL": "California real estate political action committee"
+    },
+    {
+      "Filer_ID": "1388641",
+      "Tran_Amt1": 700.0,
+      "Tran_Date": "2016-10-11",
+      "Tran_NamF": null,
+      "Tran_NamL": "best bay apartments inc"
     },
     {
       "Filer_ID": "1388641",

--- a/build/_data/committees/1395580.json
+++ b/build/_data/committees/1395580.json
@@ -408,17 +408,17 @@
     },
     {
       "Filer_ID": "1395580",
-      "Tran_Amt1": 125.0,
-      "Tran_Date": "2017-09-09",
-      "Tran_NamF": "Wise E.",
-      "Tran_NamL": "Allen"
-    },
-    {
-      "Filer_ID": "1395580",
       "Tran_Amt1": 800.0,
       "Tran_Date": "2017-09-09",
       "Tran_NamF": null,
       "Tran_NamL": "ARAM Electric, Inc."
+    },
+    {
+      "Filer_ID": "1395580",
+      "Tran_Amt1": 125.0,
+      "Tran_Date": "2017-09-09",
+      "Tran_NamF": "Wise E.",
+      "Tran_NamL": "Allen"
     },
     {
       "Filer_ID": "1395580",

--- a/build/_data/committees/1395968.json
+++ b/build/_data/committees/1395968.json
@@ -1425,6 +1425,13 @@
       "Filer_ID": "1395968",
       "Tran_Amt1": 800.0,
       "Tran_Date": "2017-06-30",
+      "Tran_NamF": null,
+      "Tran_NamL": "AB&I Foundry"
+    },
+    {
+      "Filer_ID": "1395968",
+      "Tran_Amt1": 800.0,
+      "Tran_Date": "2017-06-30",
       "Tran_NamF": "Isaac",
       "Tran_NamL": "Abid"
     },
@@ -1434,13 +1441,6 @@
       "Tran_Date": "2017-06-30",
       "Tran_NamF": "Puja",
       "Tran_NamL": "Abid"
-    },
-    {
-      "Filer_ID": "1395968",
-      "Tran_Amt1": 800.0,
-      "Tran_Date": "2017-06-30",
-      "Tran_NamF": null,
-      "Tran_NamL": "AB&I Foundry"
     },
     {
       "Filer_ID": "1395968",
@@ -1577,10 +1577,10 @@
     },
     {
       "Filer_ID": "1395968",
-      "Tran_Amt1": 100.0,
+      "Tran_Amt1": 500.0,
       "Tran_Date": "2017-06-30",
-      "Tran_NamF": "Benito",
-      "Tran_NamL": "Delgado-Olson"
+      "Tran_NamF": null,
+      "Tran_NamL": "DMC Real Estate Consulting LLC"
     },
     {
       "Filer_ID": "1395968",
@@ -1593,15 +1593,15 @@
       "Filer_ID": "1395968",
       "Tran_Amt1": 100.0,
       "Tran_Date": "2017-06-30",
-      "Tran_NamF": "Jeanne",
-      "Tran_NamL": "Dinvaut"
+      "Tran_NamF": "Benito",
+      "Tran_NamL": "Delgado-Olson"
     },
     {
       "Filer_ID": "1395968",
-      "Tran_Amt1": 500.0,
+      "Tran_Amt1": 100.0,
       "Tran_Date": "2017-06-30",
-      "Tran_NamF": null,
-      "Tran_NamL": "DMC Real Estate Consulting LLC"
+      "Tran_NamF": "Jeanne",
+      "Tran_NamL": "Dinvaut"
     },
     {
       "Filer_ID": "1395968",
@@ -1726,15 +1726,15 @@
       "Filer_ID": "1395968",
       "Tran_Amt1": 800.0,
       "Tran_Date": "2017-06-30",
-      "Tran_NamF": "Michael",
-      "Tran_NamL": "LaHorgue"
+      "Tran_NamF": null,
+      "Tran_NamL": "La Plazita Preschool III"
     },
     {
       "Filer_ID": "1395968",
       "Tran_Amt1": 800.0,
       "Tran_Date": "2017-06-30",
-      "Tran_NamF": null,
-      "Tran_NamL": "La Plazita Preschool III"
+      "Tran_NamF": "Michael",
+      "Tran_NamL": "LaHorgue"
     },
     {
       "Filer_ID": "1395968",
@@ -1763,6 +1763,20 @@
       "Tran_Date": "2017-06-30",
       "Tran_NamF": "Pelayo A",
       "Tran_NamL": "Llamas Jr"
+    },
+    {
+      "Filer_ID": "1395968",
+      "Tran_Amt1": 800.0,
+      "Tran_Date": "2017-06-30",
+      "Tran_NamF": null,
+      "Tran_NamL": "M & M Property Company, LLC"
+    },
+    {
+      "Filer_ID": "1395968",
+      "Tran_Amt1": 800.0,
+      "Tran_Date": "2017-06-30",
+      "Tran_NamF": null,
+      "Tran_NamL": "MT - 1 Properties, LLC"
     },
     {
       "Filer_ID": "1395968",
@@ -1801,24 +1815,10 @@
     },
     {
       "Filer_ID": "1395968",
-      "Tran_Amt1": 800.0,
-      "Tran_Date": "2017-06-30",
-      "Tran_NamF": null,
-      "Tran_NamL": "M & M Property Company, LLC"
-    },
-    {
-      "Filer_ID": "1395968",
       "Tran_Amt1": 500.0,
       "Tran_Date": "2017-06-30",
       "Tran_NamF": "Tomiquia",
       "Tran_NamL": "Moss"
-    },
-    {
-      "Filer_ID": "1395968",
-      "Tran_Amt1": 800.0,
-      "Tran_Date": "2017-06-30",
-      "Tran_NamF": null,
-      "Tran_NamL": "MT - 1 Properties, LLC"
     },
     {
       "Filer_ID": "1395968",
@@ -1990,17 +1990,17 @@
     },
     {
       "Filer_ID": "1395968",
-      "Tran_Amt1": 250.0,
-      "Tran_Date": "2017-06-30",
-      "Tran_NamF": "Aaron",
-      "Tran_NamL": "Stevens"
-    },
-    {
-      "Filer_ID": "1395968",
       "Tran_Amt1": 150.0,
       "Tran_Date": "2017-06-30",
       "Tran_NamF": "Gene",
       "Tran_NamL": "St Onge"
+    },
+    {
+      "Filer_ID": "1395968",
+      "Tran_Amt1": 250.0,
+      "Tran_Date": "2017-06-30",
+      "Tran_NamF": "Aaron",
+      "Tran_NamL": "Stevens"
     },
     {
       "Filer_ID": "1395968",

--- a/build/_data/committees/1396338.json
+++ b/build/_data/committees/1396338.json
@@ -10593,17 +10593,17 @@
     },
     {
       "Filer_ID": "1396338",
-      "Tran_Amt1": 250.0,
-      "Tran_Date": "2018-02-19",
-      "Tran_NamF": "Lokelani",
-      "Tran_NamL": "Devone"
-    },
-    {
-      "Filer_ID": "1396338",
       "Tran_Amt1": 125.0,
       "Tran_Date": "2018-02-19",
       "Tran_NamF": "Savio",
       "Tran_NamL": "D'Souza"
+    },
+    {
+      "Filer_ID": "1396338",
+      "Tran_Amt1": 250.0,
+      "Tran_Date": "2018-02-19",
+      "Tran_NamF": "Lokelani",
+      "Tran_NamL": "Devone"
     },
     {
       "Filer_ID": "1396338",
@@ -12707,17 +12707,17 @@
     },
     {
       "Filer_ID": "1396338",
-      "Tran_Amt1": 50.0,
-      "Tran_Date": "2018-03-11",
-      "Tran_NamF": "Stewart",
-      "Tran_NamL": "Oaten"
-    },
-    {
-      "Filer_ID": "1396338",
       "Tran_Amt1": 150.0,
       "Tran_Date": "2018-03-11",
       "Tran_NamF": "Robin",
       "Tran_NamL": "O'Connor"
+    },
+    {
+      "Filer_ID": "1396338",
+      "Tran_Amt1": 50.0,
+      "Tran_Date": "2018-03-11",
+      "Tran_NamF": "Stewart",
+      "Tran_NamL": "Oaten"
     },
     {
       "Filer_ID": "1396338",
@@ -12737,15 +12737,15 @@
       "Filer_ID": "1396338",
       "Tran_Amt1": 500.0,
       "Tran_Date": "2018-03-11",
-      "Tran_NamF": "Mark",
-      "Tran_NamL": "Seiler"
+      "Tran_NamF": null,
+      "Tran_NamL": "SF International Building Supply"
     },
     {
       "Filer_ID": "1396338",
       "Tran_Amt1": 500.0,
       "Tran_Date": "2018-03-11",
-      "Tran_NamF": null,
-      "Tran_NamL": "SF International Building Supply"
+      "Tran_NamF": "Mark",
+      "Tran_NamL": "Seiler"
     },
     {
       "Filer_ID": "1396338",
@@ -17147,15 +17147,15 @@
       "Filer_ID": "1396338",
       "Tran_Amt1": 500.0,
       "Tran_Date": "2018-04-30",
-      "Tran_NamF": "Jack",
-      "Tran_NamL": "Schafer"
+      "Tran_NamF": null,
+      "Tran_NamL": "SFMMS PAC"
     },
     {
       "Filer_ID": "1396338",
       "Tran_Amt1": 500.0,
       "Tran_Date": "2018-04-30",
-      "Tran_NamF": null,
-      "Tran_NamL": "SFMMS PAC"
+      "Tran_NamF": "Jack",
+      "Tran_NamL": "Schafer"
     },
     {
       "Filer_ID": "1396338",
@@ -18937,6 +18937,13 @@
     },
     {
       "Filer_ID": "1396338",
+      "Tran_Amt1": 500.0,
+      "Tran_Date": "2018-05-16",
+      "Tran_NamF": null,
+      "Tran_NamL": "SEIU Local 2015 State PAC"
+    },
+    {
+      "Filer_ID": "1396338",
       "Tran_Amt1": 100.0,
       "Tran_Date": "2018-05-16",
       "Tran_NamF": "Kory",
@@ -18948,13 +18955,6 @@
       "Tran_Date": "2018-05-16",
       "Tran_NamF": "Steven",
       "Tran_NamL": "Scarborough"
-    },
-    {
-      "Filer_ID": "1396338",
-      "Tran_Amt1": 500.0,
-      "Tran_Date": "2018-05-16",
-      "Tran_NamF": null,
-      "Tran_NamL": "SEIU Local 2015 State PAC"
     },
     {
       "Filer_ID": "1396338",

--- a/build/_data/committees/1400832.json
+++ b/build/_data/committees/1400832.json
@@ -10719,17 +10719,17 @@
     },
     {
       "Filer_ID": "1400832",
-      "Tran_Amt1": 50.0,
-      "Tran_Date": "2018-04-22",
-      "Tran_NamF": "Gregory",
-      "Tran_NamL": "Dixon"
-    },
-    {
-      "Filer_ID": "1400832",
       "Tran_Amt1": 250.0,
       "Tran_Date": "2018-04-22",
       "Tran_NamF": "Alan",
       "Tran_NamL": "D'Souza"
+    },
+    {
+      "Filer_ID": "1400832",
+      "Tran_Amt1": 50.0,
+      "Tran_Date": "2018-04-22",
+      "Tran_NamF": "Gregory",
+      "Tran_NamL": "Dixon"
     },
     {
       "Filer_ID": "1400832",
@@ -11300,16 +11300,16 @@
     },
     {
       "Filer_ID": "1400832",
-      "Tran_Amt1": 200.0,
+      "Tran_Amt1": 100.0,
       "Tran_Date": "2018-04-28",
-      "Tran_NamF": "Dongwoon",
+      "Tran_NamF": "Dong Young",
       "Tran_NamL": "Lee"
     },
     {
       "Filer_ID": "1400832",
-      "Tran_Amt1": 100.0,
+      "Tran_Amt1": 200.0,
       "Tran_Date": "2018-04-28",
-      "Tran_NamF": "Dong Young",
+      "Tran_NamF": "Dongwoon",
       "Tran_NamL": "Lee"
     },
     {
@@ -12492,6 +12492,13 @@
       "Filer_ID": "1400832",
       "Tran_Amt1": 500.0,
       "Tran_Date": "2018-05-04",
+      "Tran_NamF": null,
+      "Tran_NamL": "KKT Hyde Pacific, LLC"
+    },
+    {
+      "Filer_ID": "1400832",
+      "Tran_Amt1": 500.0,
+      "Tran_Date": "2018-05-04",
       "Tran_NamF": "Jung Min",
       "Tran_NamL": "Kim"
     },
@@ -12501,13 +12508,6 @@
       "Tran_Date": "2018-05-04",
       "Tran_NamF": "Hyejin",
       "Tran_NamL": "Kim-Cha"
-    },
-    {
-      "Filer_ID": "1400832",
-      "Tran_Amt1": 500.0,
-      "Tran_Date": "2018-05-04",
-      "Tran_NamF": null,
-      "Tran_NamL": "KKT Hyde Pacific, LLC"
     },
     {
       "Filer_ID": "1400832",
@@ -14639,6 +14639,13 @@
     },
     {
       "Filer_ID": "1400832",
+      "Tran_Amt1": 250.0,
+      "Tran_Date": "2018-05-19",
+      "Tran_NamF": null,
+      "Tran_NamL": "HNTB Holdings Ltd. PAC"
+    },
+    {
+      "Filer_ID": "1400832",
       "Tran_Amt1": 100.0,
       "Tran_Date": "2018-05-19",
       "Tran_NamF": "Molly",
@@ -14650,13 +14657,6 @@
       "Tran_Date": "2018-05-19",
       "Tran_NamF": "Jennifer",
       "Tran_NamL": "Harvie-Watt"
-    },
-    {
-      "Filer_ID": "1400832",
-      "Tran_Amt1": 250.0,
-      "Tran_Date": "2018-05-19",
-      "Tran_NamF": null,
-      "Tran_NamL": "HNTB Holdings Ltd. PAC"
     },
     {
       "Filer_ID": "1400832",

--- a/build/_data/committees/1401632.json
+++ b/build/_data/committees/1401632.json
@@ -229,14 +229,14 @@
       "Tran_Amt1": 5000.0,
       "Tran_Date": "2018-05-30",
       "Tran_NamF": null,
-      "Tran_NamL": "Monterey Mechanical Company"
+      "Tran_NamL": "MWH Constructors"
     },
     {
       "Filer_ID": "1401632",
       "Tran_Amt1": 5000.0,
       "Tran_Date": "2018-05-30",
       "Tran_NamF": null,
-      "Tran_NamL": "MWH Constructors"
+      "Tran_NamL": "Monterey Mechanical Company"
     },
     {
       "Filer_ID": "1401632",

--- a/build/_data/committees/1402425.json
+++ b/build/_data/committees/1402425.json
@@ -128,17 +128,17 @@
     },
     {
       "Filer_ID": "1402425",
-      "Tran_Amt1": 1250.0,
-      "Tran_Date": "2018-04-16",
-      "Tran_NamF": "JOE",
-      "Tran_NamL": "BARCLAY"
-    },
-    {
-      "Filer_ID": "1402425",
       "Tran_Amt1": 2000.0,
       "Tran_Date": "2018-04-16",
       "Tran_NamF": "OLLIE",
       "Tran_NamL": "B'IANTON"
+    },
+    {
+      "Filer_ID": "1402425",
+      "Tran_Amt1": 1250.0,
+      "Tran_Date": "2018-04-16",
+      "Tran_NamF": "JOE",
+      "Tran_NamL": "BARCLAY"
     },
     {
       "Filer_ID": "1402425",

--- a/build/_data/committees/1404060.json
+++ b/build/_data/committees/1404060.json
@@ -121,13 +121,6 @@
     },
     {
       "Filer_ID": "1404060",
-      "Tran_Amt1": 37730.0,
-      "Tran_Date": "2018-04-27",
-      "Tran_NamF": null,
-      "Tran_NamL": "Blackstone OMP LP"
-    },
-    {
-      "Filer_ID": "1404060",
       "Tran_Amt1": 6681.0,
       "Tran_Date": "2018-04-27",
       "Tran_NamF": null,
@@ -160,6 +153,13 @@
       "Tran_Date": "2018-04-27",
       "Tran_NamF": null,
       "Tran_NamL": "BRE Market Street Holdings, LLC"
+    },
+    {
+      "Filer_ID": "1404060",
+      "Tran_Amt1": 37730.0,
+      "Tran_Date": "2018-04-27",
+      "Tran_NamF": null,
+      "Tran_NamL": "Blackstone OMP LP"
     },
     {
       "Filer_ID": "1404060",

--- a/build/_data/committees/840002.json
+++ b/build/_data/committees/840002.json
@@ -191,17 +191,17 @@
     },
     {
       "Filer_ID": "840002",
-      "Tran_Amt1": 125.0,
-      "Tran_Date": "2017-06-07",
-      "Tran_NamF": null,
-      "Tran_NamL": "SFrealestate.com"
-    },
-    {
-      "Filer_ID": "840002",
       "Tran_Amt1": 100.0,
       "Tran_Date": "2017-06-07",
       "Tran_NamF": null,
       "Tran_NamL": "SFRent"
+    },
+    {
+      "Filer_ID": "840002",
+      "Tran_Amt1": 125.0,
+      "Tran_Date": "2017-06-07",
+      "Tran_NamF": null,
+      "Tran_NamL": "SFrealestate.com"
     },
     {
       "Filer_ID": "840002",
@@ -473,15 +473,15 @@
       "Filer_ID": "840002",
       "Tran_Amt1": 125.0,
       "Tran_Date": "2018-04-13",
-      "Tran_NamF": "Andrew",
-      "Tran_NamL": "Smith"
+      "Tran_NamF": null,
+      "Tran_NamL": "STARCITY"
     },
     {
       "Filer_ID": "840002",
       "Tran_Amt1": 125.0,
       "Tran_Date": "2018-04-13",
-      "Tran_NamF": null,
-      "Tran_NamL": "STARCITY"
+      "Tran_NamF": "Andrew",
+      "Tran_NamL": "Smith"
     },
     {
       "Filer_ID": "840002",
@@ -618,6 +618,13 @@
     },
     {
       "Filer_ID": "840002",
+      "Tran_Amt1": 132.0,
+      "Tran_Date": "2018-05-14",
+      "Tran_NamF": null,
+      "Tran_NamL": "B STREET APARTMENT GROUP, LP"
+    },
+    {
+      "Filer_ID": "840002",
       "Tran_Amt1": 300.0,
       "Tran_Date": "2018-05-14",
       "Tran_NamF": null,
@@ -639,13 +646,6 @@
     },
     {
       "Filer_ID": "840002",
-      "Tran_Amt1": 132.0,
-      "Tran_Date": "2018-05-14",
-      "Tran_NamF": null,
-      "Tran_NamL": "B STREET APARTMENT GROUP, LP"
-    },
-    {
-      "Filer_ID": "840002",
       "Tran_Amt1": 84.0,
       "Tran_Date": "2018-05-14",
       "Tran_NamF": null,
@@ -657,27 +657,6 @@
       "Tran_Date": "2018-05-14",
       "Tran_NamF": null,
       "Tran_NamL": "CHAN FAMILY TRUST"
-    },
-    {
-      "Filer_ID": "840002",
-      "Tran_Amt1": 60.0,
-      "Tran_Date": "2018-05-14",
-      "Tran_NamF": "Maureen",
-      "Tran_NamL": "Chen"
-    },
-    {
-      "Filer_ID": "840002",
-      "Tran_Amt1": 60.0,
-      "Tran_Date": "2018-05-14",
-      "Tran_NamF": "Maureen",
-      "Tran_NamL": "Chen"
-    },
-    {
-      "Filer_ID": "840002",
-      "Tran_Amt1": 660.0,
-      "Tran_Date": "2018-05-14",
-      "Tran_NamF": "Maureen",
-      "Tran_NamL": "Chen"
     },
     {
       "Filer_ID": "840002",
@@ -702,6 +681,27 @@
     },
     {
       "Filer_ID": "840002",
+      "Tran_Amt1": 60.0,
+      "Tran_Date": "2018-05-14",
+      "Tran_NamF": "Maureen",
+      "Tran_NamL": "Chen"
+    },
+    {
+      "Filer_ID": "840002",
+      "Tran_Amt1": 60.0,
+      "Tran_Date": "2018-05-14",
+      "Tran_NamF": "Maureen",
+      "Tran_NamL": "Chen"
+    },
+    {
+      "Filer_ID": "840002",
+      "Tran_Amt1": 660.0,
+      "Tran_Date": "2018-05-14",
+      "Tran_NamF": "Maureen",
+      "Tran_NamL": "Chen"
+    },
+    {
+      "Filer_ID": "840002",
       "Tran_Amt1": 444.0,
       "Tran_Date": "2018-05-14",
       "Tran_NamF": null,
@@ -716,13 +716,6 @@
     },
     {
       "Filer_ID": "840002",
-      "Tran_Amt1": 132.0,
-      "Tran_Date": "2018-05-14",
-      "Tran_NamF": "Susan",
-      "Tran_NamL": "Gildea"
-    },
-    {
-      "Filer_ID": "840002",
       "Tran_Amt1": 264.0,
       "Tran_Date": "2018-05-14",
       "Tran_NamF": null,
@@ -734,6 +727,13 @@
       "Tran_Date": "2018-05-14",
       "Tran_NamF": null,
       "Tran_NamL": "GRANT PINE ENTERPRISE"
+    },
+    {
+      "Filer_ID": "840002",
+      "Tran_Amt1": 132.0,
+      "Tran_Date": "2018-05-14",
+      "Tran_NamF": "Susan",
+      "Tran_NamL": "Gildea"
     },
     {
       "Filer_ID": "840002",

--- a/build/_data/committees/892160.json
+++ b/build/_data/committees/892160.json
@@ -5639,15 +5639,15 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Jesse",
-      "Tran_NamL": "Blaylock"
+      "Tran_NamF": "Francis",
+      "Tran_NamL": "Blay-Miezah"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Francis",
-      "Tran_NamL": "Blay-Miezah"
+      "Tran_NamF": "Jesse",
+      "Tran_NamL": "Blaylock"
     },
     {
       "Filer_ID": "892160",
@@ -5996,13 +5996,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Michael",
-      "Tran_NamL": "Dearborn"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-07-23",
       "Tran_NamF": "Nicholas",
       "Tran_NamL": "DeLaTorre"
     },
@@ -6010,15 +6003,22 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Carl",
-      "Tran_NamL": "Denyer"
+      "Tran_NamF": "Allison",
+      "Tran_NamL": "DePalma"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Allison",
-      "Tran_NamL": "DePalma"
+      "Tran_NamF": "Michael",
+      "Tran_NamL": "Dearborn"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-07-23",
+      "Tran_NamF": "Carl",
+      "Tran_NamL": "Denyer"
     },
     {
       "Filer_ID": "892160",
@@ -6038,15 +6038,15 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Bryan",
-      "Tran_NamL": "Dillingham"
+      "Tran_NamF": "Brian",
+      "Tran_NamL": "DiRegolo"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Brian",
-      "Tran_NamL": "DiRegolo"
+      "Tran_NamF": "Bryan",
+      "Tran_NamL": "Dillingham"
     },
     {
       "Filer_ID": "892160",
@@ -7046,13 +7046,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Ronald",
-      "Tran_NamL": "Oatis"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-07-23",
       "Tran_NamF": "Christopher",
       "Tran_NamL": "O'Brien"
     },
@@ -7074,22 +7067,29 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-07-23",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-07-23",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-07-23",
+      "Tran_NamF": "Ronald",
+      "Tran_NamL": "Oatis"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-07-23",
       "Tran_NamF": "Carlos",
       "Tran_NamL": "Olivarez"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-07-23",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
     },
     {
       "Filer_ID": "892160",
@@ -8187,15 +8187,15 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Jesse",
-      "Tran_NamL": "Blaylock"
+      "Tran_NamF": "Francis",
+      "Tran_NamL": "Blay-Miezah"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Francis",
-      "Tran_NamL": "Blay-Miezah"
+      "Tran_NamF": "Jesse",
+      "Tran_NamL": "Blaylock"
     },
     {
       "Filer_ID": "892160",
@@ -8908,15 +8908,22 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Michael",
-      "Tran_NamL": "Dearborn"
+      "Tran_NamF": "Nicholas",
+      "Tran_NamL": "DeLaTorre"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Nicholas",
-      "Tran_NamL": "DeLaTorre"
+      "Tran_NamF": "Allison",
+      "Tran_NamL": "DePalma"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-08-20",
+      "Tran_NamF": "Michael",
+      "Tran_NamL": "Dearborn"
     },
     {
       "Filer_ID": "892160",
@@ -8931,13 +8938,6 @@
       "Tran_Date": "2015-08-20",
       "Tran_NamF": "Carl",
       "Tran_NamL": "Denyer"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Allison",
-      "Tran_NamL": "DePalma"
     },
     {
       "Filer_ID": "892160",
@@ -8971,6 +8971,13 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-08-20",
+      "Tran_NamF": "Brian",
+      "Tran_NamL": "DiRegolo"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-08-20",
       "Tran_NamF": "Zoraida",
       "Tran_NamL": "Diaz"
     },
@@ -8980,13 +8987,6 @@
       "Tran_Date": "2015-08-20",
       "Tran_NamF": "Bryan",
       "Tran_NamL": "Dillingham"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Brian",
-      "Tran_NamL": "DiRegolo"
     },
     {
       "Filer_ID": "892160",
@@ -11288,13 +11288,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Ronald",
-      "Tran_NamL": "Oatis"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-08-20",
       "Tran_NamF": "Christopher",
       "Tran_NamL": "O'Brien"
     },
@@ -11309,15 +11302,36 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Brian",
-      "Tran_NamL": "Oftedal"
+      "Tran_NamF": "Blake",
+      "Tran_NamL": "O'Hara"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Blake",
-      "Tran_NamL": "O'Hara"
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-08-20",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-08-20",
+      "Tran_NamF": "Ronald",
+      "Tran_NamL": "Oatis"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-08-20",
+      "Tran_NamF": "Brian",
+      "Tran_NamL": "Oftedal"
     },
     {
       "Filer_ID": "892160",
@@ -11332,20 +11346,6 @@
       "Tran_Date": "2015-08-20",
       "Tran_NamF": "Seth",
       "Tran_NamL": "Olyer"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
     },
     {
       "Filer_ID": "892160",
@@ -12506,6 +12506,13 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-08-20",
+      "Tran_NamF": "Manh",
+      "Tran_NamL": "Tu-Hyunh"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-08-20",
       "Tran_NamF": "Clark",
       "Tran_NamL": "Tucker"
     },
@@ -12515,13 +12522,6 @@
       "Tran_Date": "2015-08-20",
       "Tran_NamF": "Solomon",
       "Tran_NamL": "Tucker"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-08-20",
-      "Tran_NamF": "Manh",
-      "Tran_NamL": "Tu-Hyunh"
     },
     {
       "Filer_ID": "892160",
@@ -16118,20 +16118,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Jesse",
-      "Tran_NamL": "Blaylock"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Jesse",
-      "Tran_NamL": "Blaylock"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
       "Tran_NamF": "Francis",
       "Tran_NamL": "Blay-Miezah"
     },
@@ -16141,6 +16127,20 @@
       "Tran_Date": "2015-09-30",
       "Tran_NamF": "Francis",
       "Tran_NamL": "Blay-Miezah"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Jesse",
+      "Tran_NamL": "Blaylock"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Jesse",
+      "Tran_NamL": "Blaylock"
     },
     {
       "Filer_ID": "892160",
@@ -16832,20 +16832,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Michael",
-      "Tran_NamL": "Dearborn"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Michael",
-      "Tran_NamL": "Dearborn"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
       "Tran_NamF": "Nicholas",
       "Tran_NamL": "DeLaTorre"
     },
@@ -16860,20 +16846,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Carl",
-      "Tran_NamL": "Denyer"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Carl",
-      "Tran_NamL": "Denyer"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
       "Tran_NamF": "Allison",
       "Tran_NamL": "DePalma"
     },
@@ -16883,6 +16855,34 @@
       "Tran_Date": "2015-09-30",
       "Tran_NamF": "Allison",
       "Tran_NamL": "DePalma"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Michael",
+      "Tran_NamL": "Dearborn"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Michael",
+      "Tran_NamL": "Dearborn"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Carl",
+      "Tran_NamL": "Denyer"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Carl",
+      "Tran_NamL": "Denyer"
     },
     {
       "Filer_ID": "892160",
@@ -16916,20 +16916,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Bryan",
-      "Tran_NamL": "Dillingham"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Bryan",
-      "Tran_NamL": "Dillingham"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
       "Tran_NamF": "Brian",
       "Tran_NamL": "DiRegolo"
     },
@@ -16939,6 +16925,20 @@
       "Tran_Date": "2015-09-30",
       "Tran_NamF": "Brian",
       "Tran_NamL": "DiRegolo"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Bryan",
+      "Tran_NamL": "Dillingham"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Bryan",
+      "Tran_NamL": "Dillingham"
     },
     {
       "Filer_ID": "892160",
@@ -18932,20 +18932,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Ronald",
-      "Tran_NamL": "Oatis"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Ronald",
-      "Tran_NamL": "Oatis"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
       "Tran_NamF": "Christopher",
       "Tran_NamL": "O'Brien"
     },
@@ -18988,6 +18974,48 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Ronald",
+      "Tran_NamL": "Oatis"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Ronald",
+      "Tran_NamL": "Oatis"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
       "Tran_NamF": "Carlos",
       "Tran_NamL": "Olivarez"
     },
@@ -18997,34 +19025,6 @@
       "Tran_Date": "2015-09-30",
       "Tran_NamF": "Carlos",
       "Tran_NamL": "Olivarez"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
     },
     {
       "Filer_ID": "892160",
@@ -20332,22 +20332,22 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Manh",
+      "Tran_NamL": "Tu-Hyunh"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
+      "Tran_NamF": "Manh",
+      "Tran_NamL": "Tu-Hyunh"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-09-30",
       "Tran_NamF": "Clark",
       "Tran_NamL": "Tucker"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Manh",
-      "Tran_NamL": "Tu-Hyunh"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-09-30",
-      "Tran_NamF": "Manh",
-      "Tran_NamL": "Tu-Hyunh"
     },
     {
       "Filer_ID": "892160",
@@ -21102,15 +21102,15 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Jesse",
-      "Tran_NamL": "Blaylock"
+      "Tran_NamF": "Francis",
+      "Tran_NamL": "Blay-Miezah"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Francis",
-      "Tran_NamL": "Blay-Miezah"
+      "Tran_NamF": "Jesse",
+      "Tran_NamL": "Blaylock"
     },
     {
       "Filer_ID": "892160",
@@ -21459,13 +21459,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Michael",
-      "Tran_NamL": "Dearborn"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-10-20",
       "Tran_NamF": "Nicholas",
       "Tran_NamL": "DeLaTorre"
     },
@@ -21473,15 +21466,22 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Carl",
-      "Tran_NamL": "Denyer"
+      "Tran_NamF": "Allison",
+      "Tran_NamL": "DePalma"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Allison",
-      "Tran_NamL": "DePalma"
+      "Tran_NamF": "Michael",
+      "Tran_NamL": "Dearborn"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-10-20",
+      "Tran_NamF": "Carl",
+      "Tran_NamL": "Denyer"
     },
     {
       "Filer_ID": "892160",
@@ -21501,15 +21501,15 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Bryan",
-      "Tran_NamL": "Dillingham"
+      "Tran_NamF": "Brian",
+      "Tran_NamL": "DiRegolo"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Brian",
-      "Tran_NamL": "DiRegolo"
+      "Tran_NamF": "Bryan",
+      "Tran_NamL": "Dillingham"
     },
     {
       "Filer_ID": "892160",
@@ -22509,13 +22509,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Ronald",
-      "Tran_NamL": "Oatis"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-10-20",
       "Tran_NamF": "Christopher",
       "Tran_NamL": "O'Brien"
     },
@@ -22537,22 +22530,29 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-10-20",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-10-20",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-10-20",
+      "Tran_NamF": "Ronald",
+      "Tran_NamL": "Oatis"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-10-20",
       "Tran_NamF": "Carlos",
       "Tran_NamL": "Olivarez"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-10-20",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
     },
     {
       "Filer_ID": "892160",
@@ -26226,15 +26226,15 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Jesse",
-      "Tran_NamL": "Blaylock"
+      "Tran_NamF": "Francis",
+      "Tran_NamL": "Blay-Miezah"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Francis",
-      "Tran_NamL": "Blay-Miezah"
+      "Tran_NamF": "Jesse",
+      "Tran_NamL": "Blaylock"
     },
     {
       "Filer_ID": "892160",
@@ -26583,13 +26583,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Michael",
-      "Tran_NamL": "Dearborn"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-12-07",
       "Tran_NamF": "Nicholas",
       "Tran_NamL": "DeLaTorre"
     },
@@ -26597,15 +26590,22 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Carl",
-      "Tran_NamL": "Denyer"
+      "Tran_NamF": "Allison",
+      "Tran_NamL": "DePalma"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Allison",
-      "Tran_NamL": "DePalma"
+      "Tran_NamF": "Michael",
+      "Tran_NamL": "Dearborn"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-12-07",
+      "Tran_NamF": "Carl",
+      "Tran_NamL": "Denyer"
     },
     {
       "Filer_ID": "892160",
@@ -26625,15 +26625,15 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Bryan",
-      "Tran_NamL": "Dillingham"
+      "Tran_NamF": "Brian",
+      "Tran_NamL": "DiRegolo"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Brian",
-      "Tran_NamL": "DiRegolo"
+      "Tran_NamF": "Bryan",
+      "Tran_NamL": "Dillingham"
     },
     {
       "Filer_ID": "892160",
@@ -27633,13 +27633,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Ronald",
-      "Tran_NamL": "Oatis"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-12-07",
       "Tran_NamF": "Christopher",
       "Tran_NamL": "O'Brien"
     },
@@ -27661,22 +27654,29 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-07",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-12-07",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-12-07",
+      "Tran_NamF": "Ronald",
+      "Tran_NamL": "Oatis"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-12-07",
       "Tran_NamF": "Carlos",
       "Tran_NamL": "Olivarez"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-12-07",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
     },
     {
       "Filer_ID": "892160",
@@ -31322,15 +31322,15 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Jesse",
-      "Tran_NamL": "Blaylock"
+      "Tran_NamF": "Francis",
+      "Tran_NamL": "Blay-Miezah"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Francis",
-      "Tran_NamL": "Blay-Miezah"
+      "Tran_NamF": "Jesse",
+      "Tran_NamL": "Blaylock"
     },
     {
       "Filer_ID": "892160",
@@ -31672,13 +31672,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Michael",
-      "Tran_NamL": "Dearborn"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-12-20",
       "Tran_NamF": "Nicholas",
       "Tran_NamL": "DeLaTorre"
     },
@@ -31686,15 +31679,22 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Carl",
-      "Tran_NamL": "Denyer"
+      "Tran_NamF": "Allison",
+      "Tran_NamL": "DePalma"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Allison",
-      "Tran_NamL": "DePalma"
+      "Tran_NamF": "Michael",
+      "Tran_NamL": "Dearborn"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-12-20",
+      "Tran_NamF": "Carl",
+      "Tran_NamL": "Denyer"
     },
     {
       "Filer_ID": "892160",
@@ -31714,15 +31714,15 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Bryan",
-      "Tran_NamL": "Dillingham"
+      "Tran_NamF": "Brian",
+      "Tran_NamL": "DiRegolo"
     },
     {
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Brian",
-      "Tran_NamL": "DiRegolo"
+      "Tran_NamF": "Bryan",
+      "Tran_NamL": "Dillingham"
     },
     {
       "Filer_ID": "892160",
@@ -32715,13 +32715,6 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Ronald",
-      "Tran_NamL": "Oatis"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-12-20",
       "Tran_NamF": "Christopher",
       "Tran_NamL": "O'Brien"
     },
@@ -32743,22 +32736,29 @@
       "Filer_ID": "892160",
       "Tran_Amt1": 10.0,
       "Tran_Date": "2015-12-20",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-12-20",
+      "Tran_NamF": "Steven",
+      "Tran_NamL": "O'Neil"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-12-20",
+      "Tran_NamF": "Ronald",
+      "Tran_NamL": "Oatis"
+    },
+    {
+      "Filer_ID": "892160",
+      "Tran_Amt1": 10.0,
+      "Tran_Date": "2015-12-20",
       "Tran_NamF": "Carlos",
       "Tran_NamL": "Olivarez"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
-    },
-    {
-      "Filer_ID": "892160",
-      "Tran_Amt1": 10.0,
-      "Tran_Date": "2015-12-20",
-      "Tran_NamF": "Steven",
-      "Tran_NamL": "O'Neil"
     },
     {
       "Filer_ID": "892160",

--- a/build/_data/committees/931558.json
+++ b/build/_data/committees/931558.json
@@ -107,17 +107,17 @@
     },
     {
       "Filer_ID": "931558",
-      "Tran_Amt1": 100.0,
-      "Tran_Date": "2017-12-08",
-      "Tran_NamF": "Roger",
-      "Tran_NamL": "Sanders"
-    },
-    {
-      "Filer_ID": "931558",
       "Tran_Amt1": 250.0,
       "Tran_Date": "2017-12-08",
       "Tran_NamF": null,
       "Tran_NamL": "SEIU United Healthcare Workers West PAC"
+    },
+    {
+      "Filer_ID": "931558",
+      "Tran_Amt1": 100.0,
+      "Tran_Date": "2017-12-08",
+      "Tran_NamF": "Roger",
+      "Tran_NamL": "Sanders"
     },
     {
       "Filer_ID": "931558",

--- a/build/_data/referendum_supporting/oakland/2016-11-08/oakland-school-bond.json
+++ b/build/_data/referendum_supporting/oakland/2016-11-08/oakland-school-bond.json
@@ -31,12 +31,6 @@
   ],
   "supporting_organizations": [
     {
-      "id": "1331137",
-      "name": "Families and Educators for Public Education, Sponsored by Go Public Schools Advocates",
-      "payee": "Families and Educators for Public Education, Sponsored by Go Public Schools Advocates",
-      "amount": 9928.0
-    },
-    {
       "id": "1391632",
       "name": "YES ON G1, SPONSORED BY GO PUBLIC SCHOOLS ADVOCATES",
       "payee": "YES ON G1, SPONSORED BY GO PUBLIC SCHOOLS ADVOCATES",

--- a/build/_data/referendum_supporting/sf/2018-06-05/additional-tax-on-commercial-rents-mostly-to-fund-housing-and-homelessness-services.json
+++ b/build/_data/referendum_supporting/sf/2018-06-05/additional-tax-on-commercial-rents-mostly-to-fund-housing-and-homelessness-services.json
@@ -41,12 +41,6 @@
       "name": "SOMA HOTEL, LLC",
       "payee": "SOMA HOTEL, LLC",
       "amount": 50000.0
-    },
-    {
-      "id": "1392132",
-      "name": "Tenants and Owners Development Corporation and its affiliated entity Yerba Buena Neighborhood Consortium LLC",
-      "payee": "Tenants and Owners Development Corporation and its affiliated entity Yerba Buena Neighborhood Consortium LLC",
-      "amount": 2385.7
     }
   ],
   "total_contributions": [

--- a/build/_office_elections/sf/2018-06-05/supervisor-district-8.md
+++ b/build/_office_elections/sf/2018-06-05/supervisor-district-8.md
@@ -1,7 +1,7 @@
 ---
 ballot: _ballots/sf/2018-06-05.md
 candidates:
-- jeff-sheehy
 - rafael-mandelman
+- jeff-sheehy
 title: Supervisor District 8
 ---

--- a/calculators/candidate_expenditures_by_type.rb
+++ b/calculators/candidate_expenditures_by_type.rb
@@ -117,7 +117,7 @@ class CandidateExpendituresByType
             "FPPC"::varchar AS "Filer_ID",
             "Expn_Code",
             "Amount"
-          FROM "E-Expenditure", "oakland_candidates"
+          FROM "D-Expenditure", "oakland_candidates"
           WHERE "Sup_Opp_Cd" = 'S'
             AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
             AND "Committee_Type" <> 'CTL' AND "Committee_Type" <> 'CAO'
@@ -130,7 +130,7 @@ class CandidateExpendituresByType
           WHERE "Sup_Opp_Cd" = 'S'
             AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
             AND NOT EXISTS (
-              SELECT 1 from "E-Expenditure" AS "inner"
+              SELECT 1 from "D-Expenditure" AS "inner"
               WHERE "outer"."Filer_ID"::varchar = "inner"."Filer_ID"
                 AND "outer"."Exp_Date" = "inner"."Expn_Date"
                 AND "outer"."Amount" = "inner"."Amount"
@@ -162,7 +162,7 @@ class CandidateExpendituresByType
             "FPPC"::varchar AS "Filer_ID",
             "Expn_Code",
             "Amount"
-          FROM "E-Expenditure", "oakland_candidates"
+          FROM "D-Expenditure", "oakland_candidates"
           WHERE "Sup_Opp_Cd" = 'O'
             AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
             AND "Committee_Type" <> 'CTL' AND "Committee_Type" <> 'CAO'
@@ -175,7 +175,7 @@ class CandidateExpendituresByType
           WHERE "Sup_Opp_Cd" = 'O'
             AND lower("Candidate") = lower(trim(concat("Cand_NamF", ' ', "Cand_NamL")))
             AND NOT EXISTS (
-              SELECT 1 FROM "E-Expenditure" AS "inner"
+              SELECT 1 FROM "D-Expenditure" AS "inner"
               WHERE "outer"."Filer_ID"::varchar = "inner"."Filer_ID"
               AND "outer"."Exp_Date" = "inner"."Expn_Date"
               AND "outer"."Amount" = "inner"."Amount"


### PR DESCRIPTION
Remove outdated 496 data for independent committees.  We were getting the 460 data from Sched E rather than D so this is fixed too.  Unfortunately some committees seem to summarize the expenditures in Sched D when they had more details in the 496.