### PR TITLE
Sort candidates by total_contributions, then by name

### DIFF
--- a/process.rb
+++ b/process.rb
@@ -149,7 +149,13 @@ ELECTIONS.each do |election_name, election|
   # /_office_elections/oakland/2018-11-06/city-auditor.md
   OfficeElection.where(election_name: election_name).find_each do |office_election|
     build_file("/_office_elections/#{locality}/#{election[:date]}/#{slugify(office_election.title)}.md") do |f|
-      candidates = OaklandCandidate.where(Office: office_election.title, election_name: election_name).pluck(:Candidate)
+      candidates =
+        OaklandCandidate
+          .where(Office: office_election.title, election_name: election_name)
+          .sort_by do |candidate|
+            [-1 * (candidate.calculation(:total_contributions) || 0.0), candidate.Candidate]
+          end
+          .map { |candidate| candidate.Candidate }
 
       f.puts(YAML.dump({
         'ballot' => ballot_name[1..-1],


### PR DESCRIPTION
To improve the office_election list display, let's sort the candidates
in order by total_contributions. This is borne out by research
indicating that users are interested in the candidates that have raised
the most money locally. The remaining candidates are sorted by name so
they are in an expected order for a user searching to find a specific
one.

This should fix https://github.com/caciviclab/odca-jekyll/issues/188.