### PR TITLE
Post a comment with the build diff to Github

### DIFF
--- a/bin/travis-deploy
+++ b/bin/travis-deploy
@@ -1,6 +1,28 @@
 #!/bin/bash
 set -euo pipefail
 
+post_pr_diff_to_github() {
+  issue_id=$1
+  pr_head_sha=$2
+  url="https://$GITHUB_AUTH_TOKEN@api.github.com/repos/caciviclab/disclosure-backend-static/issues/${issue_id}/comments"
+  tmp=$(mktemp)
+  trap "rm $tmp" EXIT
+  cat <<BODY | jq -R -s '{ body: . }' | curl -v -H"Content-Type: application/json" -d@- "$url"
+<details>
+<summary>Build diff from Commit ${pr_head_sha}:</summary>
+
+\`\`\`diff
+$(git diff)
+\`\`\`
+</details>
+BODY
+
+}
+
+echo "hi"
+post_pr_diff_to_github 153 "37c2e6c"
+exit
+
 deploy() {
   set -x
   git add build
@@ -20,14 +42,16 @@ This is an automated update by travis-ci at
   make upload-cache
 }
 
-if git diff --exit-code --quiet; then
+if [ "${TRAVIS_EVENT_TYPE}" = "pull_request" ]; then
+  post_pr_diff_to_github "$TRAVIS_PULL_REQUEST" "$TRAVIS_PULL_REQUEST_SHA"
+elif [ ! -d "build" ]; then
+  echo "The 'build' directory is missing. Bailing!"
+elif git diff --exit-code --quiet; then
   echo "No changes to deploy!"
 elif [ "${TRAVIS_EVENT_TYPE}" = "push" -a "${TRAVIS_BRANCH}" = "master" ]; then
   deploy
-elif [ ! "${TRAVIS_EVENT_TYPE}" = "cron" -a ! "${TRAVIS_BRANCH}" = "automatic_updating" ]; then
-  echo "Not deploying since this is not a cron job or on the 'automatic_updating' branch."
-elif [ ! -d "build" ]; then
-  echo "The 'build' directory is missing. Bailing!"
-else
+elif [ "${TRAVIS_EVENT_TYPE}" = "cron" -a "${TRAVIS_BRANCH}" = "master" ]; then
   deploy
+else
+  echo "Not deploying since not push or cron build on master branch"
 fi


### PR DESCRIPTION
This will remove the need to run `make process` on your local branch -
instead Travis will run it and post it in a comment to the Pull Request.

The reason here is that there are some pesky build differences between
MacOS and Linux that have been very difficult to get rid of, so by
making the builds consistently running on Travis we can minimize
spurious diffs.