### PR TITLE
Add `make import-cached` task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 downloads/csv
 downloads/raw
+downloads/cached-db
 inputs


### PR DESCRIPTION
This is to complement `make download-cached`, i.e. the daily Travis
build will dump the SQL it used to generate the day's results. This
should make importing quite a bit quicker as CSVs will not need to be
processed in order to get the data running.

Ideally the commands can be combined like:

```
make download-cached import-cached
```