### PR TITLE
Use "Exp_Date" rather than "Rpt_Date" for removing duplicates

### DIFF
--- a/bin/remove_duplicate_transactions
+++ b/bin/remove_duplicate_transactions
@@ -6,9 +6,9 @@ cat <<-QUERY | psql ${DATABASE_NAME:-"disclosure-backend"}
 DELETE FROM "496" late
 WHERE EXISTS (
   SELECT * FROM "Summary" summary
-      WHERE summary."Filer_ID"::varchar = late."Filer_ID" AND late."Rpt_Date" <= summary."Thru_Date");
+      WHERE summary."Filer_ID"::varchar = late."Filer_ID" AND late."Exp_Date" <= summary."Thru_Date");
 DELETE FROM "497" late
 WHERE EXISTS (
   SELECT * FROM "Summary" summary
-      WHERE summary."Filer_ID"::varchar = late."Filer_ID" AND late."Rpt_Date" <= summary."Thru_Date");
+      WHERE summary."Filer_ID"::varchar = late."Filer_ID" AND late."Exp_Date" <= summary."Thru_Date");
 QUERY

--- a/bin/remove_duplicate_transactions
+++ b/bin/remove_duplicate_transactions
@@ -10,5 +10,5 @@ WHERE EXISTS (
 DELETE FROM "497" late
 WHERE EXISTS (
   SELECT * FROM "Summary" summary
-      WHERE summary."Filer_ID"::varchar = late."Filer_ID" AND late."Exp_Date" <= summary."Thru_Date");
+      WHERE summary."Filer_ID"::varchar = late."Filer_ID" AND late."Ctrib_Date" <= summary."Thru_Date");
 QUERY


### PR DESCRIPTION
We have the following situation:

FPPC #1331137 filed:
- 460 covering Thru_Date = 2018-09-22, reporting IEs in support of Gary Yee
- 496 on Rpt_Date = 2018-09-23, reporting expenditures on 2018-09-22 in support of Gary Yee

These 496 expenditures should have been deduplicated, but were not due
to us using the Rpt_Date on the 496 instead of the Exp_Date.

I'll write a test case in a subsequent commit.

Fixes https://github.com/caciviclab/odca-jekyll/issues/257