### PR TITLE
Fix #173

### DIFF
--- a/bin/make_view
+++ b/bin/make_view
@@ -135,12 +135,12 @@ CREATE VIEW combined_contributions AS
 
 DROP VIEW IF EXISTS independent_candidate_expenditures;
 CREATE VIEW independent_candidate_expenditures AS
-  SELECT "FPPC" AS "Filer_ID", "Filer_NamL", "Exp_Date", "Sup_Opp_Cd", "Amount"
+  SELECT "FPPC" AS "Cand_ID", "Filer_ID", "Filer_NamL", "Exp_Date", "Sup_Opp_Cd", "Amount"
   FROM (
-    SELECT "Filer_NamL", "Exp_Date", "Cand_NamF", "Cand_NamL", "Amount", "Sup_Opp_Cd"
+    SELECT "Filer_ID", "Filer_NamL", "Exp_Date", "Cand_NamF", "Cand_NamL", "Amount", "Sup_Opp_Cd"
     FROM "496"
     UNION ALL
-    SELECT "Filer_NamL", "Expn_Date" as "Exp_Date", "Cand_NamF", "Cand_NamL",
+    SELECT "Filer_ID", "Filer_NamL", "Expn_Date" as "Exp_Date", "Cand_NamF", "Cand_NamL",
     "Amount", "Sup_Opp_Cd"
     FROM "D-Expenditure"
     WHERE "Expn_Code" = 'IND'

--- a/calculators/candidate_opposing_expenditures.rb
+++ b/calculators/candidate_opposing_expenditures.rb
@@ -7,15 +7,15 @@ class CandidateOpposingExpenditure
   def fetch
     # Get the total expenditures against candidates by date.
     expenditures = ActiveRecord::Base.connection.execute(<<-SQL)
-      SELECT "Filer_ID", "Filer_NamL", SUM("Amount") as "Total"
+      SELECT "Cand_ID", "Filer_ID", "Filer_NamL", SUM("Amount") as "Total"
       FROM independent_candidate_expenditures
       WHERE "Sup_Opp_Cd" = 'O'
-      GROUP BY "Filer_ID", "Filer_NamL";
+      GROUP BY "Cand_ID", "Filer_ID", "Filer_NamL";
     SQL
 
     total = {}
     expenditure_against_candidate = expenditures.each_with_object({}) do |row, hash|
-      filer_id = row['Filer_ID'].to_s
+      filer_id = row['Cand_ID'].to_s
       total[filer_id] ||= 0
       total[filer_id] += row['Total']
 

--- a/calculators/candidate_supporting_expenditures.rb
+++ b/calculators/candidate_supporting_expenditures.rb
@@ -7,17 +7,17 @@ class CandidateSupportingExpenditure
   def fetch
     # Get the total indepedent expenditures for candidates by date.
     expenditures = ActiveRecord::Base.connection.execute(<<-SQL)
-      SELECT "Filer_ID", "Filer_NamL", SUM("Amount") as "Total"
+      SELECT "Cand_ID", "Filer_ID", "Filer_NamL", SUM("Amount") as "Total"
       FROM independent_candidate_expenditures
       WHERE "Sup_Opp_Cd" = 'S'
-      GROUP BY "Filer_ID", "Filer_NamL";
+      GROUP BY "Cand_ID", "Filer_ID", "Filer_NamL";
     SQL
 
     total = {}
     # TODO: Key this based off the candidate name rather than the Filer ID, to
     # support IEs for candidates that haven't filed to run yet.
    expenditure_for_candidate = expenditures.each_with_object({}) do |row, hash|
-      filer_id = row['Filer_ID'].to_s
+      filer_id = row['Cand_ID'].to_s
       total[filer_id] ||= 0
       total[filer_id] += row['Total']
 


### PR DESCRIPTION
Report the filer_id of the supporting/opposing committees in the expenditure lists for candidates.

This is built on top of the PR for locale.