### PR TITLE
Allow builds to be published from CI

### DIFF
--- a/bin/travis-deploy
+++ b/bin/travis-deploy
@@ -42,10 +42,8 @@ elif [ ! -d "build" ]; then
   echo "The 'build' directory is missing. Bailing!"
 elif git diff --exit-code --quiet; then
   echo "No changes to deploy!"
-elif [ "${TRAVIS_EVENT_TYPE}" = "push" -a "${TRAVIS_BRANCH}" = "master" ]; then
-  deploy
-elif [ "${TRAVIS_EVENT_TYPE}" = "cron" -a "${TRAVIS_BRANCH}" = "master" ]; then
+elif [ ! "${TRAVIS_EVENT_TYPE}" = "pull_request" -a "${TRAVIS_BRANCH}" = "master" ]; then
   deploy
 else
-  echo "Not deploying since not push or cron build on master branch"
+  echo "Not deploying since not api, push, or cron build on master branch"
 fi


### PR DESCRIPTION
This allows builds triggered from the Travis UI to deploy.