### PR TITLE
added line for is_winner attribute for each candidate

### DIFF
--- a/models/candidate.rb
+++ b/models/candidate.rb
@@ -37,6 +37,7 @@ class Candidate < ActiveRecord::Base
       is_incumbent: self['Incumbent'],
       occupation: self['Occupation'],
       party_affiliation: self['Party_Affiliation'],
+      is_winner: self['is_winner'],
 
       # contribution data
       filer_id: self['FPPC'],


### PR DESCRIPTION
This is pertaining to the edits @r-i-c-h made last week per comments on #287 front end (https://github.com/caciviclab/odca-jekyll/issues/287). We added the line for the is_winner attribute to use this conditionally for styling on the front end.