### PR TITLE
Extend the length of office_election title

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ do-import-spreadsheets:
 	echo 'ALTER TABLE "committees" ADD COLUMN id SERIAL PRIMARY KEY;' | psql $(DATABASE_NAME)
 	echo 'DROP TABLE IF EXISTS office_elections;' | psql $(DATABASE_NAME)
 	csvsql --doublequote --db postgresql:///$(DATABASE_NAME) --insert downloads/csv/office_elections.csv
+	echo 'ALTER TABLE "office_elections" ALTER COLUMN title TYPE varchar(50);' | psql $(DATABASE_NAME)
 	echo 'ALTER TABLE "office_elections" ADD COLUMN id SERIAL PRIMARY KEY;' | psql $(DATABASE_NAME)
 	echo 'DROP TABLE IF EXISTS elections;' | psql $(DATABASE_NAME)
 	csvsql --doublequote --db postgresql:///$(DATABASE_NAME) --insert downloads/csv/elections.csv


### PR DESCRIPTION
We automatically create some rows in office_election during the
processing step, which isn't included in the inference used to create
the initial column lengths.

As such, the 31-character longest office in the data is too long for the
inferred 27-character max.

This, along with removal of non-integer FPPC numbers in the spreadsheet,
should fix the build.

[Fixes #187]