### PR TITLE
Typecast Filer_ID as varchar

### DIFF
--- a/bin/make_view
+++ b/bin/make_view
@@ -137,7 +137,7 @@ DROP VIEW IF EXISTS independent_candidate_expenditures;
 CREATE VIEW independent_candidate_expenditures AS
   SELECT "FPPC" AS "Cand_ID", "Filer_ID", "Filer_NamL", "Exp_Date", "Sup_Opp_Cd", "Amount"
   FROM (
-    SELECT "Filer_ID", "Filer_NamL", "Exp_Date", "Cand_NamF", "Cand_NamL", "Amount", "Sup_Opp_Cd"
+    SELECT "Filer_ID"::varchar, "Filer_NamL", "Exp_Date", "Cand_NamF", "Cand_NamL", "Amount", "Sup_Opp_Cd"
     FROM "496"
     UNION ALL
     SELECT "Filer_ID", "Filer_NamL", "Expn_Date" as "Exp_Date", "Cand_NamF", "Cand_NamL",

--- a/bin/remove_duplicate_transactions
+++ b/bin/remove_duplicate_transactions
@@ -6,9 +6,9 @@ cat <<-QUERY | psql ${DATABASE_NAME:-"disclosure-backend"}
 DELETE FROM "496" late
 WHERE EXISTS (
   SELECT * FROM "Summary" summary
-      WHERE summary."Filer_ID"::varchar = late."Filer_ID" AND late."Exp_Date" <= summary."Thru_Date");
+      WHERE summary."Filer_ID"::varchar = late."Filer_ID"::varchar AND late."Exp_Date" <= summary."Thru_Date");
 DELETE FROM "497" late
 WHERE EXISTS (
   SELECT * FROM "Summary" summary
-      WHERE summary."Filer_ID"::varchar = late."Filer_ID" AND late."Ctrib_Date" <= summary."Thru_Date");
+      WHERE summary."Filer_ID"::varchar = late."Filer_ID"::varchar AND late."Ctrib_Date" <= summary."Thru_Date");
 QUERY


### PR DESCRIPTION
I'm not sure if this is correct, but the intention is to fix the Travis build.

Filer Ids are always strings, not integers. Sometimes csvkit assumes they're
integers which leads to trouble. I'm assuming that this is 2019 data that
coincidentally have all integer Filer Ids, confusing csvkit, but I'm not sure of
this.

Not sure if there is a way to hint to csvkit to just treat these as varchars without having to do the typecasts everywhere. It might make sense to just pre-define the schemas and then csvkit would just load into the existing schemas where Filer_ID is already varchar.