### PR TITLE
Remove waffle badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build
 Status](https://travis-ci.org/caciviclab/disclosure-backend-static.svg?branch=master)](https://travis-ci.org/caciviclab/disclosure-backend-static)
-[![Waffle.io - Columns and their card count](https://badge.waffle.io/caciviclab/disclosure-backend.png?columns=ready)](https://waffle.io/caciviclab/disclosure-backend?utm_source=badge)
 
 # Disclosure Backend Static
 


### PR DESCRIPTION
Having the disabled badge looked odd. If Zenhub gets a badge, it'd be cool to add that in this place but I don't think it exists yet.