### PR TITLE
Process 2020 data files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ upload-cache:
 
 download: download-spreadsheets download-SFO-2017 download-SFO-2018 \
 	download-COAK-2015 download-COAK-2016 download-COAK-2017 download-COAK-2018 \
+	download-COAK-2019 download-COAK-2020 \
 	download-BRK-2017 download-BRK-2018
 
 download-SFO-%:

--- a/process.rb
+++ b/process.rb
@@ -254,7 +254,7 @@ end
 
 build_file('/_data/stats.json') do |f|
   # TODO this should probably be locality-election specific to the date of the bulk data download
-  date_processed = File.mtime('downloads/raw/efile_COAK_2018.zip')
+  date_processed = File.mtime('downloads/raw/efile_COAK_2020.zip')
   f.puts JSON.pretty_generate(
     date_processed: date_processed.to_s
   )


### PR DESCRIPTION
We hardcode the names of the files ourselves. Let's make sure to grab
2019 (very small) and 2020 (going to be very big).