### PR TITLE
Start calculations for independent expenditures

### DIFF
--- a/build/_data/independent_expenditures.json
+++ b/build/_data/independent_expenditures.json
@@ -1,0 +1,18 @@
+{
+  "oakland-march-2020": [
+    [
+      "NATIONAL ASSOCIATION OF REALTORS",
+      165195
+    ],
+    [
+      "CALIFORNIA ASSOCIATION OF REALTORS ISSUES MOBILIZATION PAC",
+      40641
+    ]
+  ],
+  "sf-june-2018": [
+    [
+      "San Francisco Bay Area Planning & Urban Research Association",
+      1421
+    ]
+  ]
+}

--- a/process.rb
+++ b/process.rb
@@ -259,3 +259,36 @@ build_file('/_data/stats.json') do |f|
     date_processed: date_processed.to_s
   )
 end
+
+
+build_file('/_data/independent_expenditures.json') do |f|
+  ie = {}
+  results = ActiveRecord::Base.connection.execute <<-SQL
+    SELECT "Filer_NamL", SUM("Amount"), election_name FROM
+    (
+      SELECT DISTINCT "Filer_NamL", "496"."Tran_ID", "Amount", election_name
+      FROM referendums JOIN "496"
+      on referendums."Measure_number" = "496"."Bal_Num"
+    ) as unique_transactions
+    GROUP BY "Filer_NamL", election_name
+  SQL
+  results.each do |row|
+    election = row['election_name']
+    filer = row['Filer_NamL']
+    sum = row['sum']
+    ie[election] = {} unless ie[election]
+
+    if ie[election][filer]
+      ie[election][filer] += sum.to_i
+    else
+      ie[election][filer] = sum.to_i
+    end
+  end
+
+  sorted_results = {}
+  ie.each do |election, data|
+    sorted_results[election] = data.sort_by { |spender, amount| amount }.reverse 
+  end
+
+  f.puts JSON.pretty_generate(Hash[sorted_results])
+end


### PR DESCRIPTION
This update to `process.rb` is very incomplete, but should give us currently up-to-date calculations for top third party spenders for the March election. Specifically, this calculation only looks at the 496 table and joins it with the referendums table in order to figure out what election it belongs to, and then it sums up the total amount by various third party spenders.

There are some things that I think I'll still need a bit more clarification on before I can build a comprehensive solution to calculating amount spent by third parties:

1. The 496 table is currently showing null for the `election_date` column, which then required me to make a join to the `referendums` table by ballot measure name in order to figure out what election each expenditure belonged to. While this works for the current data set, this is not ideal. I tried to extend this method for candidate-related independent expenditures, but this was problematic since candidates could have data tied to multiple elections (ie. Libby Schaaf -> oakland-2018 and Libby Schaaf -> oakland-2020). The better solution would be to fix the download step to include the election_date for each independent expenditure in the 496 csvs so that we don't have to join to other tables by ballot measure name or candidate name.
2. @sfdoran Currently, this independent expenditures calculation is only based off of the 496 forms. I'm still having a hard time finding an example where something that was reported through the 496 form then later showed up on the Schedule D. I wanted to build out that database query off of a real example, and I'm wondering if we can wait until a real case comes in and then we can tweak our query for these calculations to include the Schedule D table.
3. @anlawyer @ckingbailey The goal is move this database query and massaging of data out of the `process.rb` file. I had originally wanted to build it as a calculator, but that calculators are more for creating a specific `calculation` per candidate or referendum, and this case was more about just aggregating total expenditures. Definitely would love to hear y'all's thoughts on the best way to refactor this logic out of the `process.rb` file!