### PR TITLE
Add election total and most expensive races

### DIFF
--- a/build/_data/totals.json
+++ b/build/_data/totals.json
@@ -1,36 +1,221 @@
 {
-  "berkeley-2018": {
-    "Within Berkeley": 30855.629999999997,
-    "Within California": 8366.0,
-    "Out of State": 927.0,
-    "largest_independent_expenditures": null
+  "sf-2016": {
+    "Within California": 100347.02,
+    "Total": 100347.02,
+    "largest_independent_expenditures": null,
+    "most_expensive_races": [
+      {
+        "title": "Measure V",
+        "type": "referendum",
+        "slug": "tax-on-distributing-sugar-sweetened-beverages---proposition-v",
+        "amount": 90347.02
+      },
+      {
+        "title": "Measure N",
+        "type": "referendum",
+        "slug": "non-citizen-voting-in-school-board-measure-n",
+        "amount": 10000.0
+      },
+      {
+        "title": "Measure A",
+        "type": "referendum",
+        "slug": "bond-public-health-and-safety-bond-measure",
+        "amount": 0
+      }
+    ]
   },
   "oakland-2016": {
     "Out of State": 10552796.459999999,
+    "Total": 21099401.659999993,
     "Within California": 9123736.680000002,
     "Within Oakland": 1422868.52,
-    "largest_independent_expenditures": null
+    "largest_independent_expenditures": null,
+    "most_expensive_races": [
+      {
+        "title": "Measure HH",
+        "type": "referendum",
+        "slug": "sugar-sweetened-beverage-tax",
+        "amount": 18673836.560000002
+      },
+      {
+        "title": "Measure JJ",
+        "type": "referendum",
+        "slug": "just-cause-for-eviction-and-rent-adjustment",
+        "amount": 477719.80999999994
+      },
+      {
+        "title": "Measure KK",
+        "type": "referendum",
+        "slug": "infrastructure-and-housing-bonds",
+        "amount": 450809.58
+      }
+    ]
+  },
+  "sf-june-2018": {
+    "Out of State": 14819989.39,
+    "Total": 23288054.16,
+    "Within California": 2219438.2399999998,
+    "Within San Francisco": 6248626.529999998,
+    "largest_independent_expenditures": null,
+    "most_expensive_races": [
+      {
+        "title": "Measure E",
+        "type": "referendum",
+        "slug": "uphold-ordinance-banning-the-sale-of-flavored-tobacco-products",
+        "amount": 14245967.27
+      },
+      {
+        "title": "Mayor",
+        "type": "office_election",
+        "slug": "mayor",
+        "amount": 2867477.9800000004
+      },
+      {
+        "title": "Measure D",
+        "type": "referendum",
+        "slug": "additional-tax-on-commercial-rents-mostly-to-fund-housing-and-homelessness-services",
+        "amount": 2690973.82
+      }
+    ]
   },
   "oakland-june-2018": {
     "Out of State": 7200.0,
+    "Total": 151587.72,
     "Within California": 33550.0,
     "Within Oakland": 110837.72,
-    "largest_independent_expenditures": null
+    "largest_independent_expenditures": null,
+    "most_expensive_races": [
+      {
+        "title": "Measure D",
+        "type": "referendum",
+        "slug": "library-parcel-tax",
+        "amount": 151587.72
+      },
+      {
+        "title": "Measure 3",
+        "type": "referendum",
+        "slug": "regional-measure-3",
+        "amount": 0
+      },
+      {
+        "title": "Measure A",
+        "type": "referendum",
+        "slug": "alameda-county-sales-tax-for-childcare-and-education",
+        "amount": 0
+      }
+    ]
+  },
+  "sf-2018": {
+    "Out of State": 52025.0,
+    "Total": 372543.25,
+    "Within California": 121545.0,
+    "Within San Francisco": 198973.25,
+    "largest_independent_expenditures": [
+      {
+        "Filer_NamL": "SAN FRANCISCO APARTMENT ASSOCIATION POLITICAL ACTION COMMITTEE",
+        "Total_Amount": 10177.0,
+        "election_name": "sf-2018"
+      }
+    ],
+    "most_expensive_races": [
+      {
+        "title": "Measure PENDING-4",
+        "type": "referendum",
+        "slug": "universal-childcare-in-san-francisco",
+        "amount": 328293.25
+      },
+      {
+        "title": "Measure PENDING-10",
+        "type": "referendum",
+        "slug": "expands-local-governments-authority-to-enact-rent-control-on-residential-property-intiative-statute-17-0041-",
+        "amount": 44250.0
+      }
+    ]
   },
   "oakland-2018": {
-    "Within Oakland": 2614783.9099999997,
     "Out of State": 899596.36,
+    "Total": 6404634.17,
     "Within California": 2890253.9,
-    "largest_independent_expenditures": null
+    "Within Oakland": 2614783.9099999997,
+    "largest_independent_expenditures": null,
+    "most_expensive_races": [
+      {
+        "title": "Measure AA",
+        "type": "referendum",
+        "slug": "oakland-children-s-initiative",
+        "amount": 2136485.19
+      },
+      {
+        "title": "Measure Y",
+        "type": "referendum",
+        "slug": "just-cause-eviction-amendments",
+        "amount": 816407.3800000001
+      },
+      {
+        "title": "Measure W",
+        "type": "referendum",
+        "slug": "vacant-property-parcel-tax",
+        "amount": 776996.5800000001
+      }
+    ]
+  },
+  "berkeley-2018": {
+    "Within Berkeley": 30855.629999999997,
+    "Total": 40148.63,
+    "Out of State": 927.0,
+    "Within California": 8366.0,
+    "largest_independent_expenditures": null,
+    "most_expensive_races": [
+      {
+        "title": "City Council District 4",
+        "type": "office_election",
+        "slug": "city-council-district-4",
+        "amount": 33885.86
+      },
+      {
+        "title": "City Council District 8",
+        "type": "office_election",
+        "slug": "city-council-district-8",
+        "amount": 2211.27
+      },
+      {
+        "title": "Measure PENDING-5",
+        "type": "referendum",
+        "slug": "berkeley-community-for-police-oversight",
+        "amount": 1805.0
+      }
+    ]
   },
   "oakland-2020": {
     "Out of State": 12973.84,
-    "Within Oakland": 94946.51,
-    "Within California": 88980.70999999999,
-    "largest_independent_expenditures": null
+    "Total": 200388.06,
+    "Within California": 90280.70999999999,
+    "Within Oakland": 97133.51,
+    "largest_independent_expenditures": null,
+    "most_expensive_races": [
+      {
+        "title": "City Council District 1",
+        "type": "office_election",
+        "slug": "city-council-district-1",
+        "amount": 95371.03
+      },
+      {
+        "title": "City Council District 7",
+        "type": "office_election",
+        "slug": "city-council-district-7",
+        "amount": 57920.86
+      },
+      {
+        "title": "City Council At-Large",
+        "type": "office_election",
+        "slug": "city-council-at-large",
+        "amount": 33174.0
+      }
+    ]
   },
   "oakland-march-2020": {
     "Out of State": 36764.0,
+    "Total": 335992.0,
     "Within California": 195800.0,
     "Within Oakland": 103428.0,
     "largest_independent_expenditures": [
@@ -44,27 +229,25 @@
         "Total_Amount": 40641.0,
         "election_name": "oakland-march-2020"
       }
-    ]
-  },
-  "sf-2016": {
-    "Within California": 100347.02,
-    "largest_independent_expenditures": null
-  },
-  "sf-june-2018": {
-    "Within San Francisco": 6248626.529999998,
-    "Within California": 2219438.2399999998,
-    "Out of State": 14819989.39,
-    "largest_independent_expenditures": null
-  },
-  "sf-2018": {
-    "Out of State": 52025.0,
-    "Within California": 121545.0,
-    "Within San Francisco": 198973.25,
-    "largest_independent_expenditures": [
+    ],
+    "most_expensive_races": [
       {
-        "Filer_NamL": "SAN FRANCISCO APARTMENT ASSOCIATION POLITICAL ACTION COMMITTEE",
-        "Total_Amount": 10177.0,
-        "election_name": "sf-2018"
+        "title": "Measure Q",
+        "type": "referendum",
+        "slug": "oakland-parks-and-recreation-preservation-litter-reduction-and-homelessness-support-act",
+        "amount": 335992.0
+      },
+      {
+        "title": "Measure R",
+        "type": "referendum",
+        "slug": "official-city-newspaper",
+        "amount": 0
+      },
+      {
+        "title": "Measure S",
+        "type": "referendum",
+        "slug": "increase-appropriations-limit",
+        "amount": 0
       }
     ]
   }

--- a/build/_data/totals.json
+++ b/build/_data/totals.json
@@ -66,7 +66,7 @@
       },
       {
         "title": "Mayor",
-        "type": "office_election",
+        "type": "office",
         "slug": "mayor",
         "amount": 2867477.9800000004
       },
@@ -168,13 +168,13 @@
     "most_expensive_races": [
       {
         "title": "City Council District 4",
-        "type": "office_election",
+        "type": "office",
         "slug": "city-council-district-4",
         "amount": 33885.86
       },
       {
         "title": "City Council District 8",
-        "type": "office_election",
+        "type": "office",
         "slug": "city-council-district-8",
         "amount": 2211.27
       },
@@ -195,19 +195,19 @@
     "most_expensive_races": [
       {
         "title": "City Council District 1",
-        "type": "office_election",
+        "type": "office",
         "slug": "city-council-district-1",
         "amount": 95371.03
       },
       {
         "title": "City Council District 7",
-        "type": "office_election",
+        "type": "office",
         "slug": "city-council-district-7",
         "amount": 57920.86
       },
       {
         "title": "City Council At-Large",
-        "type": "office_election",
+        "type": "office",
         "slug": "city-council-at-large",
         "amount": 33174.0
       }

--- a/build/_elections/berkeley/2018-11-06.md
+++ b/build/_elections/berkeley/2018-11-06.md
@@ -1,5 +1,6 @@
 ---
 title: Berkeley November 6th, 2018 Election
+data_key: berkeley-2018
 locality: berkeley
 election: '2018-11-06'
 office_elections:

--- a/build/_elections/oakland/2016-11-08.md
+++ b/build/_elections/oakland/2016-11-08.md
@@ -1,5 +1,6 @@
 ---
 title: Oakland November 8th, 2016 Election
+data_key: oakland-2016
 locality: oakland
 election: '2016-11-08'
 office_elections:

--- a/build/_elections/oakland/2018-06-05.md
+++ b/build/_elections/oakland/2018-06-05.md
@@ -1,5 +1,6 @@
 ---
 title: Oakland June 5th, 2018 Election
+data_key: oakland-june-2018
 locality: oakland
 election: '2018-06-05'
 office_elections: []

--- a/build/_elections/oakland/2018-11-06.md
+++ b/build/_elections/oakland/2018-11-06.md
@@ -1,5 +1,6 @@
 ---
 title: Oakland November 6th, 2018 Election
+data_key: oakland-2018
 locality: oakland
 election: '2018-11-06'
 office_elections:

--- a/build/_elections/oakland/2020-03-03.md
+++ b/build/_elections/oakland/2020-03-03.md
@@ -1,5 +1,6 @@
 ---
 title: Oakland March 3rd, 2020 Special Election
+data_key: oakland-march-2020
 locality: oakland
 election: '2020-03-03'
 office_elections: []

--- a/build/_elections/oakland/2020-11-03.md
+++ b/build/_elections/oakland/2020-11-03.md
@@ -1,5 +1,6 @@
 ---
 title: Oakland November 3rd, 2020 General Election
+data_key: oakland-2020
 locality: oakland
 election: '2020-11-03'
 office_elections:

--- a/build/_elections/sf/2016-11-08.md
+++ b/build/_elections/sf/2016-11-08.md
@@ -1,5 +1,6 @@
 ---
 title: San Francisco November 8th, 2016 Election
+data_key: sf-2016
 locality: sf
 election: '2016-11-08'
 office_elections: []

--- a/build/_elections/sf/2018-06-05.md
+++ b/build/_elections/sf/2018-06-05.md
@@ -1,5 +1,6 @@
 ---
 title: San Francisco June 5th, 2018 Election
+data_key: sf-june-2018
 locality: sf
 election: '2018-06-05'
 office_elections:

--- a/build/_elections/sf/2018-11-06.md
+++ b/build/_elections/sf/2018-11-06.md
@@ -1,5 +1,6 @@
 ---
 title: San Francisco November 6th, 2018 Election
+data_key: sf-2018
 locality: sf
 election: '2018-11-06'
 office_elections: []

--- a/calculators/candidate_contributions_by_origin.rb
+++ b/calculators/candidate_contributions_by_origin.rb
@@ -30,6 +30,8 @@ class CandidateContributionsByOrigin
         ContributionsByOrigin[election] ||= {}
         ContributionsByOrigin[election][result['locale']] ||= 0
         ContributionsByOrigin[election][result['locale']] += result['total']
+        ContributionsByOrigin[election]['Total'] ||= 0
+        ContributionsByOrigin[election]['Total'] += result['total']
       end
     hash.each do |filer_id, contributions_by_local|
       candidate = @candidates_by_filer_id[filer_id.to_i]

--- a/calculators/referendum_contributions_by_origin.rb
+++ b/calculators/referendum_contributions_by_origin.rb
@@ -59,6 +59,8 @@ class ReferendumContributionsByOrigin
       ContributionsByOrigin[election] ||= {}
       ContributionsByOrigin[election][row['locale']] ||= 0
       ContributionsByOrigin[election][row['locale']] += row['total']
+      ContributionsByOrigin[election]['Total'] ||= 0
+      ContributionsByOrigin[election]['Total'] += row['total']
     end
 
     [

--- a/process.rb
+++ b/process.rb
@@ -83,6 +83,7 @@ ELECTIONS.each do |election_name, election|
   office_elections_by_label = office_elections.group_by(&:label)
   election_content = YAML.dump(
     'title' => election[:title],
+    'data_key' => election[:name],
     'locality' => locality,
     'election' => election[:date].to_s,
     'office_elections' => office_elections_by_label.map do |label, items|

--- a/process.rb
+++ b/process.rb
@@ -151,7 +151,7 @@ ELECTIONS.each do |election_name, election|
       ContributionsByOrigin[election_name][:race_totals] ||= []
       ContributionsByOrigin[election_name][:race_totals].append({
         'title': office_election.title,
-        'type': 'office_election',
+        'type': 'office',
         'slug': slugify(office_election.title),
         'amount': candidates.sum {|candidate| candidate.calculation(:total_contributions) || 0.0}
       })

--- a/process.rb
+++ b/process.rb
@@ -151,10 +151,10 @@ ELECTIONS.each do |election_name, election|
 
       ContributionsByOrigin[election_name][:race_totals] ||= []
       ContributionsByOrigin[election_name][:race_totals].append({
-        'title': office_election.title,
-        'type': 'office',
-        'slug': slugify(office_election.title),
-        'amount': candidates.sum {|candidate| candidate.calculation(:total_contributions) || 0.0}
+        title: office_election.title,
+        type: 'office',
+        slug: slugify(office_election.title),
+        amount: candidates.sum {|candidate| candidate.calculation(:total_contributions) || 0.0}
       })
 
       f.puts(YAML.dump({
@@ -257,10 +257,10 @@ Referendum.includes(:calculations).find_each do |referendum|
   opposing_total = referendum.calculation(:opposing_total) || 0
   ContributionsByOrigin[referendum.election_name][:race_totals] ||= []
   ContributionsByOrigin[referendum.election_name][:race_totals].append({
-    'title': "Measure #{referendum['Measure_number']}",
-    'type': 'referendum',
-    'slug': title,
-    'amount': supporting_total + opposing_total
+    title: "Measure #{referendum['Measure_number']}",
+    type: 'referendum',
+    slug: title,
+    amount: supporting_total + opposing_total
   })
 end
 


### PR DESCRIPTION
I'm starting to build out these 2 sections in the election summary page. I'd like all those numbers to come directly from the backend as opposed to doing any computation on the frontend.

<img width="658" alt="Screen Shot 2020-03-30 at 12 05 48 AM" src="https://user-images.githubusercontent.com/16271389/77945768-0abbab00-7276-11ea-9e77-10dfb4b8655e.png">


For the first section, I'm adding the total for the entire election. This ends up basically just being a sum of "Within Oakland", "Within California" and "Out of State"

For the second section, I'm grabbing totals per race (across both referendums and office elections). I chose to return is as a list of hashes to give the frontend everything it needs to render. Specifically the title/amount for display and the type/slug so that the frontend can properly link out to the correct page. Still the responsibility of the frontend to construct the URL but it has all the pieces it needs without having to do extra weird lookups based on names.

Also ... over 18 million dollars were spent on the soda tax campaign? and over 14 million on flavored tobacco in SF.