### PR TITLE
Add data key to election markdown

### DIFF
--- a/build/_elections/berkeley/2018-11-06.md
+++ b/build/_elections/berkeley/2018-11-06.md
@@ -1,6 +1,6 @@
 ---
 title: Berkeley November 6th, 2018 Election
-data_key: berkeley-2018
+election_id: berkeley-2018
 locality: berkeley
 election: '2018-11-06'
 office_elections:

--- a/build/_elections/oakland/2016-11-08.md
+++ b/build/_elections/oakland/2016-11-08.md
@@ -1,6 +1,6 @@
 ---
 title: Oakland November 8th, 2016 Election
-data_key: oakland-2016
+election_id: oakland-2016
 locality: oakland
 election: '2016-11-08'
 office_elections:

--- a/build/_elections/oakland/2018-06-05.md
+++ b/build/_elections/oakland/2018-06-05.md
@@ -1,6 +1,6 @@
 ---
 title: Oakland June 5th, 2018 Election
-data_key: oakland-june-2018
+election_id: oakland-june-2018
 locality: oakland
 election: '2018-06-05'
 office_elections: []

--- a/build/_elections/oakland/2018-11-06.md
+++ b/build/_elections/oakland/2018-11-06.md
@@ -1,6 +1,6 @@
 ---
 title: Oakland November 6th, 2018 Election
-data_key: oakland-2018
+election_id: oakland-2018
 locality: oakland
 election: '2018-11-06'
 office_elections:

--- a/build/_elections/oakland/2020-03-03.md
+++ b/build/_elections/oakland/2020-03-03.md
@@ -1,6 +1,6 @@
 ---
 title: Oakland March 3rd, 2020 Special Election
-data_key: oakland-march-2020
+election_id: oakland-march-2020
 locality: oakland
 election: '2020-03-03'
 office_elections: []

--- a/build/_elections/oakland/2020-11-03.md
+++ b/build/_elections/oakland/2020-11-03.md
@@ -1,6 +1,6 @@
 ---
 title: Oakland November 3rd, 2020 General Election
-data_key: oakland-2020
+election_id: oakland-2020
 locality: oakland
 election: '2020-11-03'
 office_elections:

--- a/build/_elections/sf/2016-11-08.md
+++ b/build/_elections/sf/2016-11-08.md
@@ -1,6 +1,6 @@
 ---
 title: San Francisco November 8th, 2016 Election
-data_key: sf-2016
+election_id: sf-2016
 locality: sf
 election: '2016-11-08'
 office_elections: []

--- a/build/_elections/sf/2018-06-05.md
+++ b/build/_elections/sf/2018-06-05.md
@@ -1,6 +1,6 @@
 ---
 title: San Francisco June 5th, 2018 Election
-data_key: sf-june-2018
+election_id: sf-june-2018
 locality: sf
 election: '2018-06-05'
 office_elections:

--- a/build/_elections/sf/2018-11-06.md
+++ b/build/_elections/sf/2018-11-06.md
@@ -1,6 +1,6 @@
 ---
 title: San Francisco November 6th, 2018 Election
-data_key: sf-2018
+election_id: sf-2018
 locality: sf
 election: '2018-11-06'
 office_elections: []

--- a/process.rb
+++ b/process.rb
@@ -83,7 +83,7 @@ ELECTIONS.each do |election_name, election|
   office_elections_by_label = office_elections.group_by(&:label)
   election_content = YAML.dump(
     'title' => election[:title],
-    'data_key' => election[:name],
+    'election_id' => election[:name],
     'locality' => locality,
     'election' => election[:date].to_s,
     'office_elections' => office_elections_by_label.map do |label, items|


### PR DESCRIPTION
the `totals.json` looks like

```
{
  "berkeley-2018": {
    "Within Berkeley": 30855.629999999997,
    "Within California": 8366.0,
    "Out of State": 927.0,
    "largest_independent_expenditures": null
  },
  "oakland-2016": {
    "Out of State": 10552796.459999999,
    "Within California": 9123736.680000002,
    "Within Oakland": 1422868.52,
    "largest_independent_expenditures": null
  },
  "oakland-june-2018": {
    "Out of State": 7200.0,
    "Within California": 33550.0,
    "Within Oakland": 110837.72,
    "largest_independent_expenditures": null
  },
...
```

The problem is the keys of this hash don't make their way to the frontend so you can't actually key into this hash. This just includes `election.name` into the election object we send to the frontend. I called it `data_key` since we just use it to key into data and `name` sounded like it could be confusing alongside `title`. Certainly open to changing it though.