### PR TITLE
Add automatic Algolia reindexing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ cache:
 addons:
   postgresql: '9.6'
 script:
-  - make clean download -j2 && make import -j2 && make process && ./bin/travis-deploy
+  - make clean download -j2 && make import -j2 && make process && ./bin/travis-deploy && ./bin/travis-reindex

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ recreatedb:
 	dropdb $(DATABASE_NAME) || true
 	createdb $(DATABASE_NAME) --lc-collate=C --template=template0
 
+reindex:
+	ruby search_index.rb
+
 496 497 A-Contributions B1-Loans B2-Loans C-Contributions D-Expenditure E-Expenditure F-Expenses F461P5-Expenditure F465P3-Expenditure F496P3-Contributions G-Expenditure H-Loans I-Contributions Summary:
 	DATABASE_NAME=$(DATABASE_NAME) ./bin/import-file $(CSV_PATH) $@
 

--- a/README.md
+++ b/README.md
@@ -43,19 +43,18 @@ this after you've downloaded new data.
 
     $ make import
 
-Run the calculators.
+Run the calculators. Everything is output into the "build" folder.
 
     $ make process
 
-# everything is output into the "build" folder
-```
+Optionally, reindex the build outputs into Algolia. (Reindexing requires the
+ALGOLIASEARCH_APPLICATION_ID and ALGOLIASEARCH_API_KEY environment variables).
+
+    $ make reindex
 
 If you want to serve the static JSON files via a local web server:
 
-```bash
-make run
-```
-
+    $ make run
 
 ## Developing
 ### Adding a calculator

--- a/bin/travis-reindex
+++ b/bin/travis-reindex
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${TRAVIS_EVENT_TYPE}" = "pull_request" -o ! "${TRAVIS_BRANCH}" = "master" ]; then
+  echo "Not reindexing in Algolia because this looks like a Github PR."
+  exit
+fi
+
+if git diff --exit-code --quiet -- . ':(exclude)build/_data/stats.json'; then
+  echo "No changes to reindex. Exiting."
+  exit
+fi
+
+echo "Reindexing into Algolia..."
+
+search_args=""
+if [ "$(date +%A)" != "Monday" ]; then
+  echo "Skipping contributor list indexing because it's not Monday."
+  search_args+="--skip-contributors"
+fi
+
+ruby ./search_index.rb $search_args

--- a/models/candidate.rb
+++ b/models/candidate.rb
@@ -1,6 +1,7 @@
 class Candidate < ActiveRecord::Base
   include HasCalculations
 
+  has_one :committee, foreign_key: 'Filer_ID', primary_key: 'FPPC'
   belongs_to :office_election, foreign_key: 'Office', primary_key: 'title'
   belongs_to :election, foreign_key: 'election_name', primary_key: 'name'
 

--- a/search_index.rb
+++ b/search_index.rb
@@ -31,42 +31,9 @@ puts "Indexing #{candidate_data.length} Candidates..."
 index.add_objects(candidate_data)
 
 contributor_data = []
-Candidate.includes(:election, :office_election).find_each do |candidate|
-  committee = Committee.find_by(Filer_ID: candidate.FPPC)
-  if committee.nil?
-    next
-  end
-  list = committee.calculation(:contribution_list).map do |contributor|
-    {
-      type: :contributor,
-      first_name: contributor['Tran_NamF'],
-      last_name: contributor['Tran_NamL'],
-      amount: contributor['Tran_Amt1'],
-      name: candidate['Candidate'],
-      candidate_slug: slugify(candidate['Candidate']),
-      office_label: candidate.office_election.label,
-      office_title: candidate.office_election.title,
-      office_slug: slugify(candidate.office_election.title),
-      election_slug: candidate.election.name,
-      election_location: candidate.election.location,
-      election_date: candidate.election.date,
-      election_title: candidate.election.title,
-    }
-  end
-  unless list.nil?
-    contributor_data += list
-  end
-end
-puts "Indexing #{contributor_data.length} Contributors..."
-index.add_objects(contributor_data)
-
-contributor_data = []
-Candidate.includes(:election, :office_election).find_each do |candidate|
-  committee = Committee.find_by(Filer_ID: candidate.FPPC)
-  if committee.nil?
-    next
-  end
-  list = committee.calculation(:contribution_list).map do |contributor|
+Candidate.includes(:election, :committee, :office_election).find_each do |candidate|
+  next if candidate.committee.nil?
+  list = candidate.committee.calculation(:contribution_list).map do |contributor|
     {
       type: :contributor,
       first_name: contributor['Tran_NamF'],

--- a/search_index.rb
+++ b/search_index.rb
@@ -1,6 +1,23 @@
+#!/usr/bin/env ruby
+# Usage:
+#   ruby search_index.rb
+#
+# Or to skip indexing the contributor list (to prevent exhausting our Algolia
+# monthly quota):
+#
+#   ruby search_index.rb --skip-contributors
+#
 require_relative './environment.rb'
 
 require 'algoliasearch'
+require 'optparse'
+options = { skip_contributors: false }
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{$0} [options]"
+  opts.on('--skip-contributors', 'Skip indexing contributor list') do |s|
+    options[:skip_contributors] = true
+  end
+end.parse!
 
 client = Algolia::Client.new(
   application_id: ENV['ALGOLIASEARCH_APPLICATION_ID'],
@@ -30,32 +47,36 @@ end
 puts "Indexing #{candidate_data.length} Candidates..."
 index.add_objects(candidate_data)
 
-contributor_data = []
-Candidate.includes(:election, :committee, :office_election).find_each do |candidate|
-  next if candidate.committee.nil?
-  list = candidate.committee.calculation(:contribution_list).map do |contributor|
-    {
-      type: :contributor,
-      first_name: contributor['Tran_NamF'],
-      last_name: contributor['Tran_NamL'],
-      amount: contributor['Tran_Amt1'],
-      name: candidate['Candidate'],
-      candidate_slug: slugify(candidate['Candidate']),
-      office_label: candidate.office_election.label,
-      office_title: candidate.office_election.title,
-      office_slug: slugify(candidate.office_election.title),
-      election_slug: candidate.election.name,
-      election_location: candidate.election.location,
-      election_date: candidate.election.date,
-      election_title: candidate.election.title,
-    }
+if options[:skip_contributors]
+  puts "Skipping contributor indexing..."
+else
+  contributor_data = []
+  Candidate.includes(:election, :committee, :office_election).find_each do |candidate|
+    next if candidate.committee.nil?
+    list = candidate.committee.calculation(:contribution_list).map do |contributor|
+      {
+        type: :contributor,
+        first_name: contributor['Tran_NamF'],
+        last_name: contributor['Tran_NamL'],
+        amount: contributor['Tran_Amt1'],
+        name: candidate['Candidate'],
+        candidate_slug: slugify(candidate['Candidate']),
+        office_label: candidate.office_election.label,
+        office_title: candidate.office_election.title,
+        office_slug: slugify(candidate.office_election.title),
+        election_slug: candidate.election.name,
+        election_location: candidate.election.location,
+        election_date: candidate.election.date,
+        election_title: candidate.election.title,
+      }
+    end
+    unless list.nil?
+      contributor_data += list
+    end
   end
-  unless list.nil?
-    contributor_data += list
-  end
+  puts "Indexing #{contributor_data.length} Contributors..."
+  index.add_objects(contributor_data)
 end
-puts "Indexing #{contributor_data.length} Contributors..."
-index.add_objects(contributor_data)
 
 referendum_data = Referendum.includes(:election).map do |referendum|
   {


### PR DESCRIPTION
* Add `make reindex` command to reindex manually.
* Add `bin/travis-reindex` script for the daily build.
* Add `--skip-contributors` option to reindexing script.
* Daily build will only reindex when there are changes.
* Daily build will only reindex full contributor list on Mondays.
* Improve documentation of these things.