### PR TITLE
Candidates need cadidate_slug.

### DIFF
--- a/search_index.rb
+++ b/search_index.rb
@@ -37,7 +37,7 @@ candidate_data = Candidate.includes(:election, :office_election).map do |candida
     office_label: candidate.office_election.label,
     office_title: candidate.office_election.title,
     office_slug: slugify(candidate.office_election.title),
-    slug: slugify(candidate['Candidate']),
+    candidate_slug: slugify(candidate['Candidate']),
     election_slug: candidate.election.name,
     election_location: candidate.election.location,
     election_date: candidate.election.date,


### PR DESCRIPTION
We were labeling the candidate slug as 'slug' rather than 'candidate_slug' in the candidate records leading to an 'undefined' in the path.