### PR TITLE
Output contribution list for Candidates without committee rows

### DIFF
--- a/calculators/committee_contribution_list_calculator.rb
+++ b/calculators/committee_contribution_list_calculator.rb
@@ -50,7 +50,7 @@ class CommitteeContributionListCalculator
         end
 
         committee.save_calculation(:contribution_list, sorted)
-        committee.save_calculation(:total_contributions, total_contributions)
+        committee.save_calculation(:contribution_list_total, total_contributions)
         committee.save_calculation(:total_small_itemized_contributions, total_small)
       end
     end

--- a/calculators/election_totals.rb
+++ b/calculators/election_totals.rb
@@ -28,8 +28,9 @@ class ElectionTotal
           .includes(:office_election, :calculations)
           .find_each do |candidate|
 
-          total = candidate.calculation(:total_contributions)
-          total_contributions += total;
+          total = candidate.calculation(:total_contributions) ||
+            candidate.calculation(:contribution_list_total)
+          total_contributions += total
           total_small = candidate.calculation(:total_small_contributions)
 
           unless total == 0 || total_small.nil?

--- a/models/candidate.rb
+++ b/models/candidate.rb
@@ -51,8 +51,10 @@ class Candidate < ActiveRecord::Base
       # contribution data
       filer_id: self['FPPC'],
       supporting_money: {
-        contributions_received: calculation(:total_contributions).try(:to_f),
-        total_contributions: calculation(:total_contributions).try(:to_f),
+        contributions_received: calculation(:total_contributions).try(:to_f) ||
+          calculation(:contribution_list_total).try(:to_f),
+        total_contributions: calculation(:total_contributions).try(:to_f) ||
+          calculation(:contribution_list_total).try(:to_f),
         total_expenditures: calculation(:total_expenditures).try(:to_f),
         total_loans_received: calculation(:total_loans_received).try(:to_f),
         total_supporting_independent: calculation(:total_supporting_independent).try(:to_f),
@@ -72,10 +74,19 @@ class Candidate < ActiveRecord::Base
       # for backwards compatibility, these should also be exposed at the
       # top-level:
       # TODO: remove once the frontend no longer uses this
-      total_contributions: calculation(:total_contributions).try(:to_f),
+      total_contributions: calculation(:total_contributions).try(:to_f) ||
+        calculation(:contribution_list_total).try(:to_f),
       total_expenditures: calculation(:total_expenditures).try(:to_f),
       total_loans_received: calculation(:total_loans_received).try(:to_f),
     )
+  end
+
+  # Keep this method in-sync with the `data` method in Committee model.
+  def committee_data
+    {
+      total_contributions: calculation(:contribution_list_total),
+      contributions: calculation(:contribution_list) || [],
+    }
   end
 
   private

--- a/models/committee.rb
+++ b/models/committee.rb
@@ -21,9 +21,10 @@ class Committee < ActiveRecord::Base
     }
   end
 
+  # Keep this method in-sync with the `committe_data` method in Candidate model.
   def data
     {
-      total_contributions: calculation(:total_contributions),
+      total_contributions: calculation(:contribution_list_total),
       contributions: calculation(:contribution_list) || [],
     }
   end

--- a/process.rb
+++ b/process.rb
@@ -75,6 +75,11 @@ Election.find_each do |election|
         f.puts(YAML.dump(Committee.from_candidate(candidate).metadata))
         f.puts('---')
       end
+
+      # /_data/committees/1229791.json
+      build_file("/_data/committees/#{candidate.FPPC}.json") do |f|
+        f.puts JSON.pretty_generate(candidate.committee_data)
+      end
     end
 
 


### PR DESCRIPTION
For candidates without entries in the `committees` spreadsheet tab, we
still want to output their contribution list. The problem is, we store
their contribution list on the `Candidate` instead of their associated
committee. We also muddy the waters by saving a calculation called
`total_contributions` which is calculated differently between Candidates
and Committees.

This commit:
* Renames the calculation for the total of the contribution list to
  `contribution_list_total` and adds fallback logic to mimic the
  previous implicit overwriting behavior
* Adds a `committee_data` method to Candidate to output the calculations
  related to the committee.