### PR TITLE
Add map_url field to Candidate model

### DIFF
--- a/models/candidate.rb
+++ b/models/candidate.rb
@@ -23,6 +23,7 @@ class Candidate < ActiveRecord::Base
       'website_url' => self[:Website],
       'facebook_url' => self[:Facebook],
       'instagram_url' => self[:Instagram],
+      'map_url' => self[:map_app]
     }.compact
   end
 
@@ -39,6 +40,7 @@ class Candidate < ActiveRecord::Base
       twitter_url: self['Twitter'],
       facebook_url: self['Facebook'],
       instagram_url: self['Instagram'],
+      map_url: self['map_app'],
       votersedge_url: self['VotersEdge'],
       first_name: first_name,
       last_name: last_name,


### PR DESCRIPTION
New field on Candidate model, `map_url`, comes from the "map_app" field on the spreadsheet. We will use this field on the frontend to link to the Oakland Data Portal mapping app.

@sfdoran hard-coded the links to each candidate's view on Oakland Data Portal mapping app for the current election. This is a short term fix for this election. Beyond this election, we should be composing these links.

I made these changes through the GH UI. Hopefully they're great.