### PR TITLE
Attempt TravisCI upgrade to Ubuntu Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
-dist: trusty
+dist: bionic
 env:
   global:
     - TZ=America/Los_Angeles
 pyton:
   - '2.7'
-group: deprecated-2017Q4
+services:
+  - postgresql
 sudo: required
 install:
   - pip install 'urllib3[secure]'


### PR DESCRIPTION
From 14.04 -> 18.04, hopefully two years of Ubuntu development will get
us a version of Python that can download the dependencies correctly.