### PR TITLE
Add SODA to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'pg'
 gem 'puma'
 gem 'rspec'
 gem 'roo'
+gem 'soda-ruby', :require => 'soda'
 gem 'tzinfo'
 gem 'tzinfo-data'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
+    ffi (1.15.5)
+    hashie (3.6.0)
     httpclient (2.8.3)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -25,6 +27,7 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.0)
     minitest (5.14.1)
+    multipart-post (2.0.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.5.2)
@@ -64,6 +67,12 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
+    soda-ruby (1.0.1)
+      hashie (~> 3.5)
+      multipart-post (~> 2.0.0)
+      sys-uname (~> 1.0.2)
+    sys-uname (1.0.4)
+      ffi (>= 1.0.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (1.2.7)
@@ -86,6 +95,7 @@ DEPENDENCIES
   roo
   rspec
   sinatra
+  soda-ruby
   tzinfo
   tzinfo-data
 


### PR DESCRIPTION
The SODA package was missing from the gemfile.  Needed to support indexing bequested donations.