### PR TITLE
change travis to using python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   global:
     - TZ=America/Los_Angeles
 pyton:
-  - '2.7'
+  - '3.9'
 group: deprecated-2017Q4
 sudo: required
 install:


### PR DESCRIPTION
When we are ready, this will simply switch travis to using Python 3.9 instead of 2.7