### PR TITLE
switch Travis CI to use Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   global:
     - TZ=America/Los_Angeles
 python:
-  - '2.7'
+  - '3.9'
 services:
   - postgresql
 sudo: required


### PR DESCRIPTION
This will simply switch Travis CI to start using Python 3.9 when we are ready.