### PR TITLE
Fix filings that have 'pending' as the Filer_ID

### DIFF
--- a/bin/fix-pending
+++ b/bin/fix-pending
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Usage: ./bin/fix-pending [database name] [table name]
+#        ./bin/fix-pending disclosure-backend A-Contributions
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo 'Usage: ./bin/fix-pending [database name] [table name]'
+  exit 1
+fi
+
+database_name=$1
+table_name=$2
+
+cat <<-QUERY | psql ${database_name}
+  \\set ON_ERROR_STOP on
+  UPDATE "$table_name" t SET "Filer_ID" = "FPPC"
+  from candidates
+  WHERE lower(t."Filer_ID"::varchar(9)) = 'pending'
+  AND t."Filer_NamL" = "Committee_Name"
+  AND has_pending;
+
+QUERY

--- a/bin/import-file
+++ b/bin/import-file
@@ -31,6 +31,9 @@ if ls $filename_glob 2>/dev/null >/dev/null; then
     csvsql --db postgresql:///$DATABASE_NAME --tables $table_name --insert ${table_exists:+--no-create}
   echo -n '  Removing empty Tran_Date... '
   ./bin/clean "$DATABASE_NAME" "$table_name"
+  echo
+  echo -n '  Fixing pending Filer_IDs... '
+  ./bin/fix-pending "$DATABASE_NAME" "$table_name"
 else
   echo 'Found no files to import'
 fi


### PR DESCRIPTION
Candidates can file reports with a 'pending' Filer_ID.  At some later point they can file an amended filing but in the meantime after they get their ID we mark them in the has_pending column of the candidates sheet.  This code can then update the tables with the ID.  
(Current example is Jorge Lerma)