### PR TITLE
Add election_name to contributions list

### DIFF
--- a/calculators/committee_contribution_list_calculator.rb
+++ b/calculators/committee_contribution_list_calculator.rb
@@ -8,15 +8,15 @@ class CommitteeContributionListCalculator
     descriptions = CandidateContributionsByType::TYPE_DESCRIPTIONS
     results = ActiveRecord::Base.connection.execute(<<-SQL)
       WITH all_committees AS (
-        SELECT DISTINCT "Filer_ID", "Start_Date", "End_Date"
+        SELECT DISTINCT "Ballot_Measure_Election" as election_name, "Filer_ID", "Start_Date", "End_Date"
         FROM committees
         WHERE NOT EXISTS (SELECT * FROM candidates
                           WHERE "FPPC"::varchar = "Filer_ID")
         UNION ALL
-        SELECT "FPPC"::varchar AS "Filer_ID", "Start_Date", "End_Date"
+        SELECT election_name, "FPPC"::varchar AS "Filer_ID", "Start_Date", "End_Date"
         FROM candidates
       )
-      SELECT all_contributions."Filer_ID", "Tran_Amt1", "Tran_Date", "Tran_NamF", "Tran_NamL",
+      SELECT election_name, all_contributions."Filer_ID", "Tran_Amt1", "Tran_Date", "Tran_NamF", "Tran_NamL",
         "Tran_Zip4", "Tran_Occ", "Tran_Emp", "Entity_Cd"
       FROM all_contributions
       JOIN all_committees

--- a/calculators/committee_contribution_list_calculator.rb
+++ b/calculators/committee_contribution_list_calculator.rb
@@ -16,13 +16,15 @@ class CommitteeContributionListCalculator
         SELECT election_name, "FPPC"::varchar AS "Filer_ID", "Start_Date", "End_Date"
         FROM candidates
       )
-      SELECT election_name, all_contributions."Filer_ID", "Tran_Amt1", "Tran_Date", "Tran_NamF", "Tran_NamL",
+      SELECT election_name, title, all_contributions."Filer_ID",
+        "Tran_Amt1", "Tran_Date", "Tran_NamF", "Tran_NamL",
         "Tran_Zip4", "Tran_Occ", "Tran_Emp", "Entity_Cd"
       FROM all_contributions
       JOIN all_committees
       ON all_committees."Filer_ID" = all_contributions."Filer_ID"
       AND ("Start_Date" IS NULL OR "Tran_Date" >= "Start_Date")
       AND ("End_Date" IS NULL OR "Tran_Date" <= "End_Date")
+      JOIN elections ON election_name = name
       ORDER BY "Tran_Date" ASC, CONCAT("Tran_NamL", "Tran_NamF"), "Tran_Amt1" ASC, "Tran_Emp" ASC
     SQL
 

--- a/models/candidate.rb
+++ b/models/candidate.rb
@@ -90,6 +90,7 @@ class Candidate < ActiveRecord::Base
   # Keep this method in-sync with the `data` method in Committee model.
   def committee_data
     {
+      iec: false,
       total_contributions: calculation(:contribution_list_total),
       contributions: calculation(:contribution_list) || [],
     }

--- a/models/committee.rb
+++ b/models/committee.rb
@@ -23,6 +23,7 @@ class Committee < ActiveRecord::Base
   # Keep this method in-sync with the `committe_data` method in Candidate model.
   def data
     {
+      iec: true,
       total_contributions: calculation(:contribution_list_total),
       contributions: calculation(:contribution_list) || [],
     }


### PR DESCRIPTION
This adds the election name to the contributions list so that, for Independent Expenditure Committees, the front end can sort by election.