### PR TITLE
Improve committee contribution page

### DIFF
--- a/calculators/committee_contribution_list_calculator.rb
+++ b/calculators/committee_contribution_list_calculator.rb
@@ -45,14 +45,20 @@ class CommitteeContributionListCalculator
         sorted = Array(contributions_by_committee[filer_id])
         total_contributions = 0
         total_small = 0
+        total_by_election = {}
         sorted.each do |contribution|
           amount = contribution['Tran_Amt1']
           total_contributions += amount
           total_small += amount unless amount  >= 100 || amount <= -100
+          election_title = contribution['title']
+          total_by_election[election_title] ||= 0
+          total_by_election[election_title] += amount.round(2)
+
         end
         committee_or_candidate.save_calculation(:contribution_list, sorted)
         committee_or_candidate.save_calculation(:contribution_list_total, total_contributions.round(2))
         committee_or_candidate.save_calculation(:total_small_itemized_contributions, total_small.round(2))
+        committee_or_candidate.save_calculation(:total_by_election, total_by_election)
       end
     end
   end

--- a/models/committee.rb
+++ b/models/committee.rb
@@ -1,6 +1,8 @@
 class Committee < ActiveRecord::Base
   include HasCalculations
 
+  belongs_to :election, foreign_key: 'Ballot_Measure_Election', primary_key: 'name'
+
   def self.from_candidate(candidate)
     new(
       Filer_ID: candidate.FPPC,
@@ -26,6 +28,7 @@ class Committee < ActiveRecord::Base
       iec: true,
       total_contributions: calculation(:contribution_list_total),
       contributions: calculation(:contribution_list) || [],
+      contributions_by_election: calculation(:total_by_election) || [],
     }
   end
 end

--- a/models/election.rb
+++ b/models/election.rb
@@ -4,6 +4,7 @@ class Election < ActiveRecord::Base
   has_many :candidates, foreign_key: :election_name, primary_key: :name
   has_many :office_elections, foreign_key: :election_name, primary_key: :name
   has_many :referendums, foreign_key: :election_name, primary_key: :name
+  has_many :committees, foreign_key: 'Ballot_Measure_Election', primary_key: :name
 
   def locality
     name.split('-', 2).first

--- a/process.rb
+++ b/process.rb
@@ -25,7 +25,7 @@ CalculatorRunner
 
 # This must be before Candidate because candidate also output committee files
 # that can duplicate these.
-Committee.includes(:calculations).find_each do |committee|
+Committee.includes(:calculations).joins(:election).order("elections.date ASC").each do |committee|
   next if committee['Filer_ID'].nil?
   next if committee['Filer_ID'] =~ /pending/i
 


### PR DESCRIPTION
This has two changes:
1) output committee contribution files in ascending election date order.  This makes sure the most recent committee name appears. Ideally we would output different files for different elections but that is a bigger change.
2) include per-election contribution totals.